### PR TITLE
PER-5 Write changes to an in-mem buffer to decrease DB op frequency.

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,0 +1,57 @@
+// TODO: We want several data structures, maybe inside one "Buffer" struct
+//       where we can store:
+//       1. Orders as follows
+//           {
+//             action: Option<String>,
+//             symbol: Option<String>,
+//             quantity: Option<i32>,
+//             filled: Option<i32>,
+//             price: Option<f64>,
+//             order_id: Option<i32>,
+//             status: Option<OrderStatus>,
+//             user_id: Option<i32>
+//           }
+//
+//          By storing orders in this way, we can represent a NEW order (i.e one the database has
+//          never seen) by having some fields like action or symbol be Some(string). Meanwhile, an
+//          old order would have action, symbol, quantity, price, order_id, user_id all set to None
+//          in our Buffer structure, since the database knows the values already and they do not
+//          change.
+//
+//          Therefore, orders the DB knows about will be stored in the buffer as:
+//           {
+//             action: None,
+//             symbol: None,
+//             quantity: None,
+//             filled: Option<i32>, // Some(i32) if update occured, else None
+//             price: None,
+//             order_id: None,
+//             status: Option<OrderStatus>, // Some(OrderStatus) if update occured, else None
+//             user_id: None
+//           }
+//          This makes it easy for us to determine
+//          a. If we need to to an insert (new order) or update (old order).
+//          b. Which fields need to be updated for an old order.
+//          c. We can differentiate between a complete order, a cancelled order, and a pending
+//          order.
+//
+//      2. Trades can just be stored in a vector. They are always new and unique!
+//      3. New accounts can probably still be inserted immediately
+//      4. The "exchangeStats", i.e max order ID, can just be read straight from the exchange
+//
+//
+//  Ideally, we will spin up some thread whenever we want to perform DB writes so this doesn't
+//  affect program operation. This means we want to move the buffers to the other thread,
+//  essentially draining them in the main thread (not deallocating!).
+//
+//  Somehow, we should run this all in a loop, i.e every n seconds, write the buffer to the DB. Or
+//  instead, once the buffer reaches a certain size (10MB?), write the contents to the DB. It
+//  really depends on:
+//
+//      1. Overall program memory consumption
+//          - If the program is running hot, we will have to decrease the buffer capacity.
+//            However, we can probably control a few things like # users in the cache (evict LRU),
+//            # of pending orders we want to store in each market, etc.
+//      2. Latency of writing to the database.
+//      3. Ability to write to DB by moving buffer to another thread and continuing normal
+//         operations (in this case, we could have a very large buffer).

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -143,18 +143,6 @@ impl DatabaseReadyOrder {
 
         self.time_updated = Some(Local::now());
     }
-
-    fn update_filled(&mut self, new_filled: i32) {
-        self.filled = Some(new_filled);
-    }
-
-    fn update_status(&mut self, new_status: OrderStatus) {
-        self.status = Some(new_status);
-    }
-
-    fn update_time_updated(&mut self) {
-        self.time_updated = Some(Local::now());
-    }
 }
 
 #[derive(Debug)]

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -438,6 +438,7 @@ impl Exchange {
                     }
                 }
             }
+            buffers.update_buffer_states();
         }
 
         // If you want prints of each users account, uncomment this.

--- a/src/exchange/filled.rs
+++ b/src/exchange/filled.rs
@@ -1,4 +1,5 @@
 use crate::exchange::Order;
+use chrono::{DateTime, FixedOffset, Utc};
 
 /* Note that a trade does not indicate a full order was processed!
  * It may have only filled part of an order.
@@ -12,7 +13,8 @@ pub struct Trade {
     pub filled_uid: i32,    // ID of user who placed the order that is being filled
     pub filler_oid: i32,    // ID of new order that triggered the trade
     pub filler_uid: i32,    // ID of user who placed new order that triggered the trade
-    pub exchanged: i32      // the amount of shares exchanged
+    pub exchanged: i32,     // the amount of shares exchanged
+    pub execution_time: DateTime<Utc>
 }
 
 impl Trade {
@@ -25,7 +27,8 @@ impl Trade {
             filled_uid,
             filler_oid,
             filler_uid,
-            exchanged
+            exchanged,
+            execution_time: Utc::now()
         }
     }
 
@@ -35,7 +38,7 @@ impl Trade {
     }
 
     /* Used when reading data directly from the database. */
