### PR TITLE
Create extremely basic accounts, and integrate them with the exchange's operations.

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -62,11 +62,11 @@ impl UserAccount {
                 for (_, pending) in market.iter() {
                     // If this order will fill a pending order that this account placed:
                     if  (order.action != pending.action) &&
-                        (order.action.as_str() == "buy"  && pending.price <= order.price) ||
-                        (order.action.as_str() == "sell" && order.price <= pending.price)
-                   {
-                       return false;
-                   }
+                        ((order.action.as_str() == "buy"  && pending.price <= order.price) ||
+                        (order.action.as_str() == "sell" && order.price <= pending.price))
+                    {
+                        return false;
+                    }
                 }
             },
             None => ()
@@ -197,8 +197,10 @@ impl Users {
             Ok(account) => {
                 println!("\nAccount information for user: {}", account.username);
                 println!("\n\tOrders Awaiting Execution");
-                for (_, value) in account.pending_orders.iter() {
-                    println!("\t\t{:?}", value);
+                for (_, market) in account.pending_orders.iter() {
+                    for (_, order) in market.iter() {
+                        println!("\t\t{:?}", order);
+                    }
                 }
                 println!("\n\tExecuted Trades");
                 for order in account.executed_trades.iter() {

--- a/src/account.rs
+++ b/src/account.rs
@@ -2,6 +2,12 @@ use crate::exchange::requests::Order;
 use crate::exchange::filled::FilledOrder;
 use std::collections::HashMap;
 
+// Error types for authentication
+pub enum AuthError<'a> {
+    NoUser(&'a String),
+    BadPassword(&'a String),
+}
+
 // Stores data about a user
 #[derive(Debug)]
 pub struct UserAccount {
@@ -39,21 +45,26 @@ impl UserAccount {
 }
 
 impl Users {
-    /* TODO: Lets return some type of Error instead.
-     *       This would let us specify the reason for failure.
-     * Returns true if authentication succeeded,
-     * false if username doesn't exist or if password is wrong.
+    /* If the username exists and the password is correct,
+     * we do not return an error.
+     *
+     * If the user doesn't exist, or the user exists and the
+     * password is incorrect, we return an error.
+     *
+     * TODO: Maybe we can return some type of session token
+     *       for the frontend to hold on to?
      */
-    pub fn authenticate(&self, username: &String, password: &String) -> bool {
+    pub fn authenticate<'a>(&self, username: &'a String, password: & String) -> Result<(), AuthError<'a>> {
         match self.users.get(username) {
             Some(account) => {
                 if *password == account.password {
-                    return true;
+                    return Ok(());
                 }
+                return Err(AuthError::BadPassword(username))
             },
             None => ()
         }
-        return false;
+        return Err(AuthError::NoUser(username));
     }
 
     pub fn new() -> Self {

--- a/src/account.rs
+++ b/src/account.rs
@@ -40,7 +40,7 @@ impl UserAccount {
     }
 
     // Sets this account's user id, and returns it.
-    pub fn set_id(&mut self, users: &Users) -> i32 {
+    fn set_id(&mut self, users: &Users) -> i32 {
         self.id = Some(users.total + 1);
         return self.id.unwrap();
     }

--- a/src/account.rs
+++ b/src/account.rs
@@ -1,0 +1,60 @@
+use crate::exchange::requests::Order;
+use std::collections::HashMap;
+
+// Stores data about a user
+pub struct UserAccount {
+    username: String,
+    password: String,
+    id: Option<i32>,
+    buys: Vec<Order>,
+    sells: Vec<Order>
+}
+
+// Where we store all our users
+pub struct Users {
+    users: HashMap<String, UserAccount>,
+    total: i32
+}
+
+impl UserAccount {
+    pub fn from(name: &String, password: &String) -> Self {
+        let vec: Vec<Order> = Vec::new();
+        UserAccount {
+            username: name.to_string().clone(),
+            password: password.to_string().clone(),
+            id: None, // Set later
+            buys: vec.clone(),
+            sells: vec,
+        }
+    }
+
+    // Sets this account's user id, and returns it.
+    pub fn set_id(&mut self, users: &Users) -> i32 {
+        self.id = Some(users.total + 1);
+        return self.id.unwrap();
+    }
+}
+
+impl Users {
+
+    pub fn new() -> Self {
+        let map: HashMap<String, UserAccount> = HashMap::new();
+        Users {
+            users: map,
+            total: 0
+        }
+    }
+
+    // If an account with this username exists, exit early, otherwise
+    // add the account and return it's ID.
+    pub fn new_account(&mut self, account: UserAccount) -> Option<i32> {
+        if self.users.contains_key(&account.username) {
+            return None;
+        } else {
+            let mut account = account;
+            self.total = account.set_id(&self);
+            self.users.insert(account.username.clone(), account);
+            return Some(self.total);
+        }
+    }
+}

--- a/src/account.rs
+++ b/src/account.rs
@@ -14,13 +14,21 @@ pub struct UserAccount {
     pub username: String,
     pub password: String,
     pub id: Option<i32>,
-    pub pending_orders: HashMap<i32, Order>,// Orders that have not been completely filled.
-    pub executed_trades: Vec<FilledOrder>   // Trades that have occurred.
+    /* Quick architecture note about pending_orders.
+     * Format: { "symbol" => {"order_id" => Order} }
+     * This means we can find pending orders by first
+     * looking up the symbol, then the order ID.
+     *  - Solves 2 problems at once
+     *      1. Very easy to check if a pending order has been filled.
+     *      2. Fast access to orders in each market (see validate_order function).
+    * */
+    pub pending_orders: HashMap<String, HashMap<i32, Order>>,   // Orders that have not been completely filled.
+    pub executed_trades: Vec<FilledOrder>                       // Trades that have occurred.
 }
 
 impl UserAccount {
     pub fn from(name: &String, password: &String) -> Self {
-        let placed: HashMap<i32, Order> = HashMap::new();
+        let placed: HashMap<String, HashMap<i32, Order>> = HashMap::new();
         let trades: Vec<FilledOrder> = Vec::new();
         UserAccount {
             username: name.to_string().clone(),
@@ -48,16 +56,20 @@ impl UserAccount {
      *  this user. Otherwise, returns false.
      **/
     pub fn validate_order(&self, order: &Order) -> bool {
-        // TODO: Optimize this, maybe change the data structure. (another hashmap)
-        for (_, pending) in self.pending_orders.iter() {
-            // Same market
-            if order.security == pending.security && order.action != pending.action {
-                if (order.action.as_str() == "buy"  && pending.price <= order.price) ||
-                   (order.action.as_str() == "sell" && order.price <= pending.price)
-               {
-                   return false;
-               }
-            }
+        match self.pending_orders.get(&order.security) {
+            // We only care about the market that `order` is being submitted to.
+            Some(market) => {
+                for (_, pending) in market.iter() {
+                    // If this order will fill a pending order that this account placed:
+                    if  (order.action != pending.action) &&
+                        (order.action.as_str() == "buy"  && pending.price <= order.price) ||
+                        (order.action.as_str() == "sell" && order.price <= pending.price)
+                   {
+                       return false;
+                   }
+                }
+            },
+            None => ()
         }
         return true;
     }
@@ -211,6 +223,8 @@ impl Users {
         const BUY: &str = "buy";
         const SELL: &str = "sell";
 
+        let market = account.pending_orders.entry(trades[0].security.clone()).or_insert(HashMap::new());
+
         for trade in trades.iter() {
             let mut id = trade.id;
             let mut update_trade = trade.clone();
@@ -226,13 +240,13 @@ impl Users {
                 }
             }
 
-            match account.pending_orders.get_mut(&id) {
+            // After processing the order, move it to executed trades.
+            match market.get_mut(&id) {
                 Some(order) => {
                     if trade.exchanged == (order.quantity - order.filled) {
-                        // order completely filled
-                        entries_to_remove.push(order.order_id);
+                        entries_to_remove.push(order.order_id); // order completely filled
                     } else {
-                        order.filled += trade.exchanged;
+                        order.filled += trade.exchanged; // order partially filled
                     }
                     account.executed_trades.push(update_trade);
                 },
@@ -242,9 +256,9 @@ impl Users {
             }
         }
 
-        // Remove all elements from account's hashmap that need to be removed.
+        // Remove any completed orders from the accounts pending orders.
         for i in &entries_to_remove {
-            account.pending_orders.remove(&i);
+            market.remove(&i);
         }
     }
 

--- a/src/account.rs
+++ b/src/account.rs
@@ -61,7 +61,7 @@ impl UserAccount {
             Some(market) => {
                 for (_, pending) in market.iter() {
                     // If this order will fill a pending order that this account placed:
-                    if  (order.action != pending.action) &&
+                    if  (order.action.ne(&pending.action)) &&
                         ((order.action.as_str() == "buy"  && pending.price <= order.price) ||
                         (order.action.as_str() == "sell" && order.price <= pending.price))
                     {
@@ -291,5 +291,11 @@ impl Users {
         }
         // Case 2: update account who placed order that filled others.
         self.update_single_user(&trades[0].filler_name, &trades, true);
+    }
+
+    pub fn print_all(&self) {
+        for (k, v) in self.users.iter() {
+            self.print_user(&k, &v.password);
+        }
     }
 }

--- a/src/account.rs
+++ b/src/account.rs
@@ -1,30 +1,32 @@
 use crate::exchange::requests::Order;
+use crate::exchange::filled::FilledOrder;
 use std::collections::HashMap;
 
 // Stores data about a user
 pub struct UserAccount {
-    username: String,
-    password: String,
-    id: Option<i32>,
-    buys: Vec<Order>,
-    sells: Vec<Order>
+    pub username: String,
+    pub password: String,
+    pub id: Option<i32>,
+    pub placed_orders: Vec<Order>,
+    pub trades: Vec<FilledOrder>
 }
 
 // Where we store all our users
 pub struct Users {
-    users: HashMap<String, UserAccount>,
-    total: i32
+    pub users: HashMap<String, UserAccount>,
+    pub total: i32
 }
 
 impl UserAccount {
     pub fn from(name: &String, password: &String) -> Self {
-        let vec: Vec<Order> = Vec::new();
+        let placed: Vec<Order> = Vec::new();
+        let trades: Vec<FilledOrder> = Vec::new();
         UserAccount {
             username: name.to_string().clone(),
             password: password.to_string().clone(),
-            id: None, // Set later
-            buys: vec.clone(),
-            sells: vec,
+            id: None, // We set this later
+            placed_orders: placed,
+            trades: trades,
         }
     }
 
@@ -36,7 +38,6 @@ impl UserAccount {
 }
 
 impl Users {
-
     pub fn new() -> Self {
         let map: HashMap<String, UserAccount> = HashMap::new();
         Users {
@@ -55,6 +56,63 @@ impl Users {
             self.total = account.set_id(&self);
             self.users.insert(account.username.clone(), account);
             return Some(self.total);
+        }
+    }
+
+    /* Returns a reference to a user account if:
+     *  - the account exists and
+     *  - the password is correct for this user
+     */
+    pub fn get(&self, username: &String, password: &String) -> Option<&UserAccount> {
+        match self.users.get(username) {
+            Some(account) => {
+                if *password == account.password {
+                    return Some(account);
+                }
+                println!("Incorrect password for username ({})", username);
+                return None;
+            },
+            None => {
+                println!("The provided username doesn't exist in our records.");
+                return None;
+            }
+        }
+    }
+
+    /* Returns a mutable reference to a user account if:
+     *  - the account exists and
+     *  - the password is correct for this user
+     */
+    pub fn get_mut(&mut self, username: &String, password: &String) -> Option<&mut UserAccount> {
+        match self.users.get_mut(username) {
+            Some(account) => {
+                if *password == account.password {
+                    return Some(account);
+                }
+                println!("Incorrect password for username ({})", username);
+                return None;
+            },
+            None => {
+                println!("The provided username doesn't exist in our records.");
+                return None;
+            }
+        }
+    }
+
+    /* Prints the account information of this user if:
+     *  - the account exists and
+     *  - the password is correct for this user
+     */
+    pub fn print_user(&self, username: &String, password: &String) {
+        if let Some(account) = self.get(username, password) {
+            println!("Orders Awaiting Execution");
+            for order in account.placed_orders.iter() {
+                println!("{:?}", order);
+            }
+            println!("\nExecuted Trades");
+            for order in account.trades.iter() {
+                println!("{:?}", order);
+            }
         }
     }
 }

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -247,17 +247,9 @@ impl Exchange {
      * If these preconditions are not met, we will return an error.
      * Otherwise, we return the number of trades that took place.
      * */
-    pub fn simulate_market(&mut self, sim: &Simulation) -> Result<i32, ()> {
+    pub fn simulate_market(&mut self, sim: &Simulation, current_price: f64) -> Result<i32, ()> {
 
-        let mut current_price: f64;
-
-        match self.get_price(&sim.symbol) {
-            Ok(p) => {
-                current_price = p;
-            },
-            // TODO better error handling
-            Err(_) => return Err(())
-        };
+        let mut current_price = current_price;
 
         let buy = String::from("buy");
         let sell = String::from("sell");

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -217,7 +217,6 @@ impl Exchange {
                     // println!("The order has been filled!");
                 }
                 // Update the state of the exchange.
-                // TODO: have this function modify relevant user accounts
                 new_price = self.update_state(&order, users, filled_orders);
             },
             None => {
@@ -303,15 +302,14 @@ impl Exchange {
 
             // Update price here instead of calling get_price, since that requires
             // unnecessary HashMap lookup.
-            // println!("{} placing order.", username);
             if let Some(p) = self.submit_order_to_market(users, order, username) {
                 current_price = p;
             }
         }
 
-        // for (k, v) in users.users.iter() {
-        //     users.print_user(&k, &v.password);
-        // }
+        for (k, v) in users.users.iter() {
+            users.print_user(&k, &v.password);
+        }
 
         return Ok(0);
     }

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -265,7 +265,15 @@ impl Exchange {
 
         let mut action: &String;
 
-        let mut account = UserAccount::from(&"admin".to_string(), &"password".to_string());
+        let mut all_users = Users::new();
+
+        all_users.new_account(UserAccount::from(&"buyer".to_string(), &"password".to_string()));
+        all_users.new_account(UserAccount::from(&"seller".to_string(), &"password".to_string()));
+
+        // let buyer_account = all_users.get_mut(&"buyer".to_string(), &"password".to_string()).unwrap();
+        // let seller_account = all_users.get_mut(&"seller".to_string(), &"password".to_string()).unwrap();
+
+        let mut account: &mut UserAccount;
 
         // Simulation loop
         for _time_step in 0..sim.duration {
@@ -276,8 +284,10 @@ impl Exchange {
             let rand: f64 = random!(); // quick 0.0 ~ 1.0 generation
             if rand < 0.5 {
                 action = &buy;
+                account = all_users.get_mut(&"buyer".to_string(), &"password".to_string()).expect("ERROR WITH BUY USER!");
             } else {
                 action = &sell;
+                account = all_users.get_mut(&"seller".to_string(), &"password".to_string()).expect("ERROR WITH SELL USER!");
             }
 
             // Deviate from the current price
@@ -292,7 +302,7 @@ impl Exchange {
 
             // Update price here instead of calling get_price, since that requires
             // unnecessary HashMap lookup.
-            if let Some(p) = self.submit_order_to_market(order, &mut account) {
+            if let Some(p) = self.submit_order_to_market(order, account) {
                 current_price = p;
             }
         }

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -51,9 +51,7 @@ impl Exchange {
         self.total_orders += 1;
     }
 
-    /* TODO: Update each users account!
-     *
-     * Update the stats for a market given the new order.
+    /* Update the stats for a market given the new order.
      * We modify total buys/sells, total order, as well as potentially price and filled orders.
      *
      * Returns Some(price) if trade occured, or None.

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -181,10 +181,10 @@ impl Exchange {
      *
      * Returns Some(new_price) if trade occurred, else None.
     */
-    pub fn submit_order_to_market(&mut self, users: &mut Users, order: Order, username: &String) -> Option<f64> {
+    pub fn submit_order_to_market(&mut self, users: &mut Users, order: Order, username: &String, auth: bool) -> Option<f64> {
 
         // Mutable reference to the account associated with given username.
-        let account = users._get_mut(username).expect("USER NOT FOUND!");
+        let account = users.get_mut(username, auth).expect("USER NOT FOUND!");
         let mut order: Order = order;
         let mut new_price = None; // new price if trade occurs
 
@@ -211,7 +211,7 @@ impl Exchange {
                         },
                         _ => ()
                     }
-                    account.placed_orders.push(order.clone());
+                    account.pending_orders.push(order.clone());
                 } else {
                     // TEST SPEED
                     // println!("The order has been filled!");
@@ -235,7 +235,7 @@ impl Exchange {
                     // We can never get here.
                     _ => ()
                 };
-                account.placed_orders.push(order.clone());
+                account.pending_orders.push(order.clone());
 
                 let new_market = Market::new(buy_heap, sell_heap);
                 self.live_orders.insert(order.security.clone(), new_market);
@@ -302,7 +302,7 @@ impl Exchange {
 
             // Update price here instead of calling get_price, since that requires
             // unnecessary HashMap lookup.
-            if let Some(p) = self.submit_order_to_market(users, order, username) {
+            if let Some(p) = self.submit_order_to_market(users, order, username, true) {
                 current_price = p;
             }
         }

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -182,7 +182,13 @@ impl Exchange {
     pub fn submit_order_to_market(&mut self, users: &mut Users, order: Order, username: &String, auth: bool) -> Option<f64> {
 
         // Mutable reference to the account associated with given username.
-        let account = users.get_mut(username, auth).expect("USER NOT FOUND!");
+        let account = match users.get_mut(username, auth) {
+            Ok(acc) => acc,
+            Err(e) => {
+                Users::print_auth_error(e);
+                return None;
+            }
+        };
         let mut order: Order = order;
         let mut new_price = None; // new price if trade occurs
 

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -211,7 +211,8 @@ impl Exchange {
                         },
                         _ => ()
                     }
-                    account.pending_orders.push(order.clone());
+                    // account.pending_orders.push(order.clone());
+                    account.pending_orders.insert(order.order_id, order.clone());
                 } else {
                     // TEST SPEED
                     // println!("The order has been filled!");
@@ -235,7 +236,8 @@ impl Exchange {
                     // We can never get here.
                     _ => ()
                 };
-                account.pending_orders.push(order.clone());
+                // account.pending_orders.push(order.clone());
+                account.pending_orders.insert(order.order_id, order.clone());
 
                 let new_market = Market::new(buy_heap, sell_heap);
                 self.live_orders.insert(order.security.clone(), new_market);
@@ -307,9 +309,9 @@ impl Exchange {
             }
         }
 
-        for (k, v) in users.users.iter() {
-            users.print_user(&k, &v.password);
-        }
+        // for (k, v) in users.users.iter() {
+        //     users.print_user(&k, &v.password);
+        // }
 
         return Ok(0);
     }

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -78,6 +78,16 @@ impl Exchange {
             new_price = Some(price);
             stats.update_price(price);
             stats.update_filled_orders(&filled_orders);
+            /* TODO: Updating accounts seems like something that
+             *       shouldn't slow down order execution.
+             *
+             * Market state doesn't depend on users view of the market.
+             * This function is also computationally expensive, I think
+             * the better route is to compute this in a separate thread,
+             * and somehow force sequential access of users accounts
+             * (think mutex locks, and maybe write filled orders to a buffer
+             * in the mean time?)
+             */
             users.update_account_orders(&filled_orders);
             self.extend_past_orders(&mut filled_orders);
         };

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -237,6 +237,7 @@ impl Exchange {
                 // buy is a max heap, sell is a min heap.
                 let mut buy_heap: BinaryHeap<Order> = BinaryHeap::new();
                 let mut sell_heap: BinaryHeap<Reverse<Order>> = BinaryHeap::new();
+
                 // Store order on market, and in users account.
                 match &order.action[..] {
                     "buy" => {
@@ -287,7 +288,6 @@ impl Exchange {
                             let new_size = market.buy_orders.len() - 1;
                             let mut temp = BinaryHeap::with_capacity(new_size);
                             for order in market.buy_orders.drain().filter(|order| order.order_id != order_to_cancel.order_id) {
-                                // temp.push(order.clone()); // Worst case is < O(n) since we preallocate
                                 temp.push(order); // Worst case is < O(n) since we preallocate
                             }
                             market.buy_orders.append(&mut temp);
@@ -298,7 +298,6 @@ impl Exchange {
                             let new_size = market.sell_orders.len() - 1;
                             let mut temp = BinaryHeap::with_capacity(new_size);
                             for order in market.sell_orders.drain().filter(|order| order.0.order_id != order_to_cancel.order_id) {
-                                // temp.push(order.clone()); // Worst case is < O(n) since we preallocate
                                 temp.push(order); // Worst case is < O(n) since we preallocate
                             }
                             market.sell_orders.append(&mut temp);
@@ -320,7 +319,6 @@ impl Exchange {
                 }
             } else {
                 return Err("The order requested to be cancelled was not found in the associated user's pending orders!".to_string());
-                // return Err("The order that was requested to be cancelled was not placed by the account that made the request!".to_string());
             }
         }
         panic!("Could not find the user while cancelling an order.\
@@ -404,6 +402,7 @@ impl Exchange {
                 }
             }
         }
+
         // If you want prints of each users account, uncomment this.
         // users.print_all();
     }

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -306,10 +306,14 @@ impl Exchange {
             // Create the order and send it to the market
             let order = Order::from(action.to_string(), sim.symbol.clone(), shares, new_price, username);
 
-            // Update price here instead of calling get_price, since that requires
-            // unnecessary HashMap lookup.
-            if let Some(p) = self.submit_order_to_market(users, order, username, true) {
-                current_price = p;
+            if let Ok(account) =  users.authenticate(username, &"password".to_string()) {
+                if account.validate_order(&order) {
+                    // Update price here instead of calling get_price, since that requires
+                    // unnecessary HashMap lookup.
+                    if let Some(p) = self.submit_order_to_market(users, order, username, true) {
+                        current_price = p;
+                    }
+                }
             }
         }
 

--- a/src/exchange/filled.rs
+++ b/src/exchange/filled.rs
@@ -1,4 +1,3 @@
-// use crate::exchange::requests::Order;
 use crate::exchange::Order;
 
 #[derive(Debug)]
@@ -7,24 +6,40 @@ pub struct FilledOrder {
     pub security: String,
     pub price: f64,         // price at which this order was filled
     pub id: i32,            // this order's ID
+    pub username: String,
     pub filled_by: i32,     // the order ID that filled this order
+    pub filler_name: String,
     pub exchanged: i32      // the amount of shares exchanged
 }
 
 impl FilledOrder {
-    fn from(action: &String, security: &String, price: f64, id: i32, filled_by: i32, exchanged: i32) -> Self {
+    fn from(action: &String, security: &String, price: f64, id: i32, username: &String, filled_by: i32, filler_name: &String, exchanged: i32) -> Self {
         FilledOrder {
             action: action.clone(),
             security: security.clone(),
             price,
             id,
+            username: username.clone(),
             filled_by,
+            filler_name: filler_name.clone(),
             exchanged
         }
     }
 
     // Create a FilledOrder from a pair of orders.
     pub fn order_to_filled_order(old: &Order, filler: &Order, exchanged: i32) -> Self {
-        FilledOrder::from(&old.action, &old.security, old.price, old.order_id, filler.order_id, exchanged)
+        FilledOrder::from(&old.action, &old.security, old.price, old.order_id, &old.username, filler.order_id, &filler.username, exchanged)
+    }
+}
+
+impl Clone for FilledOrder {
+    fn clone(&self) -> Self {
+        FilledOrder {
+            action: self.action.clone(),
+            security: self.security.clone(),
+            username: self.username.clone(),
+            filler_name: self.filler_name.clone(),
+            ..*self
+        }
     }
 }

--- a/src/exchange/market.rs
+++ b/src/exchange/market.rs
@@ -65,16 +65,6 @@ impl Market {
                     // Add this trade
                     highest_bid.filled += amount_traded;
                     filled_orders.push(FilledOrder::order_to_filled_order(&lowest_offer.0, &highest_bid, amount_traded));
-
-                    // If the newly placed order was consumed
-                    /*
-                    // Since the sell has been filled, add it to the new vector.
-                    if lowest_sell_remaining == highest_bid_remaining {
-                        // TODO: Do we really want to do this in this way?
-                        // filled_orders.push(highest_bid.clone());
-                        filled_orders.push(FilledOrder::order_to_filled_order(&highest_bid, &update_lowest, amount_traded));
-                    }
-                    */
                 } else {
                     // The buy order was completely filled.
                     let amount_traded = highest_bid_remaining;
@@ -144,14 +134,6 @@ impl Market {
 
                     // Add the updated buy to the Vector we return
                     filled_orders.push(FilledOrder::order_to_filled_order(&highest_bid, &lowest_offer, amount_traded));
-
-                    /*
-                    // If the newly placed order was consumed
-                    if lowest_sell_remaining == highest_bid_remaining {
-                        // TODO: Do we really want to do this in this way?
-                        filled_orders.push(FilledOrder::order_to_filled_order(&lowest_offer, &update_highest, amount_traded));
-                    }
-                    */
                 } else {
                     // The sell order was completely filled.
                     let amount_traded = lowest_sell_remaining;

--- a/src/exchange/market.rs
+++ b/src/exchange/market.rs
@@ -41,6 +41,11 @@ impl Market {
                 None => return new_price // No more sell orders to fill
             };
 
+            // We don't allow a user to buy their own sell order.
+            if highest_bid.username == lowest_offer.username {
+                continue;
+            }
+
             let lowest_sell_remaining = lowest_offer.quantity - lowest_offer.filled;
             let highest_bid_remaining = highest_bid.quantity - highest_bid.filled;
 
@@ -113,6 +118,11 @@ impl Market {
                 Some(bid) => bid,
                 None => return new_price // No more buy orders to fill
             };
+
+            // We don't allow a user to sell into their own buy order.
+            if highest_bid.username == lowest_offer.username {
+                continue;
+            }
 
             let lowest_sell_remaining = lowest_offer.quantity - lowest_offer.filled;
             let highest_bid_remaining = highest_bid.quantity - highest_bid.filled;

--- a/src/exchange/market.rs
+++ b/src/exchange/market.rs
@@ -41,11 +41,6 @@ impl Market {
                 None => return new_price // No more sell orders to fill
             };
 
-            // We don't allow a user to buy their own sell order.
-            if highest_bid.username == lowest_offer.username {
-                continue;
-            }
-
             let lowest_sell_remaining = lowest_offer.quantity - lowest_offer.filled;
             let highest_bid_remaining = highest_bid.quantity - highest_bid.filled;
 
@@ -108,11 +103,6 @@ impl Market {
                 Some(bid) => bid,
                 None => return new_price // No more buy orders to fill
             };
-
-            // We don't allow a user to sell into their own buy order.
-            if highest_bid.username == lowest_offer.username {
-                continue;
-            }
 
             let lowest_sell_remaining = lowest_offer.quantity - lowest_offer.filled;
             let highest_bid_remaining = highest_bid.quantity - highest_bid.filled;

--- a/src/exchange/requests.rs
+++ b/src/exchange/requests.rs
@@ -99,7 +99,7 @@ impl Simulation {
 }
 
 pub enum Request {
-    OrderReq(Order),
+    OrderReq(Order, String, String), // first string is username, second password
     InfoReq(InfoRequest),
     SimReq(Simulation),
     UserReq(UserAccount)

--- a/src/exchange/requests.rs
+++ b/src/exchange/requests.rs
@@ -1,4 +1,5 @@
 use std::cmp::Ordering;
+use crate::account::UserAccount;
 // An order type for a security
 #[derive(Debug)]
 pub struct Order {
@@ -100,5 +101,6 @@ impl Simulation {
 pub enum Request {
     OrderReq(Order),
     InfoReq(InfoRequest),
-    SimReq(Simulation)
+    SimReq(Simulation),
+    UserReq(UserAccount)
 }

--- a/src/exchange/requests.rs
+++ b/src/exchange/requests.rs
@@ -8,11 +8,12 @@ pub struct Order {
     pub quantity: i32,
     pub filled: i32,        // Quantity filled so far
     pub price: f64,
-    pub order_id: i32
+    pub order_id: i32,
+    pub username: String        // username of user who placed order.
 }
 
 impl Order {
-    pub fn from(action: String, security: String, quantity: i32, price: f64) -> Order {
+    pub fn from(action: String, security: String, quantity: i32, price: f64, name: &String) -> Order {
         // Truncate price to 2 decimal places
         let price = f64::trunc(price  * 100.0) / 100.0;
 
@@ -22,7 +23,8 @@ impl Order {
             quantity,
             filled: 0,
             price,
-            order_id: 0 // Updated later.
+            order_id: 0, // Updated later.
+            username: name.to_string().clone()
         }
     }
 }
@@ -32,6 +34,7 @@ impl Clone for Order {
         Order {
             action: self.action.clone(),
             security: self.security.clone(),
+            username: self.username.clone(),
             ..*self
         }
     }

--- a/src/exchange/requests.rs
+++ b/src/exchange/requests.rs
@@ -87,16 +87,18 @@ impl InfoRequest {
 // Allows us to perform simulations on our market
 pub struct Simulation {
     pub action: String,
-    pub symbol: String,
+    pub trader_count: u32,
+    pub market_count: u32,
     pub duration: u32
 }
 
 impl Simulation {
-    pub fn from(action: String, symbol: String, duration: u32) -> Self {
+    pub fn from(action: String, trader_count: u32, market_count: u32, duration: u32) -> Self {
         Simulation {
             action,
-            symbol,
-            duration
+            trader_count,   // number of traders
+            market_count,   // number of markets to trade in
+            duration        // number of trades to make
         }
     }
 }

--- a/src/exchange/requests.rs
+++ b/src/exchange/requests.rs
@@ -103,8 +103,15 @@ impl Simulation {
     }
 }
 
+pub struct CancelOrder {
+    pub symbol: String,
+    pub order_id: i32,
+    pub username: String,
+}
+
 pub enum Request {
     OrderReq(Order, String, String),// first string is username, second password
+    CancelReq(CancelOrder, String), // string is password
     InfoReq(InfoRequest),
     SimReq(Simulation),
     UserReq(UserAccount, String)    // Account followed by action

--- a/src/exchange/requests.rs
+++ b/src/exchange/requests.rs
@@ -9,7 +9,7 @@ pub struct Order {
     pub filled: i32,        // Quantity filled so far
     pub price: f64,
     pub order_id: i32,
-    pub username: String        // username of user who placed order.
+    pub username: String    // username of user who placed order.
 }
 
 impl Order {

--- a/src/exchange/requests.rs
+++ b/src/exchange/requests.rs
@@ -102,8 +102,8 @@ impl Simulation {
 }
 
 pub enum Request {
-    OrderReq(Order, String, String), // first string is username, second password
+    OrderReq(Order, String, String),// first string is username, second password
     InfoReq(InfoRequest),
     SimReq(Simulation),
-    UserReq(UserAccount)
+    UserReq(UserAccount, String)    // Account followed by action
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,9 +101,7 @@ pub fn print_instructions() {
     println!("\t\tEx: show GME\t\t<---- shows statistics for the GME market.");
     println!("\t\tEx: history GME\t\t<---- shows past orders that were filled in the GME market.\n");
 
-    // println!("\tSimulation Requests: simulate SYMBOL(ticker) NUM_ORDERS");
     println!("\tSimulation Requests: simulate NUM_USERS NUM_MARKETS NUM_ORDERS");
-    // println!("\t\tEx: simulate GME 100\t<---- Simulates 100 random buy/sell orders in the GME market.\n");
     println!("\t\tEx: simulate 300 500 10000\t<---- Simulates 10000 random buy/sell orders in 500 markets, with 300 random users.\n");
 
     println!("\tAccount Requests: account create/show USERNAME PASSWORD");

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ pub fn print_instructions() {
     let pass = "pass";
 
     println!("Usage:");
-    println!("\tOrders: ACTION SYMBOL(ticker) QUANTITY PRICE USERNAME PASSWORD");
+    println!("\tOrders: ACTION(buy/sell) SYMBOL(ticker) QUANTITY PRICE USERNAME PASSWORD");
     println!("\t\tEx: BUY GME {} {} {} {}\t<---- Sends a buy order for {} shares of GME at ${} a share. Order is placed by {} with password {}.", buy_amount, buy_price, user, pass, buy_amount, buy_price, user, pass);
     println!("\t\tEx: SELL GME {} {} {} {}\t<---- Sends a sell order for {} shares of GME at ${} a share. Order is placed by {} with password {}.\n", sell_amount, sell_price, user, pass, sell_amount, sell_price, user, pass);
 
@@ -34,8 +34,8 @@ pub fn print_instructions() {
     println!("\tSimulation Requests: simulate SYMBOL(ticker) NUM_ORDERS");
     println!("\t\tEx: simulate GME 100\t<---- Simulates 100 random buy/sell orders in the GME market.\n");
 
-    println!("\tCreate new user: create USERNAME PASSWORD");
-    println!("\t\tEx: create bigMoney notHashed\n");
+    println!("\tAccount Requests: account create/show USERNAME PASSWORD");
+    println!("\t\tEx: account create bigMoney notHashed\n");
     println!("\tYou can see these instructions at any point by typing help.");
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,12 @@
 
 pub mod exchange;
 pub mod parser;
+pub mod account;
 
 pub use crate::exchange::{Exchange, Market, Request};
 pub use crate::parser::{tokenize_input, service_request};
+
+pub use crate::account::{Users};
 
 use std::io::{self, prelude::*, BufReader};
 use std::env;
@@ -14,6 +17,8 @@ fn main() {
 
     // Our central exchange, everything happens here.
     let mut exchange: Exchange = Exchange::new();
+    // All our users are stored here.
+    let mut users: Users = Users::new();
 
     let args: Vec<String> = env::args().collect();
 
@@ -41,7 +46,7 @@ fn main() {
                     // Our input has been validated, and we can now
                     // attempt to service the request.
                     println!("Request: {}", keep);
-                    service_request(request, &mut exchange);
+                    service_request(request, &mut exchange, &mut users);
                 },
                 Err(_) => return
             }
@@ -63,16 +68,18 @@ fn main() {
         println!("\tOrders: ACTION SYMBOL(ticker) QUANTITY PRICE");
         println!("\t\tEx: BUY GME {} {}\t<---- Sends a buy order for {} shares of GME at ${} a share.", buy_amount, buy_price, buy_amount, buy_price);
         println!("\t\tEx: SELL GME {} {}\t<---- Sends a sell order for {} shares of GME at ${} a share.\n", sell_amount, sell_price, sell_amount, sell_price);
+
         println!("\tInfo Requests: ACTION SYMBOL(ticker)");
         println!("\t\tEx: price GME\t\t<---- gives latest price an order was filled at.");
         println!("\t\tEx: show GME\t\t<---- shows statistics for the GME market.");
-        println!("\t\tEx: history GME\t\t<---- shows past orders that were filled in the GME market.");
+        println!("\t\tEx: history GME\t\t<---- shows past orders that were filled in the GME market.\n");
+
+        println!("\tSimulation Requests: simulate SYMBOL(ticker) NUM_ORDERS");
         println!("\t\tEx: simulate GME 100\t<---- Simulates 100 random buy/sell orders in the GME market.\n");
+
+        println!("\tCreate new user: create USERNAME PASSWORD");
+        println!("\t\tEx: create bigMoney notHashed\n");
         println!("\tYou can see these instructions at any point by typing help.");
-
-
-        // // Our central exchange, everything happens here.
-        // let mut exchange: Exchange = Exchange::new();
 
         loop {
             println!("\n---What would you like to do?---\n");
@@ -93,7 +100,7 @@ fn main() {
 
             // Our input has been validated, and we can now
             // attempt to service the request.
-            service_request(request, &mut exchange);
+            service_request(request, &mut exchange, &mut users);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,10 +70,7 @@ fn main() {
 
             let request: Request = match parser::tokenize_input(input) {
                 Ok(req) => req,
-                Err(_)  => {
-                    println!("Please enter a valid request.");
-                    continue;
-                }
+                Err(_)  => continue
             };
 
             // Our input has been validated, and we can now

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,16 +93,21 @@ pub fn print_instructions() {
 
     println!("Usage:");
     println!("\tOrders: ACTION(buy/sell) SYMBOL(ticker) QUANTITY PRICE USERNAME PASSWORD");
-    println!("\t\tEx: BUY GME {} {} {} {}\t<---- Sends a buy order for {} shares of GME at ${} a share. Order is placed by {} with password {}.", buy_amount, buy_price, user, pass, buy_amount, buy_price, user, pass);
-    println!("\t\tEx: SELL GME {} {} {} {}\t<---- Sends a sell order for {} shares of GME at ${} a share. Order is placed by {} with password {}.\n", sell_amount, sell_price, user, pass, sell_amount, sell_price, user, pass);
+    println!("\t\tEx: buy GME {} {} {} {}\t<---- Sends a buy order for {} shares of GME at ${} a share. Order is placed by {} with password {}.", buy_amount, buy_price, user, pass, buy_amount, buy_price, user, pass);
+    println!("\t\tEx: sell GME {} {} {} {}\t<---- Sends a sell order for {} shares of GME at ${} a share. Order is placed by {} with password {}.\n", sell_amount, sell_price, user, pass, sell_amount, sell_price, user, pass);
+
+    println!("\tCancel Request: cancel SYMBOL ORDER_ID USERNAME PASSWORD");
+    println!("\t\tEx: cancel AAPL 4 admin pass\t\t<---- Cancels the order with ID 4 in the AAPL market, provided user (admin) placed it.\n");
 
     println!("\tInfo Requests: ACTION SYMBOL(ticker)");
     println!("\t\tEx: price GME\t\t<---- gives latest price an order was filled at.");
     println!("\t\tEx: show GME\t\t<---- shows statistics for the GME market.");
     println!("\t\tEx: history GME\t\t<---- shows past orders that were filled in the GME market.\n");
 
-    println!("\tSimulation Requests: simulate SYMBOL(ticker) NUM_ORDERS");
-    println!("\t\tEx: simulate GME 100\t<---- Simulates 100 random buy/sell orders in the GME market.\n");
+    // println!("\tSimulation Requests: simulate SYMBOL(ticker) NUM_ORDERS");
+    println!("\tSimulation Requests: simulate NUM_USERS NUM_MARKETS NUM_ORDERS");
+    // println!("\t\tEx: simulate GME 100\t<---- Simulates 100 random buy/sell orders in the GME market.\n");
+    println!("\t\tEx: simulate 300 500 10000\t<---- Simulates 10000 random buy/sell orders in 500 markets, with 300 random users.\n");
 
     println!("\tAccount Requests: account create/show USERNAME PASSWORD");
     println!("\t\tEx: account create bigMoney notHashed\n");

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,32 @@ use std::io::{self, prelude::*, BufReader};
 use std::env;
 use std::fs::File;
 
+pub fn print_instructions() {
+    let buy_price = 167.34;
+    let buy_amount = 24;
+    let sell_price = 999.85;
+    let sell_amount = 12;
+    let user = "example";
+    let pass = "pass";
+
+    println!("Usage:");
+    println!("\tOrders: ACTION SYMBOL(ticker) QUANTITY PRICE USERNAME PASSWORD");
+    println!("\t\tEx: BUY GME {} {} {} {}\t<---- Sends a buy order for {} shares of GME at ${} a share. Order is placed by {} with password {}.", buy_amount, buy_price, user, pass, buy_amount, buy_price, user, pass);
+    println!("\t\tEx: SELL GME {} {} {} {}\t<---- Sends a sell order for {} shares of GME at ${} a share. Order is placed by {} with password {}.\n", sell_amount, sell_price, user, pass, sell_amount, sell_price, user, pass);
+
+    println!("\tInfo Requests: ACTION SYMBOL(ticker)");
+    println!("\t\tEx: price GME\t\t<---- gives latest price an order was filled at.");
+    println!("\t\tEx: show GME\t\t<---- shows statistics for the GME market.");
+    println!("\t\tEx: history GME\t\t<---- shows past orders that were filled in the GME market.\n");
+
+    println!("\tSimulation Requests: simulate SYMBOL(ticker) NUM_ORDERS");
+    println!("\t\tEx: simulate GME 100\t<---- Simulates 100 random buy/sell orders in the GME market.\n");
+
+    println!("\tCreate new user: create USERNAME PASSWORD");
+    println!("\t\tEx: create bigMoney notHashed\n");
+    println!("\tYou can see these instructions at any point by typing help.");
+}
+
 fn main() {
 
     // Our central exchange, everything happens here.
@@ -60,27 +86,7 @@ fn main() {
          | |/ |/ /  __/ / /__/ /_/ / / / / / /  __/  / /_/ /_/ /  / _, _/ /_/ (__  ) /_/   |
          |__/|__/\\___/_/\\___/\\____/_/ /_/ /_/\\___/   \\__/\\____/  /_/ |_|\\__,_/____/\\__/_/|_|\n");
 
-        let buy_price = 167.34;
-        let buy_amount = 24;
-        let sell_price = 999.85;
-        let sell_amount = 12;
-        println!("Usage:");
-        println!("\tOrders: ACTION SYMBOL(ticker) QUANTITY PRICE");
-        println!("\t\tEx: BUY GME {} {}\t<---- Sends a buy order for {} shares of GME at ${} a share.", buy_amount, buy_price, buy_amount, buy_price);
-        println!("\t\tEx: SELL GME {} {}\t<---- Sends a sell order for {} shares of GME at ${} a share.\n", sell_amount, sell_price, sell_amount, sell_price);
-
-        println!("\tInfo Requests: ACTION SYMBOL(ticker)");
-        println!("\t\tEx: price GME\t\t<---- gives latest price an order was filled at.");
-        println!("\t\tEx: show GME\t\t<---- shows statistics for the GME market.");
-        println!("\t\tEx: history GME\t\t<---- shows past orders that were filled in the GME market.\n");
-
-        println!("\tSimulation Requests: simulate SYMBOL(ticker) NUM_ORDERS");
-        println!("\t\tEx: simulate GME 100\t<---- Simulates 100 random buy/sell orders in the GME market.\n");
-
-        println!("\tCreate new user: create USERNAME PASSWORD");
-        println!("\t\tEx: create bigMoney notHashed\n");
-        println!("\tYou can see these instructions at any point by typing help.");
-
+        print_instructions();
         loop {
             println!("\n---What would you like to do?---\n");
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,12 +1,19 @@
 pub use crate::exchange::{self, Exchange, Market, Order, InfoRequest, Simulation, Request, PriceError};
+pub use crate::print_instructions;
 
 // pub mod account;
 use crate::account::{UserAccount, Users};
 
 /* Prints some helpful information to the console when input is malformed. */
-fn malformed_req(req: &String) {
+fn malformed_req(req: &str, req_type: &str) {
     println!("\nMalformed \"{}\" request!", req);
-    println!("Hint - format should be: {} symbol", req);
+    match req_type {
+       "create" => println!("Hint - format should be: {} username password", req),
+       "order"  => println!("Hint - format should be: {} symbol quantity price username password", req),
+       "info"   => println!("Hint - format should be: {} symbol", req),
+       "sim"    => println!("Hint - format should be: {} symbol timesteps", req),
+       _        => ()
+    }
 }
 
 /* Takes a string from stdin, and turns it into a Request Enum.
@@ -41,8 +48,7 @@ pub fn tokenize_input(text: String) -> Result<Request, ()> {
                     return Ok(Request::UserReq(user));
                 },
                 _ => {
-                    println!("Malformed \"{}\" request!", words[0]);
-                    println!("Hint - format should be: {} username password", words[0]);
+                    malformed_req(&words[0], &words[0]);
                     return Err(());
                 }
             }
@@ -65,8 +71,7 @@ pub fn tokenize_input(text: String) -> Result<Request, ()> {
                     return Ok(Request::OrderReq(order, words[4].to_string(), words[5].to_string()));
                 },
                 _ => {
-                    println!("Malformed \"{}\" request!", words[0]);
-                    println!("Hint - format should be: {} symbol quantity price username password", words[0]);
+                    malformed_req(&words[0], "order");
                     return Err(());
                 }
             }
@@ -79,7 +84,7 @@ pub fn tokenize_input(text: String) -> Result<Request, ()> {
                     return Ok(Request::InfoReq(req));
                 },
                 _ =>  {
-                    malformed_req(&words[0]);
+                    malformed_req(&words[0], "info");
                     return Err(());
                 }
             }
@@ -96,34 +101,14 @@ pub fn tokenize_input(text: String) -> Result<Request, ()> {
                     return Ok(Request::SimReq(req));
                 },
                 _ => {
-                    println!("Malformed \"{}\" request!", words[0]);
-                    println!("Hint - format should be: {} symbol timesteps", words[0]);
+                    malformed_req(&words[0], "sim");
                     return Err(());
                 }
             }
         },
         // request instructions
         "help" => {
-            let buy_price = 167.34;
-            let buy_amount = 24;
-            let sell_price = 999.85;
-            let sell_amount = 12;
-            println!("Usage:");
-            println!("\tOrders: ACTION SYMBOL(ticker) QUANTITY PRICE");
-            println!("\t\tEx: BUY GME {} {}\t<---- Sends a buy order for {} shares of GME at ${} a share.", buy_amount, buy_price, buy_amount, buy_price);
-            println!("\t\tEx: SELL GME {} {}\t<---- Sends a sell order for {} shares of GME at ${} a share.\n", sell_amount, sell_price, sell_amount, sell_price);
-
-            println!("\tInfo Requests: ACTION SYMBOL(ticker)");
-            println!("\t\tEx: price GME\t\t<---- gives latest price an order was filled at.");
-            println!("\t\tEx: show GME\t\t<---- shows statistics for the GME market.");
-            println!("\t\tEx: history GME\t\t<---- shows past orders that were filled in the GME market.\n");
-
-            println!("\tSimulation Requests: simulate SYMBOL(ticker) NUM_ORDERS");
-            println!("\t\tEx: simulate GME 100\t<---- Simulates 100 random buy/sell orders in the GME market.\n");
-
-            println!("\tCreate new user: create USERNAME PASSWORD");
-            println!("\t\tEx: create bigMoney notHashed\n");
-
+            print_instructions();
             return Err(()); // We return an empty error only because there's no more work to do.
         },
         // Unknown input

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -126,10 +126,13 @@ pub fn service_request(request: Request, exchange: &mut Exchange, users: &mut Us
                 "buy" | "sell" => {
                     // Try to get the account
                     match users.authenticate(&username, &password) {
-                        Ok(_) => {
-                            &exchange.submit_order_to_market(users, order.clone(), &username, true);
-                            &exchange.show_market(&order.security);
-                            &users.print_user(&username, &password);
+                        Ok(account) => {
+                            if account.validate_order(&order) {
+                                &exchange.submit_order_to_market(users, order.clone(), &username, true);
+                                &exchange.show_market(&order.security);
+                            } else {
+                                println!("Order could not be placed. This order would fill one of your currently pending orders!");
+                            }
                         },
                         Err(e) => Users::print_auth_error(e)
                     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,7 +2,7 @@ pub use crate::exchange::{self, Exchange, Market, Order, InfoRequest, Simulation
 pub use crate::print_instructions;
 
 // pub mod account;
-use crate::account::{UserAccount, Users, AuthError};
+use crate::account::{UserAccount, Users};
 
 /* Prints some helpful information to the console when input is malformed. */
 fn malformed_req(req: &str, req_type: &str) {
@@ -132,10 +132,7 @@ pub fn service_request(request: Request, exchange: &mut Exchange, users: &mut Us
                             &exchange.show_market(&order.security);
                             &users.print_user(&username, &password);
                         },
-                        Err(e) => match e {
-                            AuthError::NoUser(name) => println!("Authentication failed! User ({}) not found.", name),
-                            AuthError::BadPassword(_) => println!("Authentication failed! Incorrect password!.")
-                        }
+                        Err(e) => Users::print_auth_error(e)
                     }
                 },
                 // Handle unknown action!

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -142,9 +142,9 @@ pub fn service_request(request: Request, exchange: &mut Exchange, users: &mut Us
                 "buy" | "sell" => {
                     // Try to get the account
                     if users.authenticate(&username, &password) {
-                        &exchange.submit_order_to_market(users, order.clone(), &username);
+                        &exchange.submit_order_to_market(users, order.clone(), &username, true);
                         &exchange.show_market(&order.security);
-                        // &users.print_user(&username, &password);
+                        &users.print_user(&username, &password);
                     } else {
                         println!("Authentication failed! Either the username doesn't exist or the password was wrong.");
                     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,8 +1,44 @@
 pub use crate::exchange::{self, Exchange, Market, Order, InfoRequest, Simulation, Request, PriceError};
 pub use crate::print_instructions;
 
-// pub mod account;
 use crate::account::{UserAccount, Users};
+
+// IO stuff
+use std::io::BufReader;
+use std::env;
+use std::fs::File;
+
+pub struct Argument<R> {
+    pub interactive: bool,                      // false means read from file, true means interactive mode
+    pub reader: Option<std::io::BufReader<R>>   // The buffer we read from
+}
+
+// Parses the command line arguments.
+// Returns an argument struct on success, or an error string.
+pub fn command_args(mut args: env::Args) -> Result<Argument<std::fs::File>, String> {
+    args.next(); // skip the first argument since it's the program name
+
+    // Default argument
+    let mut argument = Argument {
+        interactive: true,
+        reader: None
+    };
+
+    // Modify the argument depending on user input.
+    match args.next() {
+        Some(filename) => {
+            let file = match File::open(filename) {
+                Ok(f) => f,
+                // TODO: pass the error up call stack?
+                Err(_) => return Err("Failed to open the file!".to_string())
+            };
+            argument.interactive = false;
+            argument.reader = Some(BufReader::new(file));
+        }
+        None => ()
+    }
+    return Ok(argument);
+}
 
 /* Prints some helpful information to the console when input is malformed. */
 fn malformed_req(req: &str, req_type: &str) {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,4 @@
-pub use crate::exchange::{self, Exchange, Market, Order, InfoRequest, Simulation, Request, PriceError};
+pub use crate::exchange::{self, Exchange, Market, Order, InfoRequest, Simulation, CancelOrder, Request, PriceError};
 pub use crate::print_instructions;
 
 use crate::account::{UserAccount, Users};
@@ -42,12 +42,13 @@ pub fn command_args(mut args: env::Args) -> Result<Argument<std::fs::File>, Stri
 
 /* Prints some helpful information to the console when input is malformed. */
 fn malformed_req(req: &str, req_type: &str) {
-    println!("\nMalformed \"{}\" request!", req);
+    eprintln!("\nMalformed \"{}\" request!", req);
     match req_type {
-       "account" => println!("Hint - format should be: {} create/show username password", req),
-       "order"  => println!("Hint - format should be: {} symbol quantity price username password", req),
-       "info"   => println!("Hint - format should be: {} symbol", req),
-       "sim"    => println!("Hint - format should be: {} trader_count market_count duration", req),
+       "account" => eprintln!("Hint - format should be: {} create/show username password", req),
+       "order"  => eprintln!("Hint - format should be: {} symbol quantity price username password", req),
+       "cancel"  => eprintln!("Hint - format should be: {} symbol order_id username password", req),
+       "info"   => eprintln!("Hint - format should be: {} symbol", req),
+       "sim"    => eprintln!("Hint - format should be: {} trader_count market_count duration", req),
        _        => ()
     }
 }
@@ -99,8 +100,8 @@ pub fn tokenize_input(text: String) -> Result<Request, ()> {
                                              &words[4].to_string()
                                             );
                     if order.quantity <= 0 || order.price <= 0.0 {
-                        println!("Malformed \"{}\" request!", words[0]);
-                        println!("Make sure the quantity and price are greater than 0!");
+                        eprintln!("Malformed \"{}\" request!", words[0]);
+                        eprintln!("Make sure the quantity and price are greater than 0!");
                         return Err(());
                     }
                     return Ok(Request::OrderReq(order, words[4].to_string(), words[5].to_string()));
@@ -111,6 +112,23 @@ pub fn tokenize_input(text: String) -> Result<Request, ()> {
                 }
             }
         },
+        "cancel" => {
+            match words.len() {
+                5 => {
+                    let req = CancelOrder {
+                        symbol: words[1].to_string().to_uppercase(),
+                        order_id: words[2].to_string().trim().parse::<i32>().expect("Please enter an integer order id"), // TODO we don't need to panic here.
+                        username: words[3].to_string()
+                    };
+
+                    return Ok(Request::CancelReq(req, words[4].to_string()));
+                },
+                _ => {
+                    malformed_req(&words[0], &words[0]);
+                    return Err(());
+                }
+            }
+        }
         // request price info, current market info, or past market info
         "price" | "show" | "history" =>  {
             match words.len() {
@@ -153,7 +171,7 @@ pub fn tokenize_input(text: String) -> Result<Request, ()> {
         },
         // Unknown input
         _ => {
-            println!("I don't understand the action type \'{}\'.", words[0]);
+            eprintln!("I don't understand the action type \'{}\'.", words[0]);
             return Err(());
         }
     }
@@ -172,15 +190,27 @@ pub fn service_request(request: Request, exchange: &mut Exchange, users: &mut Us
                                 &exchange.submit_order_to_market(users, order.clone(), &username, true);
                                 &exchange.show_market(&order.security);
                             } else {
-                                println!("Order could not be placed. This order would fill one of your currently pending orders!");
+                                eprintln!("Order could not be placed. This order would fill one of your currently pending orders!");
                             }
                         },
                         Err(e) => Users::print_auth_error(e)
                     }
                 },
                 // Handle unknown action!
-                _ => println!("Sorry, I do not know how to perform {:?}", order)
+                _ => eprintln!("Sorry, I do not know how to perform {:?}", order)
             }
+        },
+        Request::CancelReq(order_to_cancel, password) => {
+            match users.authenticate(&(order_to_cancel.username), &password) {
+                Ok(_) => {
+                    match exchange.cancel_order(&order_to_cancel, users) {
+                        Ok(_) => println!("Order successfully cancelled."),
+                        Err(e) => eprintln!("{}", e)
+                    }
+                },
+                Err(e) => Users::print_auth_error(e)
+            }
+
         },
         Request::InfoReq(req) => {
             match &req.action[..] {
@@ -218,7 +248,7 @@ pub fn service_request(request: Request, exchange: &mut Exchange, users: &mut Us
                     }
                 },
                 _ => {
-                    println!("I don't know how to handle this information request.");
+                    eprintln!("I don't know how to handle this information request.");
                 }
             }
         },
@@ -229,7 +259,7 @@ pub fn service_request(request: Request, exchange: &mut Exchange, users: &mut Us
                     &exchange.simulate_market(&req, users);
                 },
                 _ => {
-                    println!("I don't know how to handle this Simulation request.");
+                    eprintln!("I don't know how to handle this Simulation request.");
                 }
             }
         },
@@ -244,8 +274,7 @@ pub fn service_request(request: Request, exchange: &mut Exchange, users: &mut Us
                 "show" => {
                     match users.authenticate(&account.username, &account.password) {
                         Ok(_) => {
-                            // TODO: Figure out authentication because this is dumb.
-                            users.print_user(&account.username, &account.password);
+                            users.print_user(&account.username, true);
                         },
                         Err(e) => Users::print_auth_error(e)
                     }


### PR DESCRIPTION
This PR will include user accounts, and will now require every buy or sell request to include `username` and `password` information. This lets us associate an order with a user account, for example, we can store pending and completed orders in a user's account, and we can store a user's `username` as part of each `Order` or `FilledOrder`.

These improvements will lay the groundwork for cancelling orders, and also it's pretty obvious any useful exchange has to know which shares belong to who.