### PR TITLE
Cancel orders that have been placed in a market

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -40,7 +40,7 @@ impl UserAccount {
     }
 
     // Sets this account's user id, and returns it.
-    pub fn set_id(&mut self, users: &Users) -> i32 {
+    fn set_id(&mut self, users: &Users) -> i32 {
         self.id = Some(users.total + 1);
         return self.id.unwrap();
     }

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -78,6 +78,16 @@ impl Exchange {
             new_price = Some(price);
             stats.update_price(price);
             stats.update_filled_orders(&filled_orders);
+            /* TODO: Updating accounts seems like something that
+             *       shouldn't slow down order execution.
+             *
+             * Market state doesn't depend on users view of the market.
+             * This function is also computationally expensive, I think
+             * the better route is to compute this in a separate thread,
+             * and somehow force sequential access of users accounts
+             * (think mutex locks, and maybe write filled orders to a buffer
+             * in the mean time?)
+             */
             users.update_account_orders(&filled_orders);
             self.extend_past_orders(&mut filled_orders);
         };

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -237,6 +237,7 @@ impl Exchange {
                 // buy is a max heap, sell is a min heap.
                 let mut buy_heap: BinaryHeap<Order> = BinaryHeap::new();
                 let mut sell_heap: BinaryHeap<Reverse<Order>> = BinaryHeap::new();
+
                 // Store order on market, and in users account.
                 match &order.action[..] {
                     "buy" => {
@@ -287,7 +288,6 @@ impl Exchange {
                             let new_size = market.buy_orders.len() - 1;
                             let mut temp = BinaryHeap::with_capacity(new_size);
                             for order in market.buy_orders.drain().filter(|order| order.order_id != order_to_cancel.order_id) {
-                                // temp.push(order.clone()); // Worst case is < O(n) since we preallocate
                                 temp.push(order); // Worst case is < O(n) since we preallocate
                             }
                             market.buy_orders.append(&mut temp);
@@ -298,7 +298,6 @@ impl Exchange {
                             let new_size = market.sell_orders.len() - 1;
                             let mut temp = BinaryHeap::with_capacity(new_size);
                             for order in market.sell_orders.drain().filter(|order| order.0.order_id != order_to_cancel.order_id) {
-                                // temp.push(order.clone()); // Worst case is < O(n) since we preallocate
                                 temp.push(order); // Worst case is < O(n) since we preallocate
                             }
                             market.sell_orders.append(&mut temp);
@@ -320,7 +319,6 @@ impl Exchange {
                 }
             } else {
                 return Err("The order requested to be cancelled was not found in the associated user's pending orders!".to_string());
-                // return Err("The order that was requested to be cancelled was not placed by the account that made the request!".to_string());
             }
         }
         panic!("Could not find the user while cancelling an order.\
@@ -404,6 +402,7 @@ impl Exchange {
                 }
             }
         }
+
         // If you want prints of each users account, uncomment this.
         // users.print_all();
     }

--- a/src/exchange/requests.rs
+++ b/src/exchange/requests.rs
@@ -103,8 +103,15 @@ impl Simulation {
     }
 }
 
+pub struct CancelOrder {
+    pub symbol: String,
+    pub order_id: i32,
+    pub username: String,
+}
+
 pub enum Request {
     OrderReq(Order, String, String),// first string is username, second password
+    CancelReq(CancelOrder, String), // string is password
     InfoReq(InfoRequest),
     SimReq(Simulation),
     UserReq(UserAccount, String)    // Account followed by action

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,8 +1,44 @@
 pub use crate::exchange::{self, Exchange, Market, Order, InfoRequest, Simulation, Request, PriceError};
 pub use crate::print_instructions;
 
-// pub mod account;
 use crate::account::{UserAccount, Users};
+
+// IO stuff
+use std::io::BufReader;
+use std::env;
+use std::fs::File;
+
+pub struct Argument<R> {
+    pub interactive: bool,                      // false means read from file, true means interactive mode
+    pub reader: Option<std::io::BufReader<R>>   // The buffer we read from
+}
+
+// Parses the command line arguments.
+// Returns an argument struct on success, or an error string.
+pub fn command_args(mut args: env::Args) -> Result<Argument<std::fs::File>, String> {
+    args.next(); // skip the first argument since it's the program name
+
+    // Default argument
+    let mut argument = Argument {
+        interactive: true,
+        reader: None
+    };
+
+    // Modify the argument depending on user input.
+    match args.next() {
+        Some(filename) => {
+            let file = match File::open(filename) {
+                Ok(f) => f,
+                // TODO: pass the error up call stack?
+                Err(_) => return Err("Failed to open the file!".to_string())
+            };
+            argument.interactive = false;
+            argument.reader = Some(BufReader::new(file));
+        }
+        None => ()
+    }
+    return Ok(argument);
+}
 
 /* Prints some helpful information to the console when input is malformed. */
 fn malformed_req(req: &str, req_type: &str) {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,4 @@
-pub use crate::exchange::{self, Exchange, Market, Order, InfoRequest, Simulation, Request, PriceError};
+pub use crate::exchange::{self, Exchange, Market, Order, InfoRequest, Simulation, CancelOrder, Request, PriceError};
 pub use crate::print_instructions;
 
 use crate::account::{UserAccount, Users};
@@ -42,12 +42,13 @@ pub fn command_args(mut args: env::Args) -> Result<Argument<std::fs::File>, Stri
 
 /* Prints some helpful information to the console when input is malformed. */
 fn malformed_req(req: &str, req_type: &str) {
-    println!("\nMalformed \"{}\" request!", req);
+    eprintln!("\nMalformed \"{}\" request!", req);
     match req_type {
-       "account" => println!("Hint - format should be: {} create/show username password", req),
-       "order"  => println!("Hint - format should be: {} symbol quantity price username password", req),
-       "info"   => println!("Hint - format should be: {} symbol", req),
-       "sim"    => println!("Hint - format should be: {} trader_count market_count duration", req),
+       "account" => eprintln!("Hint - format should be: {} create/show username password", req),
+       "order"  => eprintln!("Hint - format should be: {} symbol quantity price username password", req),
+       "cancel"  => eprintln!("Hint - format should be: {} symbol order_id username password", req),
+       "info"   => eprintln!("Hint - format should be: {} symbol", req),
+       "sim"    => eprintln!("Hint - format should be: {} trader_count market_count duration", req),
        _        => ()
     }
 }
@@ -99,8 +100,8 @@ pub fn tokenize_input(text: String) -> Result<Request, ()> {
                                              &words[4].to_string()
                                             );
                     if order.quantity <= 0 || order.price <= 0.0 {
-                        println!("Malformed \"{}\" request!", words[0]);
-                        println!("Make sure the quantity and price are greater than 0!");
+                        eprintln!("Malformed \"{}\" request!", words[0]);
+                        eprintln!("Make sure the quantity and price are greater than 0!");
                         return Err(());
                     }
                     return Ok(Request::OrderReq(order, words[4].to_string(), words[5].to_string()));
@@ -111,6 +112,23 @@ pub fn tokenize_input(text: String) -> Result<Request, ()> {
                 }
             }
         },