-    pub fn direct(symbol: &str, action: &str, price: f64, filled_oid: i32, filled_uid: i32, filler_oid: i32, filler_uid: i32, exchanged: i32) -> Self {
+    pub fn direct(symbol: &str, action: &str, price: f64, filled_oid: i32, filled_uid: i32, filler_oid: i32, filler_uid: i32, exchanged: i32, execution_time: DateTime<FixedOffset>) -> Self {
         Trade {
             symbol: symbol.to_string().clone(),
             action: action.to_string().clone(),
@@ -44,7 +47,8 @@ impl Trade {
             filled_uid,
             filler_oid,
             filler_uid,
-            exchanged
+            exchanged,
+            execution_time: execution_time.with_timezone(&Utc)
         }
     }
 }

--- a/src/exchange/market.rs
+++ b/src/exchange/market.rs
@@ -1,6 +1,6 @@
 use std::collections::BinaryHeap;
 use std::cmp::Reverse;
-use crate::exchange::{Order, Trade};
+use crate::exchange::{Order, Trade, OrderStatus};
 
 // The market for a security
 #[derive(Debug)]
@@ -33,6 +33,7 @@ impl Market {
         loop {
             // The new buy order was filled.
             if highest_bid.quantity == highest_bid.filled {
+                highest_bid.status = OrderStatus::COMPLETE;
                 break;
             }
 
@@ -98,6 +99,7 @@ impl Market {
         loop {
             // The new sell order was filled.
             if lowest_offer.quantity == lowest_offer.filled {
+                lowest_offer.status = OrderStatus::COMPLETE;
                 break;
             }
 

--- a/src/exchange/requests.rs
+++ b/src/exchange/requests.rs
@@ -57,6 +57,22 @@ impl Order {
             user_id: Some(user_id)
         }
     }
+
+    /* This constructs a mostly empty order. We only ever use it when cancelling an order,
+     * as we need to modify the orders state in the order buffer.
+     **/
+    pub fn from_cancelled(order_id: i32) -> Self {
+        Order {
+            action: "".to_string(),
+            symbol: "".to_string(),
+            quantity: 0,
+            filled: 0,
+            price: 0.0,
+            order_id,
+            status: OrderStatus::CANCELLED,
+            user_id: None,
+        }
+    }
 }
 
 impl Clone for Order {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,8 +18,9 @@ use std::io::{self, prelude::*};
 use postgres::{Client, NoTls};
 
 fn main() {
-    let mut exchange: Exchange = Exchange::new();   // Our central exchange, everything happens here.
-    let mut users: Users = Users::new();            // All our users are stored here.
+    let mut exchange = Exchange::new();  // Our central exchange, everything happens here.
+    let mut users    = Users::new();     // All our users are stored here.
+    let mut buffers  = BufferCollection::new(20000, 20000); // In-memory buffers that will write to DB.
 
     let mut client = Client::connect("host=localhost user=postgres dbname=mydb", NoTls)
         .expect("Failed to connect to Database. Please ensure it is up and running.");
@@ -72,10 +73,14 @@ fn main() {
                     // Our input has been validated, and we can now
                     // attempt to service the request.
                     println!("Servicing Request: {}", raw);
-                    parser::service_request(request, &mut exchange, &mut users, &mut client);
+                    parser::service_request(request, &mut exchange, &mut users, &mut buffers, &mut client);
                 },
                 Err(_) => return
             }
+
+            // Make sure our buffer states are accurate.
+            println!("{:?}", buffers);
+            buffers.update_buffer_states();
         }
     } else {
         // User interface version
@@ -104,7 +109,11 @@ fn main() {
 
             // Our input has been validated, and we can now
             // attempt to service the request.
-            parser::service_request(request, &mut exchange, &mut users, &mut client);
+            parser::service_request(request, &mut exchange, &mut users, &mut buffers, &mut client);
+
+            // Make sure our buffer states are accurate.
+            println!("{:?}", buffers);
+            buffers.update_buffer_states();
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,10 +4,12 @@ extern crate chrono;
 pub mod exchange;
 pub mod parser;
 pub mod account;
+pub mod buffer;
 pub mod database;
 
 pub use crate::exchange::{Exchange, Market, Request};
 pub use crate::account::{Users};
+pub use crate::buffer::BufferCollection;
 
 use std::env;
 use std::process;


### PR DESCRIPTION
The goal of this PR is to create some in-memory buffers that allow us to make fewer/less frequent database writes.

As of **PER-4**, we are still doing several DB operations per order placement, making the overall program run extremely slow. IO is very obviously the limiting factor, and so the only way to approach this in my opinion is to buffer the writes and do large batch update/inserts.

I've outlined some aspects of my approach in the `src/buffer.rs` file in the first commit of this PR. Essentially, we will write changes between the previous DB update and the next in a collection of HashMaps and vectors, using Rusts `Option<x>` type to represent if a field has been updated or not.

### Disclaimer
This PR will **NOT** make an changes to current database operations! The program will still run slow, and will even consume more memory by the end of this PR. I will save batch updates for another PR, and may even push the event loop of 
1. check if buffer full/write time has elapsed
2. if no, continuing writing to buffer until 1 is satisfied
3. 3. if yes, launch new thread, move buffers in (or however rust handles multithreadding, I have to read that section of the book), and write to DB