### PR TITLE
PER-6

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -287,8 +287,10 @@ impl BufferCollection {
 
     /* Check our buffer states.
      * TODO: Eventually, we will write our buffers to the database in here.
+     * Returns true if Orders buffer was drained, false otherwise.
+     *      - If order buffer drained, we can reset user modified fields.
      * */
-    pub fn update_buffer_states(&mut self) {
+    pub fn update_buffer_states(&mut self) -> bool {
         self.buffered_orders.update_space_remaining();
         self.buffered_trades.update_space_remaining();
 
@@ -296,6 +298,7 @@ impl BufferCollection {
             // TODO: must drain orders buffer!
             eprintln!("WARNING: order buffer is full. Write to the database!");
             self.buffered_orders.drain_buffer();
+            return true;
         };
 
         if let BufferState::FULL = self.buffered_trades.state {
@@ -303,5 +306,7 @@ impl BufferCollection {
             eprintln!("WARNING: trade buffer is full. Write to the database!");
             self.buffered_trades.drain_buffer();
         };
+
+        return false;
     }
 }

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -211,6 +211,9 @@ impl Exchange {
         let mut order: Order = order;
         let mut new_price = None; // new price if trade occurs
 
+        // PER-6 account is being modified so set modified to true.
+        account.modified = true;
+
         // Set the order_id for the order.
         order.order_id = self.total_orders + 1;
 
@@ -329,6 +332,9 @@ impl Exchange {
                     // 3. Remove order from users account
                     if let Ok(account) = users.get_mut(&(order_to_cancel.username), true) {
                         account.remove_order_from_account(&(order_to_cancel.symbol), order_to_cancel.order_id);
+
+                        // Indicate that the user's account has been modified.
+                        account.modified = true;
                     }
 
                     // TODO: Do we want to update market stats? total_cancelled maybe?

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -58,6 +58,7 @@ impl Exchange {
     fn update_state(&mut self, order: &Order, users: &mut Users, buffers: &mut BufferCollection, executed_trades: Option<Vec<Trade>>, conn: &mut Client) -> Option<f64> {
 
         let stats: &mut SecStat = self.statistics.get_mut(&order.symbol).unwrap();
+        stats.modified = true;
 
         // Write the newly placed order to the Orders table.
         // If Order isn't complete, adds to pending as well.
@@ -338,6 +339,7 @@ impl Exchange {
                     }
 
                     // TODO: Do we want to update market stats? total_cancelled maybe?
+                    //       If we do, we have to also set stats.modified = true
                     let mut to_remove = Vec::new();
                     to_remove.push(order_to_cancel.order_id);
 

--- a/src/exchange/stats.rs
+++ b/src/exchange/stats.rs
@@ -9,6 +9,7 @@ pub struct SecStat {
     pub filled_buys: i32,
     pub filled_sells: i32,
     pub last_price: Option<f64>, // Last price we got
+    pub modified: bool
 }
 
 impl SecStat {
@@ -34,7 +35,8 @@ impl SecStat {
             total_sells: total_sells,
             filled_buys: 0,
             filled_sells: 0,
-            last_price: last_price
+            last_price: last_price,
+            modified: false
         }
     }
 
@@ -52,7 +54,8 @@ impl SecStat {
             total_sells,
             filled_buys,
             filled_sells,
-            last_price
+            last_price,
+            modified: false
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,14 @@ fn main() {
 
             // Make sure our buffer states are accurate.
             println!("{:?}", buffers);
-            buffers.update_buffer_states();
+            // TODO: PER-7 write our markets to DB too.
+            if buffers.update_buffer_states() {
+                users.reset_users_modified();
+                // Set all market stats modified to false
+                for (_key, entry) in exchange.statistics.iter_mut() {
+                    entry.modified = false;
+                }
+            }
         }
     } else {
         // User interface version
@@ -112,8 +119,15 @@ fn main() {
             parser::service_request(request, &mut exchange, &mut users, &mut buffers, &mut client);
 
             // Make sure our buffer states are accurate.
-            println!("{:?}", buffers);
-            buffers.update_buffer_states();
+            // TODO: PER-7 write our markets to DB too.
+            if buffers.update_buffer_states() {
+                users.reset_users_modified();
+
+                // Set all market stats modified to false
+                for (_key, entry) in exchange.statistics.iter_mut() {
+                    entry.modified = false;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Add `modified` field to `UserAccount` and `SecStat` so that we know if these structures have changed since the last batch write to the DB.

Additionally, we should implement Cache eviction for `Users`, only evict if a `UserAccount`'s `modified` field is false (i.e consistent with database).

*Note*: We might need to consider the case where the cache is full and all users are modified.