### PR TITLE
PER-9 Only read pending orders for accounts that are submitting/cancelling an order.

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -426,7 +426,7 @@ impl BufferCollection {
 
         match self.buffered_trades.state {
             BufferState::FULL | BufferState::FORCEFLUSH => {
-                println!("WARNING: trade buffer is full. Write to the database!");
+                println!("WARNING: trade buffer must be flushed. Write to the database!");
 
                 // We have to insert orders before trades, since
                 // trades have a foreign key constraint on order_id.

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -183,7 +183,7 @@ impl OrderBuffer {
         match self.state {
             BufferState::EMPTY => println!("The Order buffer is empty, there is nothing to drain."),
             BufferState::NONEMPTY => println!("The Order buffer is not full, we can wait before draining."),
-            BufferState::FORCEFLUSH => println!("The Order buffer is being forced to flush by an external module."),
+            BufferState::FORCEFLUSH => println!("The Order buffer is being forced to flush."),
             BufferState::FULL => ()
         }
         self.state = BufferState::EMPTY;
@@ -310,7 +310,7 @@ impl TradeBuffer {
         match self.state {
             BufferState::EMPTY => println!("The Trade buffer is empty, there is nothing to drain."),
             BufferState::NONEMPTY => println!("The Trade buffer is not full, we can wait before draining."),
-            BufferState::FORCEFLUSH => println!("The Trade buffer is being forced to flush by an external module."),
+            BufferState::FORCEFLUSH => println!("The Trade buffer is being forced to flush."),
             BufferState::FULL => ()
         }
         self.state = BufferState::EMPTY;
@@ -368,9 +368,15 @@ impl BufferCollection {
         // Flush Orders if we have any
         match self.buffered_orders.state {
             BufferState::FULL | BufferState::NONEMPTY | BufferState::FORCEFLUSH => {
+                self.buffered_orders.state = BufferState::FORCEFLUSH; // Unnecessary, but more accurately describes state.
+                println!("Consuming order buffer...");
+
                 let mut categories = TableModCategories::new();
                 self.buffered_orders.prepare_for_db_update(&mut categories);
+
+                println!("Updating database...\n");
                 BufferCollection::launch_batch_db_updates(&categories, exchange, conn);
+
                 self.buffered_orders.drain_buffer();
             },
             _ => println!("Orders buffer is empty, skipping.")
@@ -379,7 +385,11 @@ impl BufferCollection {
         // Flush Trades
         match self.buffered_trades.state {
             BufferState::FULL | BufferState::NONEMPTY | BufferState::FORCEFLUSH => {
+                self.buffered_trades.state = BufferState::FORCEFLUSH;
+
+                println!("Consuming trade buffer and updating database...\n");
                 database::insert_buffered_trades(&self.buffered_trades.data, conn);
+
                 self.buffered_trades.drain_buffer();
             },
             _ => println!("Trades buffer is empty, skipping.")
@@ -410,19 +420,6 @@ impl BufferCollection {
             },
             _ => ()
         }
-        /*
-        if let BufferState::FULL = self.buffered_orders.state {
-            println!("WARNING: order buffer is full. Write to the database!");
-
-            // Prepare for Order buffer drain
-            let mut categories = TableModCategories::new();
-            self.buffered_orders.prepare_for_db_update(&mut categories);
-            BufferCollection::launch_batch_db_updates(&categories, exchange, conn);
-
-            self.buffered_orders.drain_buffer();
-            orders_drained = true;
-        };
-        */
 
         match self.buffered_trades.state {
             BufferState::FULL | BufferState::FORCEFLUSH => {

--- a/src/database.rs
+++ b/src/database.rs
@@ -357,8 +357,9 @@ ORDER BY o.order_ID;";
                                   order_id,
                                   OrderStatus::PENDING,
                                   user_id);
-        let market = user.pending_orders.entry(order.symbol.clone()).or_insert(HashMap::new());
-        market.insert(order.order_id, order);
+        // let market = user.pending_orders.entry(order.symbol.clone()).or_insert(HashMap::new());
+        // market.insert(order.order_id, order);
+        user.pending_orders.insert_order(order);
     }
 }
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -128,7 +128,6 @@ ORDER BY (o.symbol, o.action)", &[]).expect("Something went wrong in the query."
         let price: f64 = row.get(5);
         let user_id: i32 = row.get(6);
         // No need to get status, it's obviously pending.
-        // let status: &str = row.get(7);
 
         let order = Order::direct(action, symbol, quantity, filled, price, order_id, OrderStatus::PENDING, user_id);
         // Add the order we found to the market.
@@ -344,9 +343,8 @@ ORDER BY o.order_ID;";
         let filled:         i32  = row.get(4);
         let price:          f64  = row.get(5);
         let user_id:        i32  = row.get(6);
-        // let status:         i32  = row.get(7); // <---- unnecessary, we know it's pending
-        // let time_placed:    i32  = row.get(7); // <---- TODO
-        // let time_updated:   i32  = row.get(7); // <---- TODO
+        // let time_placed:    i32  = row.get(8); // <---- TODO
+        // let time_updated:   i32  = row.get(9); // <---- TODO
 
         // We will just re-insert everything.
         let order = Order::direct(action,
@@ -357,8 +355,7 @@ ORDER BY o.order_ID;";
                                   order_id,
                                   OrderStatus::PENDING,
                                   user_id);
-        // let market = user.pending_orders.entry(order.symbol.clone()).or_insert(HashMap::new());
-        // market.insert(order.order_id, order);
+
         user.pending_orders.insert_order(order);
     }
 }
@@ -531,7 +528,7 @@ pub fn read_exchange_markets_simulations(symbol_vec: &mut Vec<String>, conn: &mu
 
 
 /******************************************************************************************************
- *                                  NEW API - Buffered Database                                       *
+ *                                         Buffered Writes API                                        *
  ******************************************************************************************************/
 // TODO: For all, try to construct a large query string and execute just once.
 //       I have a sneaking suspicion that calling execute() n times where n is large

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -55,7 +55,6 @@ impl Exchange {
      *
      * Returns Some(price) if trade occured, or None.
      */
-    // fn update_state(&mut self, order: &Order, users: &mut Users, buffers: &mut BufferCollection, executed_trades: Option<Vec<Trade>>, conn: &mut Client) -> Option<f64> {
     fn update_state(&mut self, order: &Order, users: &mut Users, buffers: &mut BufferCollection, exchange_event: Option<(Vec<Order>, Vec<Trade>)>, conn: &mut Client) -> Option<f64> {
 
         let stats: &mut SecStat = self.statistics.get_mut(&order.symbol).unwrap();
@@ -323,7 +322,6 @@ impl Exchange {
      *       cannot be cancelled.
      * */
     pub fn cancel_order(&mut self, order_to_cancel: &CancelOrder, users: &mut Users, buffers: &mut BufferCollection, conn: &mut Client) -> Result<(), String>{
-        // if let Ok(account) = users.get(&(order_to_cancel.username), true) {
         if let Ok(account) = users.get_mut(&(order_to_cancel.username), true) {
 
             // If we don't have the full picture of this users pending orders,

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -75,7 +75,6 @@ impl Exchange {
         let mut new_price = None;
 
         // Update the price and filled orders if a trade occurred.
-        // if let Some(mut trades) = executed_trades {
         if let Some((mut modified_orders, mut trades)) = exchange_event {
             let price = trades[trades.len() - 1].price;
             new_price = Some(price);
@@ -136,11 +135,6 @@ impl Exchange {
             for buy in market.buy_orders.iter() {
                 if buy.user_id == user.id {
                     user.pending_orders.insert_order(buy.clone());
-                    // let pending_market = user.pending_orders.entry(buy.symbol.clone()).or_insert(HashMap::new());
-
-                    // let pending_market = user.pending_orders.get_mut_market(&buy.symbol.as_str());
-                    // pending_market.insert(buy.order_id, buy.clone());
-
                 }
             }
             // Check all the sell orders of this market.
@@ -149,11 +143,6 @@ impl Exchange {
 
                 if sell.user_id == user.id {
                     user.pending_orders.insert_order(sell.clone());
-                    // let pending_market = user.pending_orders.entry(sell.symbol.clone()).or_insert(HashMap::new());
-
-                    // let pending_market = user.pending_orders.get_mut_market(&buy.symbol.as_str());
-                    // pending_market.insert(sell.order_id, sell.clone());
-
                 }
             }
         }
@@ -257,8 +246,6 @@ impl Exchange {
         match self.live_orders.get_mut(&order.symbol) {
             Some(market) => {
                 // Try to fill the new order with existing orders on the market.
-                // TODO: Get back a vector of orders that were modified as well!
-                // let trades = market.fill_existing_orders(&mut order);
                 let exchange_event = market.fill_existing_orders(&mut order);
 
                 // Add the new order to the buy/sell heap if it wasn't completely filled,
@@ -277,15 +264,12 @@ impl Exchange {
 
                     // Add to this accounts pending orders.
                     account.pending_orders.insert_order(order.clone());
-                    // let current_market = account.pending_orders.entry(order.symbol.clone()).or_insert(HashMap::new());
-                    // current_market.insert(order.order_id, order.clone());
                 }
 
                 // Add this new order to the database buffer
                 buffers.buffered_orders.add_unknown_to_order_buffer(&order);
 
                 // Update the state of the exchange.
-                // new_price = self.update_state(&order, users, buffers, trades, conn);
                 new_price = self.update_state(&order, users, buffers, exchange_event, conn);
             },
             // The market doesn't exist, create it if found in DB,
@@ -314,8 +298,6 @@ impl Exchange {
 
                     // Add the symbol name and order to this accounts pending orders.
                     account.pending_orders.insert_order(order.clone());
-                    // let new_account_market = account.pending_orders.entry(order.symbol.clone()).or_insert(HashMap::new());
-                    // new_account_market.insert(order.order_id, order.clone());
 
                     // Add this new order to the database buffer
                     buffers.buffered_orders.add_unknown_to_order_buffer(&order);


### PR DESCRIPTION
This is a big change.

Currently, any time an account is brought into the cache, we read all their pending orders in. This is unnecessary, since we only *really* use pending orders in accounts to determine if:
1. A user might accidentally fill their past order with a new one
2. A user owns an order that they're trying to cancel.

Obviously, if we've read an account into the cache because we're trying to fill one of their past orders, we have no reason to know their pending orders, we just write the updated order and trade to the buffers and send them to the DB eventually.

Therefore, the new system proposes the following:
- If a user is submitting or cancelling an order, and they their pending orders are not up-to-date, fetch their orders.
- Otherwise, don't worry about them.

Note that we only fetch if the orders aren't up to date, this can be achieved by storing a bool that lets us know if the user has called fetch in the past (if they have, they are guaranteed to remain up to date as long as they are cached).

Some final notes: Because I haven't touched the `market.rs` stuff in a while, I forgot that we literally remove orders from the market once they're fulfilled. This means we will have to somehow retain the orders that were modified in `fill_existing_order`, I vote I do it in the same way I retain Trade data: pass a vector in as an arg, push any modifications to it.

I think this will have some serious consequences on the runtime of the program, IO will always be the bottleneck, but users will have the illusion that their orders get filled instantly.