### PR TITLE
Use a Binary Heap instead of a vector for buy and sell orders.

### DIFF
--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -1,5 +1,9 @@
 use std::collections::{HashMap};
 use std::cmp::Ordering;
+use std::cmp::Reverse;
+
+// Use heaps instead of vecs for orders.
+use std::collections::BinaryHeap;
 
 // Error types for price information.
 pub enum PriceError {
@@ -98,7 +102,7 @@ impl Exchange {
             // Recall that the sell vector is sorted in descending order,
             // so the lowest offer is at the end.
             let lowest_offer = match market.sell_orders.pop() { // May potentially add back to vector if not filled.
-                Some(bid) => bid,
+                Some(bid) => bid.0,
                 None => return new_price // No more sell orders to fill
             };
 
@@ -145,11 +149,11 @@ impl Exchange {
                     filled_orders.push(FilledOrder::order_to_filled_order(&update_lowest, &highest_bid, amount_traded));
 
                     // Put the updated lowest offer back on the market
-                    market.sell_orders.push(update_lowest);
+                    market.sell_orders.push(Reverse(update_lowest));
                 }
             } else {
                 // Highest buy doesn't reach lowest sell.
-                market.sell_orders.push(lowest_offer); // Put the lowest sell back
+                market.sell_orders.push(Reverse(lowest_offer)); // Put the lowest sell back
                 break;
             }
         }
