### PR TITLE
PER-4 Use order status enum instead of relying on quantity - filled for status.

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -1,4 +1,4 @@
-use crate::exchange::requests::Order;
+use crate::exchange::requests::{Order, OrderStatus};
 use crate::exchange::filled::Trade;
 
 use std::collections::HashMap;
@@ -451,11 +451,19 @@ Be sure to call authenticate() before trying to get a reference to a user!")
                 Some(order) => {
                     // order completely filled
                     if trade.exchanged == (order.quantity - order.filled) {
+                        // TODO: PER-5
+                        //  This order is being removed from the account,
+                        //  so we should update it in the DIFF buffer (hashmap).
+                        //  Specifically, we should set its filled to quantity, and status to
+                        //  pending.
+                        order.status = OrderStatus::COMPLETE; // TODO this will go into buffer to DB
                         entries_to_remove.push(order.order_id);
                     } else if !is_filler {
                         // Don't update the filler's filled count,
                         // new orders are added to accounts in submit_order_to_market.
 
+                        // TODO: PER-5
+                        //  This order is being updated, we should update the buffer (hashmap) also!
                         order.filled += trade.exchanged;
                         // Extend the vector of orders we will update
                         update_partial_filled_vec.push((order.filled, order.order_id));
@@ -474,10 +482,15 @@ Be sure to call authenticate() before trying to get a reference to a user!")
         //      - If we can perform both these updates in parallel, i.e execute the functions in
         //        separate threads, on different DB connections, that might be a good idea!
 
+        // TODO - PER-5
+        //  We don't want to perform this pending delete, or parital update anymore.
+        //  Instead, we will just perform the updates according to what is in the DIFF buffer.
+        //  That is, we want to write to the DIFF buffers instead.
+
         // Remove all the completed orders from the database's pending table
         // and update Orders table.
         if entries_to_remove.len() > 0 {
-            database::write_delete_pending_orders(&entries_to_remove, conn, "COMPLETE");
+            database::write_delete_pending_orders(&entries_to_remove, conn, OrderStatus::COMPLETE);
         }
 
         // For each trade that partially filled an order, update `filled` in Orders table.
@@ -512,6 +525,10 @@ Be sure to call authenticate() before trying to get a reference to a user!")
         // Case 2: update account who placed order that filled others.
         self.update_single_user(trades[0].filler_uid, &trades, true, conn);
 
+        // TODO: PER-5
+        //  Instead of writing this trade insert here, we should be writing to a buffer of trades
+        //  which will be emptied occasionally when full.
+        //
         // For each trade, insert into ExecutedTrades table.
         database::write_insert_trades(&trades, conn);
     }

--- a/src/exchange/requests.rs
+++ b/src/exchange/requests.rs
@@ -1,5 +1,14 @@
 use std::cmp::Ordering;
 use crate::account::UserAccount;
+
+// The status of an order, each is 1 byte (u8)
+#[derive(Copy, Clone, Debug)]
+pub enum OrderStatus {
+    PENDING,
+    COMPLETE,
+    CANCELLED
+}
+
 // An order type for a security
 #[derive(Debug)]
 pub struct Order {
@@ -9,12 +18,13 @@ pub struct Order {
     pub filled: i32,        // Quantity filled so far
     pub price: f64,
     pub order_id: i32,
+    pub status: OrderStatus,
     pub user_id: Option<i32>// user ID of user who placed order, starts as None during tokenization.
 }
 
 impl Order {
     // Used when reading a user from the frontend
-    pub fn from(action: String, symbol: String, quantity: i32, price: f64, user_id: Option<i32>) -> Self {
+    pub fn from(action: String, symbol: String, quantity: i32, price: f64, status: OrderStatus, user_id: Option<i32>) -> Self {
         // Truncate price to 2 decimal places
         let price = f64::trunc(price  * 100.0) / 100.0;
 
@@ -25,12 +35,13 @@ impl Order {
             filled: 0,
             price,
             order_id: 0, // Updated later.
+            status,
             user_id
         }
     }
 
     // Used when reading an existing user from the database
-    pub fn direct(action: &str, symbol: &str, quantity: i32, filled: i32, price: f64, order_id: i32, user_id: i32) -> Self {
+    pub fn direct(action: &str, symbol: &str, quantity: i32, filled: i32, price: f64, order_id: i32, status: OrderStatus, user_id: i32) -> Self {
         // Truncate price to 2 decimal places
         let price = f64::trunc(price  * 100.0) / 100.0;
 
@@ -42,6 +53,7 @@ impl Order {
             filled,
             price,
             order_id,
+            status,
             user_id: Some(user_id)
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,4 @@
-pub use crate::exchange::{self, Exchange, Market, Order, InfoRequest, Simulation, CancelOrder, Request, PriceError};
+pub use crate::exchange::{self, Exchange, Market, Order, InfoRequest, Simulation, CancelOrder, Request, PriceError, OrderStatus};
 pub use crate::print_instructions;
 use postgres::Client;
 use crate::database;
@@ -98,8 +98,9 @@ pub fn tokenize_input(text: String) -> Result<Request, ()> {
                                          words[1].to_string().to_uppercase(),
                                          words[2].to_string().trim().parse::<i32>().expect("Please enter an integer number of shares!"),// TODO we shouldn't panic here
                                          words[3].to_string().trim().parse::<f64>().expect("Please enter a floating point price!"),     // TODO we shouldn't panic here
+                                         OrderStatus::PENDING,
                                          None
-                                        );
+                                       );
                 if order.quantity <= 0 || order.price <= 0.0 {
                     eprintln!("Malformed \"{}\" request!", words[0]);
                     eprintln!("Make sure the quantity and price are greater than 0!");


### PR DESCRIPTION
This isn't strictly necessary considering how the program currently works, since we don't hold on to **complete**/**cancelled** orders. However, in *PER-5* I plan on writing state changes to buffers, and it'll be easier and more space efficient to store modified state using status enums (1 byte) rather than the quantity field (4 bytes).