### PR TITLE
Optimize validation of orders.

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -62,11 +62,11 @@ impl UserAccount {
                 for (_, pending) in market.iter() {
                     // If this order will fill a pending order that this account placed:
                     if  (order.action != pending.action) &&
-                        (order.action.as_str() == "buy"  && pending.price <= order.price) ||
-                        (order.action.as_str() == "sell" && order.price <= pending.price)
-                   {
-                       return false;
-                   }
+                        ((order.action.as_str() == "buy"  && pending.price <= order.price) ||
+                        (order.action.as_str() == "sell" && order.price <= pending.price))
+                    {
+                        return false;
+                    }
                 }
             },
             None => ()
@@ -197,8 +197,10 @@ impl Users {
             Ok(account) => {
                 println!("\nAccount information for user: {}", account.username);
                 println!("\n\tOrders Awaiting Execution");
-                for (_, value) in account.pending_orders.iter() {
-                    println!("\t\t{:?}", value);
+                for (_, market) in account.pending_orders.iter() {
+                    for (_, order) in market.iter() {
+                        println!("\t\t{:?}", order);
+                    }
                 }
                 println!("\n\tExecuted Trades");
                 for order in account.executed_trades.iter() {

--- a/src/account.rs
+++ b/src/account.rs
@@ -14,13 +14,21 @@ pub struct UserAccount {
     pub username: String,
     pub password: String,
     pub id: Option<i32>,
-    pub pending_orders: HashMap<i32, Order>,// Orders that have not been completely filled.
-    pub executed_trades: Vec<FilledOrder>   // Trades that have occurred.
+    /* Quick architecture note about pending_orders.
+     * Format: { "symbol" => {"order_id" => Order} }
+     * This means we can find pending orders by first
+     * looking up the symbol, then the order ID.
+     *  - Solves 2 problems at once
+     *      1. Very easy to check if a pending order has been filled.
+     *      2. Fast access to orders in each market (see validate_order function).
+    * */
+    pub pending_orders: HashMap<String, HashMap<i32, Order>>,   // Orders that have not been completely filled.
+    pub executed_trades: Vec<FilledOrder>                       // Trades that have occurred.
 }
 
 impl UserAccount {
     pub fn from(name: &String, password: &String) -> Self {
-        let placed: HashMap<i32, Order> = HashMap::new();
+        let placed: HashMap<String, HashMap<i32, Order>> = HashMap::new();
         let trades: Vec<FilledOrder> = Vec::new();
         UserAccount {
             username: name.to_string().clone(),
@@ -48,16 +56,20 @@ impl UserAccount {
      *  this user. Otherwise, returns false.
      **/
     pub fn validate_order(&self, order: &Order) -> bool {
-        // TODO: Optimize this, maybe change the data structure. (another hashmap)
-        for (_, pending) in self.pending_orders.iter() {
-            // Same market
-            if order.security == pending.security && order.action != pending.action {
-                if (order.action.as_str() == "buy"  && pending.price <= order.price) ||
-                   (order.action.as_str() == "sell" && order.price <= pending.price)
-               {
-                   return false;
-               }
-            }
+        match self.pending_orders.get(&order.security) {
+            // We only care about the market that `order` is being submitted to.
+            Some(market) => {
+                for (_, pending) in market.iter() {
+                    // If this order will fill a pending order that this account placed:
+                    if  (order.action != pending.action) &&
+                        (order.action.as_str() == "buy"  && pending.price <= order.price) ||
+                        (order.action.as_str() == "sell" && order.price <= pending.price)
+                   {
+                       return false;
+                   }
+                }
+            },
+            None => ()
         }
         return true;
     }
@@ -211,6 +223,8 @@ impl Users {
         const BUY: &str = "buy";
         const SELL: &str = "sell";
 
+        let market = account.pending_orders.entry(trades[0].security.clone()).or_insert(HashMap::new());
+
         for trade in trades.iter() {
             let mut id = trade.id;
             let mut update_trade = trade.clone();
@@ -226,13 +240,13 @@ impl Users {
                 }
             }
 
-            match account.pending_orders.get_mut(&id) {
+            // After processing the order, move it to executed trades.
+            match market.get_mut(&id) {
                 Some(order) => {
                     if trade.exchanged == (order.quantity - order.filled) {
-                        // order completely filled
-                        entries_to_remove.push(order.order_id);
+                        entries_to_remove.push(order.order_id); // order completely filled
                     } else {
-                        order.filled += trade.exchanged;
+                        order.filled += trade.exchanged; // order partially filled
                     }
                     account.executed_trades.push(update_trade);
                 },
@@ -242,9 +256,9 @@ impl Users {
             }
         }
 
-        // Remove all elements from account's hashmap that need to be removed.
+        // Remove any completed orders from the accounts pending orders.
         for i in &entries_to_remove {
-            account.pending_orders.remove(&i);
+            market.remove(&i);
         }
     }
 

--- a/src/account.rs
+++ b/src/account.rs
@@ -61,7 +61,7 @@ impl UserAccount {
             Some(market) => {
                 for (_, pending) in market.iter() {
                     // If this order will fill a pending order that this account placed:
-                    if  (order.action != pending.action) &&
+                    if  (order.action.ne(&pending.action)) &&
                         ((order.action.as_str() == "buy"  && pending.price <= order.price) ||
                         (order.action.as_str() == "sell" && order.price <= pending.price))
                     {
@@ -291,5 +291,11 @@ impl Users {
         }
         // Case 2: update account who placed order that filled others.
         self.update_single_user(&trades[0].filler_name, &trades, true);
+    }
+
+    pub fn print_all(&self) {
+        for (k, v) in self.users.iter() {
+            self.print_user(&k, &v.password);
+        }
     }
 }

--- a/src/exchange/requests.rs
+++ b/src/exchange/requests.rs
@@ -87,16 +87,18 @@ impl InfoRequest {
 // Allows us to perform simulations on our market
 pub struct Simulation {
     pub action: String,
-    pub symbol: String,
+    pub trader_count: u32,
+    pub market_count: u32,
     pub duration: u32
 }
 
 impl Simulation {
-    pub fn from(action: String, symbol: String, duration: u32) -> Self {
+    pub fn from(action: String, trader_count: u32, market_count: u32, duration: u32) -> Self {
         Simulation {
             action,
-            symbol,
-            duration
+            trader_count,   // number of traders
+            market_count,   // number of markets to trade in
+            duration        // number of trades to make
         }
     }
 }


### PR DESCRIPTION
Before letting a user submit an order to a market, we have to ensure they won't fill one of their own orders. We do this by checking every pending order that user has placed in that market.

There are some unfortunate downsides to the approach I took in this PR, for example: If a user places a large number of individual orders in *one* market, every subsequent order they place in that market will have to do a large number of comparisons, at least until their pending orders count decreases in that market.

That being said, I suspect that this specific scenario is extremely rare, and in fact would likely never happen in practice. Why would you place 15,000 orders for 1 share of a stock when you could place 1 order for 15,000 shares?

With that in mind, I decided order validation (of the type described above) is less important than, say, updating pending/executed orders in users accounts; another operation that benefits from the current data structure in `UserAccount.pending_orders`