@@ -292,16 +296,31 @@ impl Exchange {
         println!("\t--SELLS--");
         println!("\t\t| ID | Price \t| Quantity | Filled |");
         println!("\t\t-------------------------------------");
-        for order in &market.sell_orders {
+        let sells = market.sell_orders.clone().into_sorted_vec();
+        // for order in &market.sell_orders {
+        let mut order_count = 0;
+        for result in &sells {
+            let order = &result.0;
+            order_count += 1;
             println!("\t\t| {}\t${:.2}\t     {}\t  \t{}   |", order.order_id, order.price, order.quantity, order.filled);
+            if order_count == 10 {
+                break
+            }
         }
         println!("\t\t-------------------------------------\n");
 
         println!("\t--BUYS--");
         println!("\t\t| ID | Price \t| Quantity | Filled |");
         println!("\t\t-------------------------------------");
-        for order in market.buy_orders.iter().rev() {
+        let buys = market.buy_orders.clone().into_sorted_vec();
+        // // for order in market.buy_orders.iter().rev() {
+        order_count = 0;
+        for order in buys.iter().rev() {
+            order_count += 1;
             println!("\t\t| {}\t${:.2}\t     {}\t  \t{}   |", order.order_id, order.price, order.quantity, order.filled);
+            if order_count == 10 {
+                break
+            }
         }
         println!("\t\t-------------------------------------\n");
 
@@ -344,16 +363,16 @@ impl Exchange {
             match self.fill_existing_orders(&mut order) {
                 Some(mut orders) => {
                     // TEST SPEED
-                    for ord in &orders {
-                        println!("Order ({}) filled order ({}) at ${}. Exchanged {} shares.", ord.filled_by, ord.id, ord.price, ord.exchanged);
-                    }
+                    // for ord in &orders {
+                    //     println!("Order ({}) filled order ({}) at ${}. Exchanged {} shares.", ord.filled_by, ord.id, ord.price, ord.exchanged);
+                    // }
 
                     // Move the recently filled orders into the filled_orders array
                     self.extend_past_orders(&mut orders);
                 },
                 None => {
                     // TEST SPEED
-                    println!("Order ({}) has been added to the market.", order.order_id);
+                    // println!("Order ({}) has been added to the market.", order.order_id);
                 }
             }
 
@@ -364,55 +383,62 @@ impl Exchange {
 
                 match &action[..] {
                     "buy" => {
-                        match entry.buy_orders.binary_search(&order) {
-                            Ok(pos) => {
-                                // TODO: We should insert this in a way such that it is filled after the
-                                // other orders with the same price that were placed first!
-                                entry.buy_orders.insert(pos, order.clone());
-                            },
-                            Err(pos) => {
-                                entry.buy_orders.insert(pos, order.clone());
-                            }
-                        }
+                        entry.buy_orders.push(order.clone());
+                        // match entry.buy_orders.binary_search(&order) {
+                        //     Ok(pos) => {
+                        //         // TODO: We should insert this in a way such that it is filled after the
+                        //         // other orders with the same price that were placed first!
+                        //         entry.buy_orders.insert(pos, order.clone());
+                        //     },
+                        //     Err(pos) => {
+                        //         entry.buy_orders.insert(pos, order.clone());
+                        //     }
+                        // }
                     },
                     "sell" => {
+                        entry.sell_orders.push(Reverse(order.clone()));
                         // Keep in mind that the sell vector is reversed!
-                        match entry.sell_orders.binary_search_by(|y| y.cmp (&order).reverse()) {
-                            Ok(pos) => {
-                                // TODO: We should insert this in a way such that it is filled after the
-                                // other orders with the same price that were placed first!
-                                entry.sell_orders.insert(pos, order.clone());
-                            },
-                            Err(pos) => {
-                                entry.sell_orders.insert(pos, order.clone());
-                            }
-                        }
+                        // match entry.sell_orders.binary_search_by(|y| y.cmp (&order).reverse()) {
+                        //     Ok(pos) => {
+                        //         // TODO: We should insert this in a way such that it is filled after the
+                        //         // other orders with the same price that were placed first!
+                        //         entry.sell_orders.insert(pos, order.clone());
+                        //     },
+                        //     Err(pos) => {
+                        //         entry.sell_orders.insert(pos, order.clone());
+                        //     }
+                        // }
                     },
                     _ => ()
                 }
             } else {
                 // TEST SPEED
-                println!("The order has been filled!");
+                // println!("The order has been filled!");
             }
 
             // Update the stats because a new order has been placed.
             self.update_stats(order.clone());
         } else {
             // Entry doesn't exist, create it.
-            let mut buy_vec : Vec<Order> = Vec::new();
-            let mut sell_vec: Vec<Order> = Vec::new();
+            // let mut buy_vec : Vec<Order> = Vec::new();
+            // let mut sell_vec: Vec<Order> = Vec::new();
+            let mut buy_heap: BinaryHeap<Order> = BinaryHeap::new();
+            let mut sell_heap: BinaryHeap<Reverse<Order>> = BinaryHeap::new();
             match &action[..] {
                 "buy" => {
-                    buy_vec.push(order.clone());
+                    // buy_vec.push(order.clone());
+                    buy_heap.push(order.clone());
                 },
                 "sell" => {
-                    sell_vec.push(order.clone());
+                    // sell_vec.push(order.clone());
+                    sell_heap.push(Reverse(order.clone()));
                 },
                 // We can never get here.
                 _ => ()
             };
 
-            let new_market = Market::new(buy_vec, sell_vec);
+            // let new_market = Market::new(buy_vec, sell_vec);
+            let new_market = Market::new(buy_heap, sell_heap);
             self.live_orders.insert(order.security.clone(), new_market);
 
             // Since this is the first order, initialize the stats for this security.
@@ -479,12 +505,12 @@ impl Exchange {
 // TODO: Do we want orders stored in a sorted binary tree instead?
 #[derive(Debug)]
 pub struct Market {
-    pub buy_orders: Vec<Order>,
-    pub sell_orders: Vec<Order>
+    pub buy_orders: BinaryHeap<Order>,
+    pub sell_orders: BinaryHeap<Reverse<Order>>
 }
 
 impl Market {
-    pub fn new(buy: Vec<Order>, sell: Vec<Order>) -> Self {
+    pub fn new(buy: BinaryHeap<Order>, sell: BinaryHeap<Reverse<Order>>) -> Self {
         Market {
             buy_orders: buy,
             sell_orders: sell

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ fn main() {
         for line in reader.lines() {
             match line {
                 Ok(input) => {
+                    let keep = input.clone();
                     let request: Request = match tokenize_input(input) {
                         // Ok(req) => req,
                         Ok(req) => {
@@ -39,6 +40,7 @@ fn main() {
 
                     // Our input has been validated, and we can now
                     // attempt to service the request.
+                    println!("Request: {}", keep);
                     service_request(request, &mut exchange);
                 },
                 Err(_) => return


### PR DESCRIPTION
Vectors were good for some time, especially since search was log(n) and I only needed to compare the end elements, but insert took O(log(n) + n) ~ O(n) because we had to move the data on each insert.

This operation becomes more and more expensive as the list grows, so we need to decrease insertion runtime while maintaining constant access to the lowest offer and highest bid. This can be achieved with min-max-heaps, although not without some costs. I have found that while bandwidth drastically increased (more orders per second can be filled in bulk), latency for the user increases by quite a bit as well (it takes longer to show the user the updated market because the orders are no longer sorted)!

I tend to think the bandwidth number is more important, especially since we can probably hack some type of order cache together to decrease latency.