### PR TITLE
PER-7

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -330,6 +330,10 @@ We need to flush the Order buffer first!");
             match database::read_auth_user(username, password, conn) {
                 // We got an account, move it into the cache.
                 Ok(mut account) => {
+                    // TODO: This is an extremely expensive operation.
+                    //       I would rather search all our in-memory markets and pull the data from
+                    //       there.
+
                     // Since our user will be cached, and we are likely to do things with the user.
                     // We should probably make sure the in-mem pending orders are consistent w/ the database!
                     database::read_account_pending_orders(&mut account, conn);

--- a/src/account.rs
+++ b/src/account.rs
@@ -62,7 +62,10 @@ impl UserAccount {
         return self.id.unwrap();
     }
 
-    /*
+    /* TODO: This has a bug. We return true even if the order theoretically cannot be filled.
+     *       Ex. The func doesn't consider if other orders (not belonging to user) would fill
+     *           the current order first.
+     *
      * Returns true if this order will not fill any pending orders placed by
      * this user. Otherwise, returns false.
      *

--- a/src/account.rs
+++ b/src/account.rs
@@ -169,11 +169,9 @@ pub struct Users {
 impl Users {
 
     pub fn new() -> Self {
-        // let map: HashMap<String, UserAccount> = HashMap::new();
+        // TODO: How do we want to decide what the max # users is?
         let max_users = 1000;
         let map: HashMap<String, UserAccount> = HashMap::with_capacity(max_users);
-        // TODO: Eventually we want to do with capacity
-        // let id_map: HashMap<i32, String> = HashMap::new();
         let id_map: HashMap<i32, String> = HashMap::with_capacity(max_users);
         Users {
             users: map,
@@ -410,7 +408,8 @@ Be sure to call authenticate() before trying to get a reference to a user!")
      *
      * This means we do not update the cache!
      */
-    fn _get_mut(&mut self, username: &String, conn: &mut Client) -> (Option<&mut UserAccount>, Option<UserAccount>){
+    // fn _get_mut(&mut self, username: &String, conn: &mut Client) -> (Option<&mut UserAccount>, Option<UserAccount>){
+    fn _get_mut(&mut self, username: &String, conn: &mut Client) -> &mut UserAccount {
         match self.users.get_mut(username) {
             // Some(account) => return (Some(account), None),
             Some(_) => (),
@@ -426,7 +425,8 @@ Be sure to call authenticate() before trying to get a reference to a user!")
                 // return (None, Some(account));
             }
         }
-        return (self.users.get_mut(username), None);
+        // return (self.users.get_mut(username), None);
+        return self.users.get_mut(username).unwrap();
     }
 
     /* TODO: This is very likley outdated
@@ -476,7 +476,6 @@ Be sure to call authenticate() before trying to get a reference to a user!")
             Some(name) => name.clone(),
             None => {
                 // Search the database for the user with this id.
-                // Do not update the cache
                 let result = database::read_user_by_id(id, conn);
                 if let Err(_) = result {
                     panic!("Query to get user by id failed!");
@@ -486,22 +485,8 @@ Be sure to call authenticate() before trying to get a reference to a user!")
             }
         };
 
-        // If _get_mut gives us a database entry, place_holder will hold it
-        // and account will refer to place_holder.
-        let mut place_holder: UserAccount;
-        let account: &mut UserAccount;
-
-        // Gives either a mutable reference to cache,
-        // or constructs account from db (no cache update).
-        let result = self._get_mut(&username, conn);
-        if let Some(acc) = result.0 {
-            // Got reference to cache
-            account = acc;
-        } else {
-            // Got user from database
-            place_holder = result.1.unwrap();
-            account = &mut place_holder;
-        }
+        // Gives a mutable reference to cache.
+        let account = self._get_mut(&username, conn);
 
         // PER-6 set account modified to true because we're modifying their orders.
         account.modified = true;

--- a/src/account.rs
+++ b/src/account.rs
@@ -400,6 +400,8 @@ Be sure to call authenticate() before trying to get a reference to a user!")
      *       orders are stored in the temp buffer but not the db or program data structures,
      *       then there's no way for us to know about the state of the users account.
      *
+     * TODO: Since we now cache, lets change the return type to be less complicated.
+     *
      * For internal use only.
      *
      * If the account is in the cache (active user), we return a mutable ref to the user.

--- a/src/account.rs
+++ b/src/account.rs
@@ -408,10 +408,8 @@ Be sure to call authenticate() before trying to get a reference to a user!")
      *
      * This means we do not update the cache!
      */
-    // fn _get_mut(&mut self, username: &String, conn: &mut Client) -> (Option<&mut UserAccount>, Option<UserAccount>){
     fn _get_mut(&mut self, username: &String, conn: &mut Client) -> &mut UserAccount {
         match self.users.get_mut(username) {
-            // Some(account) => return (Some(account), None),
             Some(_) => (),
             None => {
                 let mut account = match database::read_account(username, conn) {
@@ -422,10 +420,8 @@ Be sure to call authenticate() before trying to get a reference to a user!")
                 // Fill this account with the pending orders
                 database::read_account_pending_orders(&mut account, conn);
                 self.cache_user(account);
-                // return (None, Some(account));
             }
         }
-        // return (self.users.get_mut(username), None);
         return self.users.get_mut(username).unwrap();
     }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -178,8 +178,8 @@ impl OrderBuffer {
     /* Gives us access to the internal data buffer. */
     pub fn drain_buffer(&mut self) -> hash_map::Drain<'_, i32, DatabaseReadyOrder> {
         match self.state {
-            BufferState::EMPTY => eprintln!("The buffer is empty, there is nothing to drain."),
-            BufferState::NONEMPTY => eprintln!("The buffer is not full, we can wait before draining."),
+            BufferState::EMPTY => eprintln!("The Order buffer is empty, there is nothing to drain."),
+            BufferState::NONEMPTY => eprintln!("The Order buffer is not full, we can wait before draining."),
             BufferState::FULL => ()
         }
         self.state = BufferState::EMPTY;
@@ -305,8 +305,8 @@ impl TradeBuffer {
     /* Call this when we want to consume the buffer and write it to the database. */
     pub fn drain_buffer(&mut self) -> vec::Drain<'_, Trade> {
         match self.state {
-            BufferState::EMPTY => eprintln!("The buffer is empty, there is nothing to drain."),
-            BufferState::NONEMPTY => eprintln!("The buffer is not full, we can wait before draining."),
+            BufferState::EMPTY => eprintln!("The trade buffer is empty, there is nothing to drain."),
+            BufferState::NONEMPTY => eprintln!("The trade buffer is not full, we can wait before draining."),
             BufferState::FULL => ()
         }
         self.state = BufferState::EMPTY;

--- a/src/database.rs
+++ b/src/database.rs
@@ -847,12 +847,11 @@ WHERE order_id=$1;";
 pub fn update_total_orders(total_orders: i32, conn: &mut Client) {
     let mut transaction = conn.transaction().expect("Failed to initiate transaction!");
     // Update the exchange total orders
-    let query_string: &str;
-    if total_orders == 1 {
-        query_string = "INSERT INTO ExchangeStats VALUES ($1);";
-    } else {
-        query_string = "UPDATE ExchangeStats set total_orders=$1;";
-    };
+    let query_string = "\
+INSERT INTO ExchangeStats
+VALUES (1, $1)
+ON CONFLICT (key) DO
+UPDATE SET total_orders=$1;";
 
     if let Err(e) = transaction.execute(query_string, &[&total_orders]) {
         eprintln!("{:?}", e);

--- a/src/database/schema.sql
+++ b/src/database/schema.sql
@@ -69,5 +69,6 @@ CREATE TABLE Markets (
 -- with SELECT count(*) from Orders; would be prohibitively expensive
 CREATE TABLE ExchangeStats (
     key             int,
-    total_orders    int
+    total_orders    int,
+    PRIMARY KEY (key)
 );

--- a/src/database/schema.sql
+++ b/src/database/schema.sql
@@ -68,5 +68,6 @@ CREATE TABLE Markets (
 -- doesn't store row count as metadata, getting row count
 -- with SELECT count(*) from Orders; would be prohibitively expensive
 CREATE TABLE ExchangeStats (
+    key             int
     total_orders    int
 );

--- a/src/database/schema.sql
+++ b/src/database/schema.sql
@@ -68,6 +68,6 @@ CREATE TABLE Markets (
 -- doesn't store row count as metadata, getting row count
 -- with SELECT count(*) from Orders; would be prohibitively expensive
 CREATE TABLE ExchangeStats (
-    key             int
+    key             int,
     total_orders    int
 );

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -374,7 +374,7 @@ impl Exchange {
      **/
     pub fn simulate_market(&mut self, sim: &Simulation, users: &mut Users, buffers: &mut BufferCollection, conn: &mut Client) {
 
-        let mut test_client = Client::connect("host=localhost user=postgres dbname=test_db", NoTls).expect("Failed to access test db");
+        // let mut test_client = Client::connect("host=localhost user=postgres dbname=test_db", NoTls).expect("Failed to access test db");
 
         let buy = String::from("BUY");
         let sell = String::from("SELL");
@@ -450,7 +450,7 @@ impl Exchange {
                     }
                 }
             }
-            // buffers.update_buffer_states(&self.statistics, conn);
+
             // buffers.update_buffer_states(&self, &mut test_client);
             if buffers.update_buffer_states(&self, conn) {
                 users.reset_users_modified();

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -451,7 +451,7 @@ impl Exchange {
                 }
             }
             // buffers.update_buffer_states(&self.statistics, conn);
-            buffers.update_buffer_states(&self.statistics, &mut test_client);
+            buffers.update_buffer_states(&self, &mut test_client);
         }
 
         // If you want prints of each users account, uncomment this.

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -448,7 +448,7 @@ impl Exchange {
                     }
                 }
             }
-            buffers.update_buffer_states();
+            buffers.update_buffer_states(&self.statistics, conn);
         }
 
         // If you want prints of each users account, uncomment this.

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -62,7 +62,7 @@ impl Exchange {
 
         // Write the newly placed order to the Orders table.
         // If Order isn't complete, adds to pending as well.
-        database::write_insert_order(order, conn);
+        // database::write_insert_order(order, conn); // PER-7 TEST
 
         // Update the counters and the price
         match &order.action[..] {
@@ -84,7 +84,7 @@ impl Exchange {
             // Updates in-mem data
             stats.update_market_stats(price, &trades);
             // Updates database
-            database::write_update_market_stats(stats, conn);
+            // database::write_update_market_stats(stats, conn); // PER-7 TEST
 
             /* TODO: Updating accounts seems like something that
              *       shouldn't slow down order execution.
@@ -349,7 +349,7 @@ impl Exchange {
 
                     // TODO: PER-6/7
                     //       Remove this db write eventually, we just write the buffers.
-                    database::write_delete_pending_orders(&to_remove, conn, OrderStatus::CANCELLED);
+                    // database::write_delete_pending_orders(&to_remove, conn, OrderStatus::CANCELLED); // PER-7 TEST
 
                     return Ok(());
 
@@ -451,7 +451,14 @@ impl Exchange {
                 }
             }
             // buffers.update_buffer_states(&self.statistics, conn);
-            buffers.update_buffer_states(&self, &mut test_client);
+            // buffers.update_buffer_states(&self, &mut test_client);
+            if buffers.update_buffer_states(&self, conn) {
+                users.reset_users_modified();
+                // Set all market stats modified to false
+                for (_key, entry) in self.statistics.iter_mut() {
+                    entry.modified = false;
+                }
+            }
         }
 
         // If you want prints of each users account, uncomment this.

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -19,7 +19,7 @@ pub use crate::database;
 
 pub use crate::buffer::BufferCollection;
 
-use postgres::Client;
+use postgres::{Client, NoTls};
 
 // Error types for price information.
 pub enum PriceError {
@@ -374,6 +374,8 @@ impl Exchange {
      **/
     pub fn simulate_market(&mut self, sim: &Simulation, users: &mut Users, buffers: &mut BufferCollection, conn: &mut Client) {
 
+        let mut test_client = Client::connect("host=localhost user=postgres dbname=test_db", NoTls).expect("Failed to access test db");
+
         let buy = String::from("BUY");
         let sell = String::from("SELL");
 
@@ -448,7 +450,8 @@ impl Exchange {
                     }
                 }
             }
-            buffers.update_buffer_states(&self.statistics, conn);
+            // buffers.update_buffer_states(&self.statistics, conn);
+            buffers.update_buffer_states(&self.statistics, &mut test_client);
         }
 
         // If you want prints of each users account, uncomment this.

--- a/src/exchange/requests.rs
+++ b/src/exchange/requests.rs
@@ -160,5 +160,5 @@ pub enum Request {
     InfoReq(InfoRequest),
     SimReq(Simulation),
     UserReq(UserAccount, String), // Account followed by action
-    UpgradeDbReq(String, String), // username, password. Only admin can call this
+    UpgradeDbReq(String, String, String), // db_name, username, password. Only admin can call this
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,6 @@ fn main() {
     let mut exchange = Exchange::new();  // Our central exchange, everything happens here.
     let mut users    = Users::new();     // All our users are stored here.
     let mut buffers  = BufferCollection::new(200000, 200000); // In-memory buffers that will write to DB.
-    // let mut buffers  = BufferCollection::new(5000, 5000); // In-memory buffers that will write to DB.
 
     let mut client = Client::connect("host=localhost user=postgres dbname=mydb", NoTls)
         .expect("Failed to connect to Database. Please ensure it is up and running.");
@@ -83,8 +82,6 @@ fn main() {
             }
 
             // Make sure our buffer states are accurate.
-            // println!("{:?}", buffers);
-            // TODO: PER-7 write our markets to DB too.
             // if buffers.update_buffer_states(&exchange, &mut testing_client) {
             if buffers.update_buffer_states(&exchange, &mut client) {
                 users.reset_users_modified();
@@ -126,8 +123,6 @@ fn main() {
             parser::service_request(request, &mut exchange, &mut users, &mut buffers, &mut client);
 
             // Make sure our buffer states are accurate.
-            // TODO: PER-7 write our markets to DB too.
-            // println!("{:?}", buffers);
             // if buffers.update_buffer_states(&exchange, &mut testing_client) {
             if buffers.update_buffer_states(&exchange, &mut client) {
                 users.reset_users_modified();

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,14 +20,14 @@ use postgres::{Client, NoTls};
 fn main() {
     let mut exchange = Exchange::new();  // Our central exchange, everything happens here.
     let mut users    = Users::new();     // All our users are stored here.
-    // let mut buffers  = BufferCollection::new(20000, 20000); // In-memory buffers that will write to DB.
-    let mut buffers  = BufferCollection::new(2000, 2000); // In-memory buffers that will write to DB.
+    let mut buffers  = BufferCollection::new(200000, 200000); // In-memory buffers that will write to DB.
+    // let mut buffers  = BufferCollection::new(5000, 5000); // In-memory buffers that will write to DB.
 
     let mut client = Client::connect("host=localhost user=postgres dbname=mydb", NoTls)
         .expect("Failed to connect to Database. Please ensure it is up and running.");
 
-    let mut testing_client = Client::connect("host=localhost user=postgres dbname=test_db", NoTls)
-        .expect("Failed to connect to Database. Please ensure it is up and running.");
+    // let mut testing_client = Client::connect("host=localhost user=postgres dbname=test_db", NoTls)
+    //     .expect("Failed to connect to Database. Please ensure it is up and running.");
 
     println!("Connected to database.");
 
@@ -85,7 +85,8 @@ fn main() {
             // Make sure our buffer states are accurate.
             // println!("{:?}", buffers);
             // TODO: PER-7 write our markets to DB too.
-            if buffers.update_buffer_states(&exchange, &mut testing_client) {
+            // if buffers.update_buffer_states(&exchange, &mut testing_client) {
+            if buffers.update_buffer_states(&exchange, &mut client) {
                 users.reset_users_modified();
                 // Set all market stats modified to false
                 for (_key, entry) in exchange.statistics.iter_mut() {
@@ -93,7 +94,8 @@ fn main() {
                 }
             }
         }
-        buffers.flush_on_shutdown(&exchange, &mut testing_client);
+        // buffers.flush_on_shutdown(&exchange, &mut testing_client);
+        buffers.flush_on_shutdown(&exchange, &mut client);
     } else {
         // User interface version
         println!("
@@ -126,7 +128,8 @@ fn main() {
             // Make sure our buffer states are accurate.
             // TODO: PER-7 write our markets to DB too.
             // println!("{:?}", buffers);
-            if buffers.update_buffer_states(&exchange, &mut testing_client) {
+            // if buffers.update_buffer_states(&exchange, &mut testing_client) {
+            if buffers.update_buffer_states(&exchange, &mut client) {
                 users.reset_users_modified();
 
                 // Set all market stats modified to false

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,9 +20,13 @@ use postgres::{Client, NoTls};
 fn main() {
     let mut exchange = Exchange::new();  // Our central exchange, everything happens here.
     let mut users    = Users::new();     // All our users are stored here.
-    let mut buffers  = BufferCollection::new(20000, 20000); // In-memory buffers that will write to DB.
+    // let mut buffers  = BufferCollection::new(20000, 20000); // In-memory buffers that will write to DB.
+    let mut buffers  = BufferCollection::new(2, 2); // In-memory buffers that will write to DB.
 
     let mut client = Client::connect("host=localhost user=postgres dbname=mydb", NoTls)
+        .expect("Failed to connect to Database. Please ensure it is up and running.");
+
+    let mut testing_client = Client::connect("host=localhost user=postgres dbname=test_db", NoTls)
         .expect("Failed to connect to Database. Please ensure it is up and running.");
 
     println!("Connected to database.");
@@ -79,9 +83,9 @@ fn main() {
             }
 
             // Make sure our buffer states are accurate.
-            println!("{:?}", buffers);
+            // println!("{:?}", buffers);
             // TODO: PER-7 write our markets to DB too.
-            if buffers.update_buffer_states(&mut exchange.statistics, &mut client) {
+            if buffers.update_buffer_states(&mut exchange.statistics, &mut testing_client) {
                 users.reset_users_modified();
                 // Set all market stats modified to false
                 for (_key, entry) in exchange.statistics.iter_mut() {
@@ -120,7 +124,8 @@ fn main() {
 
             // Make sure our buffer states are accurate.
             // TODO: PER-7 write our markets to DB too.
-            if buffers.update_buffer_states(&mut exchange.statistics, &mut client) {
+            // println!("{:?}", buffers);
+            if buffers.update_buffer_states(&mut exchange.statistics, &mut testing_client) {
                 users.reset_users_modified();
 
                 // Set all market stats modified to false

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ fn main() {
             // Make sure our buffer states are accurate.
             println!("{:?}", buffers);
             // TODO: PER-7 write our markets to DB too.
-            if buffers.update_buffer_states() {
+            if buffers.update_buffer_states(&mut exchange.statistics, &mut client) {
                 users.reset_users_modified();
                 // Set all market stats modified to false
                 for (_key, entry) in exchange.statistics.iter_mut() {
@@ -120,7 +120,7 @@ fn main() {
 
             // Make sure our buffer states are accurate.
             // TODO: PER-7 write our markets to DB too.
-            if buffers.update_buffer_states() {
+            if buffers.update_buffer_states(&mut exchange.statistics, &mut client) {
                 users.reset_users_modified();
 
                 // Set all market stats modified to false

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ fn main() {
     let mut exchange = Exchange::new();  // Our central exchange, everything happens here.
     let mut users    = Users::new();     // All our users are stored here.
     // let mut buffers  = BufferCollection::new(20000, 20000); // In-memory buffers that will write to DB.
-    let mut buffers  = BufferCollection::new(2, 2); // In-memory buffers that will write to DB.
+    let mut buffers  = BufferCollection::new(2000, 2000); // In-memory buffers that will write to DB.
 
     let mut client = Client::connect("host=localhost user=postgres dbname=mydb", NoTls)
         .expect("Failed to connect to Database. Please ensure it is up and running.");
@@ -93,6 +93,7 @@ fn main() {
                 }
             }
         }
+        buffers.flush_on_shutdown(&mut exchange.statistics, &mut testing_client);
     } else {
         // User interface version
         println!("
@@ -133,6 +134,7 @@ fn main() {
                     entry.modified = false;
                 }
             }
+            // TODO: Flush Buffers on SigINT, SigKill
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,7 @@ fn main() {
             // Make sure our buffer states are accurate.
             // println!("{:?}", buffers);
             // TODO: PER-7 write our markets to DB too.
-            if buffers.update_buffer_states(&mut exchange.statistics, &mut testing_client) {
+            if buffers.update_buffer_states(&exchange, &mut testing_client) {
                 users.reset_users_modified();
                 // Set all market stats modified to false
                 for (_key, entry) in exchange.statistics.iter_mut() {
@@ -93,7 +93,7 @@ fn main() {
                 }
             }
         }
-        buffers.flush_on_shutdown(&mut exchange.statistics, &mut testing_client);
+        buffers.flush_on_shutdown(&exchange, &mut testing_client);
     } else {
         // User interface version
         println!("
@@ -126,7 +126,7 @@ fn main() {
             // Make sure our buffer states are accurate.
             // TODO: PER-7 write our markets to DB too.
             // println!("{:?}", buffers);
-            if buffers.update_buffer_states(&mut exchange.statistics, &mut testing_client) {
+            if buffers.update_buffer_states(&exchange, &mut testing_client) {
                 users.reset_users_modified();
 
                 // Set all market stats modified to false

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -138,10 +138,11 @@ pub fn tokenize_input(text: String) -> Result<Request, ()> {
         },
         // Upgrade the database, only the admin can do this.
         "upgrade_db" => {
-            if let 3 = words.len() {
-                let username  = words[1].to_string();
-                let password  = words[2].to_string();
-                return Ok(Request::UpgradeDbReq(username, password));
+            if let 4 = words.len() {
+                let db_name   = words[1].to_string();
+                let username  = words[2].to_string();
+                let password  = words[3].to_string();
+                return Ok(Request::UpgradeDbReq(db_name, username, password));
             } else {
                 malformed_req(&words[0], &words[0]);
                 return Err(());
@@ -260,7 +261,7 @@ pub fn service_request(request: Request, exchange: &mut Exchange, users: &mut Us
                 }
             }
         },
-        Request::UpgradeDbReq(username, password) => {
+        Request::UpgradeDbReq(db_name, username, password) => {
             // First, lets authenticate to make sure we're the admin.
             if username.as_str() == "admin" {
                 match users.authenticate(&username, &password, conn) {
@@ -273,7 +274,7 @@ pub fn service_request(request: Request, exchange: &mut Exchange, users: &mut Us
                         file_path = file_path.split_whitespace().next().expect("Please be sure to enter text!").to_string();
                         match File::open(file_path) {
                             Ok(f) => {
-                                database::upgrade_db(BufReader::new(f), conn);
+                                database::upgrade_db(BufReader::new(f), &db_name);
                             },
                             Err(e) => {
                                 eprintln!("{}", e);


### PR DESCRIPTION
Implement code to consume buffers and convert them into SQL statements.

We will begin the migration by having all batch DB writes go to an alternative Postgres server.

This way, we can compare our 2 databases for consistency errors. The rows should be identical (excluding timing data).

We will perform updates of Orders, Trades, and markets.