+        "cancel" => {
+            match words.len() {
+                5 => {
+                    let req = CancelOrder {
+                        symbol: words[1].to_string().to_uppercase(),
+                        order_id: words[2].to_string().trim().parse::<i32>().expect("Please enter an integer order id"), // TODO we don't need to panic here.
+                        username: words[3].to_string()
+                    };
+
+                    return Ok(Request::CancelReq(req, words[4].to_string()));
+                },
+                _ => {
+                    malformed_req(&words[0], &words[0]);
+                    return Err(());
+                }
+            }
+        }
         // request price info, current market info, or past market info
         "price" | "show" | "history" =>  {
             match words.len() {
@@ -153,7 +171,7 @@ pub fn tokenize_input(text: String) -> Result<Request, ()> {
         },
         // Unknown input
         _ => {
-            println!("I don't understand the action type \'{}\'.", words[0]);
+            eprintln!("I don't understand the action type \'{}\'.", words[0]);
             return Err(());
         }
     }
@@ -172,15 +190,27 @@ pub fn service_request(request: Request, exchange: &mut Exchange, users: &mut Us
                                 &exchange.submit_order_to_market(users, order.clone(), &username, true);
                                 &exchange.show_market(&order.security);
                             } else {
-                                println!("Order could not be placed. This order would fill one of your currently pending orders!");
+                                eprintln!("Order could not be placed. This order would fill one of your currently pending orders!");
                             }
                         },
                         Err(e) => Users::print_auth_error(e)
                     }
                 },
                 // Handle unknown action!
-                _ => println!("Sorry, I do not know how to perform {:?}", order)
+                _ => eprintln!("Sorry, I do not know how to perform {:?}", order)
             }
+        },
+        Request::CancelReq(order_to_cancel, password) => {
+            match users.authenticate(&(order_to_cancel.username), &password) {
+                Ok(_) => {
+                    match exchange.cancel_order(&order_to_cancel, users) {
+                        Ok(_) => println!("Order successfully cancelled."),
+                        Err(e) => eprintln!("{}", e)
+                    }
+                },
+                Err(e) => Users::print_auth_error(e)
+            }
+
         },
         Request::InfoReq(req) => {
             match &req.action[..] {
@@ -218,7 +248,7 @@ pub fn service_request(request: Request, exchange: &mut Exchange, users: &mut Us
                     }
                 },
                 _ => {
-                    println!("I don't know how to handle this information request.");
+                    eprintln!("I don't know how to handle this information request.");
                 }
             }
         },
@@ -229,7 +259,7 @@ pub fn service_request(request: Request, exchange: &mut Exchange, users: &mut Us
                     &exchange.simulate_market(&req, users);
                 },
                 _ => {
-                    println!("I don't know how to handle this Simulation request.");
+                    eprintln!("I don't know how to handle this Simulation request.");
                 }
             }
         },
@@ -244,8 +274,7 @@ pub fn service_request(request: Request, exchange: &mut Exchange, users: &mut Us
                 "show" => {
                     match users.authenticate(&account.username, &account.password) {
                         Ok(_) => {
-                            // TODO: Figure out authentication because this is dumb.
-                            users.print_user(&account.username, &account.password);
+                            users.print_user(&account.username, true);
                         },
                         Err(e) => Users::print_auth_error(e)
                     }


### PR DESCRIPTION
Now that we have user accounts, and orders linked to accounts, we have the necessary information to cancel orders that have been placed on the market.

This should be implemented as an order request, not an account request, since we're removing an order from a market (primarily) and an account as a consequence of that, rather than the other way around. To be clear, either way works, but it seems more clear if handled in this way.