### PR TITLE
Store userIDs instead of usernames in orders and trades

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -2,7 +2,7 @@ CREATE TABLE Account (
     ID              int,
     username        varchar(15) NOT NULL,
     password        varchar(20) NOT NULL,
-    registerTime    date,
+    register_time   date,
     PRIMARY KEY(ID)
 );
 
@@ -26,6 +26,7 @@ CREATE TABLE Orders (
 
 CREATE TABLE PendingOrders (
     order_ID        int,
+    PRIMARY KEY(order_ID),
     /* CONSTRAINT fk_order */
         FOREIGN KEY(order_ID)
             REFERENCES Orders(order_ID)
@@ -41,6 +42,9 @@ CREATE TABLE ExecutedTrades (
     filler_UID      int,
     exchanged       int,
     execution_time  date,
+    -- Will never have 2+ trades with the same
+    -- (filled, filler) order id pair
+    PRIMARY KEY(filled_OID, filler_OID),
     /* CONSTRAINT fk_Order_filled */
         FOREIGN KEY(filled_OID)
             REFERENCES Orders(order_ID),

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,67 @@
+CREATE TABLE Account (
+    ID              int,
+    username        varchar(15) NOT NULL,
+    password        varchar(20) NOT NULL,
+    registerTime    date,
+    PRIMARY KEY(ID)
+);
+
+CREATE TABLE Orders (
+    order_ID        int,
+    symbol          varchar(4) NOT NULL,
+    action          varchar(4) NOT NULL,
+    quantity        int,
+    filled          int,
+    price           float8,
+    user_ID         int,
+    status          varchar(8) NOT NULL,
+    time_placed     date,
+    time_updated    date,
+    PRIMARY KEY(order_ID),
+    /* CONSTRAINT fk_account */
+        FOREIGN KEY(user_ID)
+            REFERENCES Account(ID)
+);
+
+
+CREATE TABLE PendingOrders (
+    order_ID        int,
+    /* CONSTRAINT fk_order */
+        FOREIGN KEY(order_ID)
+            REFERENCES Orders(order_ID)
+);
+
+CREATE TABLE ExecutedTrades (
+    symbol          varchar(4) NOT NULL,
+    action          varchar(4) NOT NULL,
+    price           float8,
+    filled_OID      int,
+    filled_UID      int,
+    filler_OID      int,
+    filler_UID      int,
+    exchanged       int,
+    execution_time  date,
+    /* CONSTRAINT fk_Order_filled */
+        FOREIGN KEY(filled_OID)
+            REFERENCES Orders(order_ID),
+    /* CONSTRAINT fk_Order_filler */
+        FOREIGN KEY(filler_OID)
+            REFERENCES Orders(order_ID),
+    /* CONSTRAINT fk_Account_filled */
+        FOREIGN KEY(filled_UID)
+            REFERENCES Account(ID),
+    /* CONSTRAINT fk_Account_filler */
+        FOREIGN KEY(filler_UID)
+            REFERENCES Account(ID)
+);
+
+CREATE TABLE Markets (
+    symbol          varchar(4) NOT NULL,
+    name            varchar(80) NOT NULL,
+    total_buys      int,
+    total_sells     int,
+    filled_buys     int,
+    filled_sells    int,
+    latest_price    float8,
+    PRIMARY KEY(symbol)
+);

--- a/src/account.rs
+++ b/src/account.rs
@@ -294,7 +294,9 @@ impl Users {
                 Some(order) => {
                     if trade.exchanged == (order.quantity - order.filled) {
                         entries_to_remove.push(order.order_id); // order completely filled
-                    } else {
+                    } else if !is_filler{
+                        // Don't update the filler's filled count,
+                        // new orders are added to accounts in submit_order_to_market.
                         order.filled += trade.exchanged; // order partially filled
                     }
                     account.executed_trades.push(update_trade);
@@ -325,7 +327,7 @@ impl Users {
 
         // Fill update_map
         for trade in trades.iter() {
-            let entry = update_map.entry(trade.user_id.clone()).or_insert(Vec::with_capacity(trades.len()));
+            let entry = update_map.entry(trade.user_id).or_insert(Vec::with_capacity(trades.len()));
             entry.push(trade.clone());
         }
 

--- a/src/account.rs
+++ b/src/account.rs
@@ -120,6 +120,7 @@ impl UserAccount {
 // ------------------------------------------------------------------------------------------------------
 pub struct Users {
     users: HashMap<String, UserAccount>,
+    // TODO: This should be an LRU cache eventually
     id_map: HashMap<i32, String>,   // maps user_id to username
     total: i32
 }
@@ -128,6 +129,7 @@ impl Users {
 
     pub fn new() -> Self {
         let map: HashMap<String, UserAccount> = HashMap::new();
+        // TODO: Eventually we want to do with capacity
         let id_map: HashMap<i32, String> = HashMap::new();
         Users {
             users: map,
@@ -253,8 +255,13 @@ impl Users {
     /* Update this users pending_orders and executed_trades.
      * We have 2 cases to consider, as explained in update_account_orders().
      **/
-    // fn update_single_user(&mut self, username: &String, trades: &Vec<FilledOrder>, is_filler: bool) {
     fn update_single_user(&mut self, id: i32, trades: &Vec<FilledOrder>, is_filler: bool) {
+        // TODO:
+        //  At some point, we want to get the username by calling some helper access function.
+        //  This new function will
+        //      1. Check the id_map cache
+        //      2. If ID not found, check the database
+        //      3. Update the id_map cache (LRU)
         let username: String = self.id_map.get(&id).expect("update_single_user Error couldn't get username from userID").clone();
         let account = self._get_mut(&username).expect("update_single_user ERROR: couldn't find user!");
         // Since we can't remove entries while iterating, store the key's here.
@@ -325,11 +332,9 @@ impl Users {
         // Case 1
         // TODO: This is a good candidate for multithreading.
         for (user_id, new_trades) in update_map.iter() {
-            // self.update_single_user(&user, new_trades, false);
             self.update_single_user(*user_id, new_trades, false);
         }
         // Case 2: update account who placed order that filled others.
-        // self.update_single_user(&trades[0].filler_name, &trades, true);
         self.update_single_user(trades[0].filler_id, &trades, true);
     }
 

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -394,9 +394,13 @@ impl Exchange {
             let shares:i32 = random!(2..=13); // TODO: get random number of shares
 
             // Create the order and send it to the market
-            let order = Order::from(action.to_string(), symbol.to_string().clone(), shares, new_price, username);
+            // let order = Order::from(action.to_string(), symbol.to_string().clone(), shares, new_price, username);
 
             if let Ok(account) =  users.authenticate(username, &"password".to_string()) {
+
+                // Create the order and send it to the market
+                let order = Order::from(action.to_string(), symbol.to_string().clone(), shares, new_price, account.id);
+
                 if account.validate_order(&order) {
                     self.submit_order_to_market(users, order, username, true);
                 }

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -393,14 +393,9 @@ impl Exchange {
             // Choose the number of shares
             let shares:i32 = random!(2..=13); // TODO: get random number of shares
 
-            // Create the order and send it to the market
-            // let order = Order::from(action.to_string(), symbol.to_string().clone(), shares, new_price, username);
-
             if let Ok(account) =  users.authenticate(username, &"password".to_string()) {
-
                 // Create the order and send it to the market
                 let order = Order::from(action.to_string(), symbol.to_string().clone(), shares, new_price, account.id);
-
                 if account.validate_order(&order) {
                     self.submit_order_to_market(users, order, username, true);
                 }

--- a/src/exchange/filled.rs
+++ b/src/exchange/filled.rs
@@ -1,40 +1,39 @@
 use crate::exchange::Order;
 
+/*
+ * TODO: Perhaps a more fitting name is "Trade".
+ *       FilledOrder might imply the entire order is filled.
+ *       Trade indicates that it might be *partially* filled.
+ **/
 #[derive(Debug)]
 pub struct FilledOrder {
     pub action: String,
     pub security: String,
-    pub price: f64,         // price at which this order was filled
-    pub id: i32,            // this order's ID
-    // pub username: String,
-    pub user_id: i32,
-    pub filled_by: i32,     // the order ID that filled this order
-    // pub filler_name: String,
-    pub filler_id: i32,
+    pub price: f64,         // price at which this trade was occured
+    pub id: i32,            // ID of order getting filled
+    pub user_id: i32,       // ID of user who placed the order that is being filled
+    pub filled_by: i32,     // ID of new order that triggered the trade
+    pub filler_id: i32,     // ID of user who placed new order that triggered the trade
     pub exchanged: i32      // the amount of shares exchanged
 }
 
 impl FilledOrder {
-    // fn from(action: &String, security: &String, price: f64, id: i32, username: &String, filled_by: i32, filler_name: &String, exchanged: i32) -> Self {
     fn from(action: &String, security: &String, price: f64, id: i32, user_id: i32, filled_by: i32, filler_id: i32, exchanged: i32) -> Self {
         FilledOrder {
             action: action.clone(),
             security: security.clone(),
             price,
             id,
-            // username: username.clone(),
             user_id,
             filled_by,
-            // filler_name: filler_name.clone(),
             filler_id,
             exchanged
         }
     }
 
-    // Create a FilledOrder from a pair of orders.
-    pub fn order_to_filled_order(old: &Order, filler: &Order, exchanged: i32) -> Self {
-        // FilledOrder::from(&old.action, &old.security, old.price, old.order_id, &old.username, filler.order_id, &filler.username, exchanged)
-        FilledOrder::from(&old.action, &old.security, old.price, old.order_id, old.user_id.unwrap(), filler.order_id, filler.user_id.unwrap(), exchanged)
+    // Create a FilledOrder from a pair of Orders.
+    pub fn order_to_filled_order(pending: &Order, filler: &Order, exchanged: i32) -> Self {
+        FilledOrder::from(&pending.action, &pending.security, pending.price, pending.order_id, pending.user_id.unwrap(), filler.order_id, filler.user_id.unwrap(), exchanged)
     }
 }
 
@@ -43,8 +42,6 @@ impl Clone for FilledOrder {
         FilledOrder {
             action: self.action.clone(),
             security: self.security.clone(),
-            // username: self.username.clone(),
-            // filler_name: self.filler_name.clone(),
             ..*self
         }
     }

--- a/src/exchange/filled.rs
+++ b/src/exchange/filled.rs
@@ -6,29 +6,35 @@ pub struct FilledOrder {
     pub security: String,
     pub price: f64,         // price at which this order was filled
     pub id: i32,            // this order's ID
-    pub username: String,
+    // pub username: String,
+    pub user_id: i32,
     pub filled_by: i32,     // the order ID that filled this order
-    pub filler_name: String,
+    // pub filler_name: String,
+    pub filler_id: i32,
     pub exchanged: i32      // the amount of shares exchanged
 }
 
 impl FilledOrder {
-    fn from(action: &String, security: &String, price: f64, id: i32, username: &String, filled_by: i32, filler_name: &String, exchanged: i32) -> Self {
+    // fn from(action: &String, security: &String, price: f64, id: i32, username: &String, filled_by: i32, filler_name: &String, exchanged: i32) -> Self {
+    fn from(action: &String, security: &String, price: f64, id: i32, user_id: i32, filled_by: i32, filler_id: i32, exchanged: i32) -> Self {
         FilledOrder {
             action: action.clone(),
             security: security.clone(),
             price,
             id,
-            username: username.clone(),
+            // username: username.clone(),
+            user_id,
             filled_by,
-            filler_name: filler_name.clone(),
+            // filler_name: filler_name.clone(),
+            filler_id,
             exchanged
         }
     }
 
     // Create a FilledOrder from a pair of orders.
     pub fn order_to_filled_order(old: &Order, filler: &Order, exchanged: i32) -> Self {
-        FilledOrder::from(&old.action, &old.security, old.price, old.order_id, &old.username, filler.order_id, &filler.username, exchanged)
+        // FilledOrder::from(&old.action, &old.security, old.price, old.order_id, &old.username, filler.order_id, &filler.username, exchanged)
+        FilledOrder::from(&old.action, &old.security, old.price, old.order_id, old.user_id.unwrap(), filler.order_id, filler.user_id.unwrap(), exchanged)
     }
 }
 
@@ -37,8 +43,8 @@ impl Clone for FilledOrder {
         FilledOrder {
             action: self.action.clone(),
             security: self.security.clone(),
-            username: self.username.clone(),
-            filler_name: self.filler_name.clone(),
+            // username: self.username.clone(),
+            // filler_name: self.filler_name.clone(),
             ..*self
         }
     }

--- a/src/exchange/requests.rs
+++ b/src/exchange/requests.rs
@@ -9,11 +9,13 @@ pub struct Order {
     pub filled: i32,        // Quantity filled so far
     pub price: f64,
     pub order_id: i32,
-    pub username: String    // username of user who placed order.
+    // pub username: String    // username of user who placed order.
+    pub user_id: Option<i32>    // user ID of user who placed order.
 }
 
 impl Order {
-    pub fn from(action: String, security: String, quantity: i32, price: f64, name: &String) -> Order {
+    // pub fn from(action: String, security: String, quantity: i32, price: f64, name: &String) -> Order {
+    pub fn from(action: String, security: String, quantity: i32, price: f64, user_id: Option<i32>) -> Order {
         // Truncate price to 2 decimal places
         let price = f64::trunc(price  * 100.0) / 100.0;
 
@@ -24,7 +26,8 @@ impl Order {
             filled: 0,
             price,
             order_id: 0, // Updated later.
-            username: name.to_string().clone()
+            // username: name.to_string().clone()
+            user_id
         }
     }
 }
@@ -34,7 +37,7 @@ impl Clone for Order {
         Order {
             action: self.action.clone(),
             security: self.security.clone(),
-            username: self.username.clone(),
+            // username: self.username.clone(),
             ..*self
         }
     }

--- a/src/exchange/requests.rs
+++ b/src/exchange/requests.rs
@@ -9,12 +9,10 @@ pub struct Order {
     pub filled: i32,        // Quantity filled so far
     pub price: f64,
     pub order_id: i32,
-    // pub username: String    // username of user who placed order.
-    pub user_id: Option<i32>    // user ID of user who placed order.
+    pub user_id: Option<i32>// user ID of user who placed order, starts as None during tokenization.
 }
 
 impl Order {
-    // pub fn from(action: String, security: String, quantity: i32, price: f64, name: &String) -> Order {
     pub fn from(action: String, security: String, quantity: i32, price: f64, user_id: Option<i32>) -> Order {
         // Truncate price to 2 decimal places
         let price = f64::trunc(price  * 100.0) / 100.0;
@@ -26,7 +24,6 @@ impl Order {
             filled: 0,
             price,
             order_id: 0, // Updated later.
-            // username: name.to_string().clone()
             user_id
         }
     }
@@ -37,7 +34,6 @@ impl Clone for Order {
         Order {
             action: self.action.clone(),
             security: self.security.clone(),
-            // username: self.username.clone(),
             ..*self
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -89,16 +89,13 @@ pub fn tokenize_input(text: String) -> Result<Request, ()> {
         // Order
         "buy" | "sell" => {
             if let 6 = words.len() {
+                // Note that we do not provide an order ID (arg 4 is None).
+                // This value actually gets set later.
                 let order = Order::from( words[0].to_string(),
                                          words[1].to_string().to_uppercase(),
-                                         words[2].to_string().trim().parse::<i32>().expect("Please enter an integer number of shares!"),
-                                         words[3].to_string().trim().parse::<f64>().expect("Please enter a floating point price!"),
+                                         words[2].to_string().trim().parse::<i32>().expect("Please enter an integer number of shares!"),// TODO we shouldn't panic here
+                                         words[3].to_string().trim().parse::<f64>().expect("Please enter a floating point price!"),     // TODO we shouldn't panic here
                                          None
-                                         // &words[4].to_string()
-                                         // TODO: problem, we don't necessarily want to
-                                         // authenticate while we tokenize the input, since that's
-                                         // should be handled later. How can we push the auth to
-                                         // later?
                                         );
                 if order.quantity <= 0 || order.price <= 0.0 {
                     eprintln!("Malformed \"{}\" request!", words[0]);
@@ -115,7 +112,7 @@ pub fn tokenize_input(text: String) -> Result<Request, ()> {
             if let 5 = words.len() {
                 let req = CancelOrder {
                     symbol: words[1].to_string().to_uppercase(),
-                    order_id: words[2].to_string().trim().parse::<i32>().expect("Please enter an integer order id"), // TODO we don't need to panic here.
+                    order_id: words[2].to_string().trim().parse::<i32>().expect("Please enter an integer order id"), // TODO we shouldn't panic here.
                     username: words[3].to_string()
                 };
 
@@ -138,6 +135,7 @@ pub fn tokenize_input(text: String) -> Result<Request, ()> {
         // Simulate a market for n time steps
         "simulate" => {
             if let 4 = words.len() {
+                // TODO: We shouldn't panic here, just write to stderr...
                 let req: Simulation = Simulation::from( words[0].to_string(),
                                                         words[1].to_string().trim().parse::<u32>().expect("Please enter an integer number of traders!"),
                                                         words[2].to_string().trim().parse::<u32>().expect("Please enter an integer number of markets!"),


### PR DESCRIPTION
This has the immediate benefit of storing less, and simpler, data (strict 4 byte ints vs. n byte long Strings). Additionally, we probably want userID as the primary key in any database tables, especially considering the fact that we will be splitting tables up into at least 2NF.

The only issue so far is that prior to this PR, all users in the programs memory were stored in a hashmap of (username, account) pairs, which meant we couldn't get a users account if we only had the userID. I have fixed this by maintaining a map of (userID, username) pairs. Once we have a database connection, it may be prudent to use this as a type of cache, where we can do LRU or some other eviction policy.