### PR TITLE
PER-10 Bug fixes and tackling some TODOs

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -119,22 +119,29 @@ impl UserAccount {
         return self.id.unwrap();
     }
 
-    /* TODO: This has a bug. We return true even if the order theoretically cannot be filled.
-     *       Ex. The func doesn't consider if other orders (not belonging to user) would fill
-     *           the current order first.
-     *
-     * Returns true if this order will not fill any pending orders placed by
-     * this user. Otherwise, returns false.
+    /*
+     * Returns (true, None) if this order *CANNOT* fill any pending orders placed by
+     * this user. Otherwise, returns (false, Some(Order)) where Order is the pending order
+     * that would be filled.
      *
      * Consider the following scenario:
      *  -   user places buy order for 10 shares of X at $10/share.
      *          - the order remains on the market and is not filled.
      *  -   later, the same user places a sell order for 3 shares of X at n <= $10/share.
-     *  -   the new order will fill their old order, which is probably undesirable,
-     *      or even illegal.
+     *  -   if there are no higher buy orders, the sell will fill the original buy.
+     *  -   That is, the user will fill their own order (Trade with themselves).
+     *
+     *  We *could* check for this as we make trades, but I think it's better to make the user
+     *  explicitly resubmit their order at a valid price.
+     *
+     * Note that this function can prevent an order from being placed, even if at the moment it was
+     * placed, other pending orders were present that would prevent the new order from filling an
+     * old one. This is because the program may be multi-threaded at some point, and so we cannot
+     * be sure of order execution in extremely small time frames. I'm effectively preventing future
+     * bugs.
      *
      **/
-    pub fn validate_order(&self, order: &Order) -> bool {
+    pub fn validate_order(&self, order: &Order) -> (bool, Option<Order>) {
         if !self.pending_orders.is_complete {
             panic!("\
 Well, you've done it again.
@@ -144,19 +151,30 @@ You called validate_order on an account with in-complete pending order data.");
         match self.pending_orders.view_market(&order.symbol.as_str()) {
             // We only care about the market that `order` is being submitted to.
             Some(market) => {
-                for (_, pending) in market.iter() {
-                    // If this order will fill a pending order that this account placed:
-                    if  (order.action.ne(&pending.action)) &&
-                        ((order.action.as_str() == "BUY"  && pending.price <= order.price) ||
-                        (order.action.as_str() == "SELL" && order.price <= pending.price))
-                    {
-                        return false;
-                    }
+                let candidates = market.values().filter(|candidate| order.action.ne(&candidate.action));
+                match order.action.as_str() {
+                    "BUY" => {
+                        let result = candidates.min_by(|x, y| x.price.partial_cmp(&y.price).expect("Tried to compare NaN!"));
+                        if let Some(lowest_offer) = result {
+                            if lowest_offer.price <= order.price {
+                                return (false, Some(lowest_offer.clone()));
+                            }
+                        }
+                    },
+                    "SELL" => {
+                        let result = candidates.max_by(|x, y| x.price.partial_cmp(&y.price).expect("Tried to compare Nan!"));
+                        if let Some(highest_bid) = result {
+                            if order.price <= highest_bid.price {
+                                return (false, Some(highest_bid.clone()));
+                            }
+                        }
+                    },
+                    _ => ()
                 }
             },
             None => ()
         }
-        return true;
+        return (true, None);
     }
 
     fn check_pending_order_cache(&self, symbol: &String, id: i32) -> Option<String> {

--- a/src/account.rs
+++ b/src/account.rs
@@ -233,7 +233,7 @@ You called validate_order on an account with in-complete pending order data.");
                 }
             }
         } else {
-            println!("\n\t No Orders awaiting Execution");
+            println!("\n\tNo Orders awaiting Execution");
         }
         if executed_trades.len() > 0 {
             println!("\n\tExecuted Trades");

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,7 +1,7 @@
 use postgres::{Client, NoTls};
 use chrono::{Utc, DateTime, FixedOffset};
 
-use std::collections::{BinaryHeap, HashMap};
+use std::collections::BinaryHeap;
 use std::cmp::Reverse;
 use std::convert::TryFrom;
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -323,10 +323,10 @@ pub fn read_user_by_id(id: i32, conn: &mut Client) -> Result<String, postgres::e
     }
 }
 
-/* TODO: Order inserts by time executed!
- * TODO: Use a prepared statement!
- * Read the pending orders that belong to this user
- * into their account.
+/* Read the pending orders that belong to this user into their account.
+ * This is currently not in use, however, if we only store a subset
+ * of market info in the in-mem markets, we will have to call this
+ * to get the full view of an account (in, say, print_user).
  **/
 pub fn read_account_pending_orders(user: &mut UserAccount, conn: &mut Client) {
     let query_string = "\
@@ -361,9 +361,7 @@ ORDER BY o.order_ID;";
 }
 
 
-/* TODO: Order inserts by time executed!
- * Get this accounts executed trades from the database.
- **/
+/* Get this accounts executed trades from the database. */
 pub fn read_account_executed_trades(user: &UserAccount, executed_trades: &mut Vec<Trade>, conn: &mut Client) {
     // First, lets get trades where we had our order filled.
     let query_string = "\
@@ -444,7 +442,10 @@ pub fn read_trades(symbol: &String, conn: &mut Client) -> Option<Vec<Trade>> {
     return Some(trades);
 }
 
-/* TODO: Untested, not sure even how to test this.
+/* TODO: Doesn't get called ever, since we have a perfect market view.
+ *       If we cap the number of orders visible to a market in the program,
+ *       keeping the rest in the DB, then we may trigger this code.
+ *
  * Returns Some(action) if the user owns this pending order, else None. */
 pub fn read_match_pending_order(user_id: i32, order_id: i32, conn: &mut Client) -> Option<String> {
     let result = conn.query("\
@@ -532,7 +533,7 @@ pub fn read_exchange_markets_simulations(symbol_vec: &mut Vec<String>, conn: &mu
  ******************************************************************************************************/
 // TODO: For all, try to construct a large query string and execute just once.
 //       I have a sneaking suspicion that calling execute() n times where n is large
-//       is less performant, even within a transaction, than a single execute() with a large query.
+//       is less performant, even within a transaction, than a single execute() with multiple rows.
 pub fn insert_buffered_orders(orders: &Vec<DatabaseReadyOrder>, conn: &mut Client) {
 
     let mut transaction = conn.transaction().expect("Failed to initiate transaction!");
@@ -543,26 +544,37 @@ INSERT INTO Orders
 (order_ID, symbol, action, quantity, filled, price, user_ID, status, time_placed, time_updated)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10);";
 
+    let statement = match transaction.prepare(&query_string) {
+        Ok(stmt) => stmt,
+        Err(e) => {
+            eprintln!("{}", e);
+            panic!("Failed to insert new orders to database!");
+        }
+    };
+
     for order in orders {
 
         let status: String = format!["{:?}", order.status.unwrap()];
 
-        transaction.execute(query_string, &[&order.order_id,
-                                     &order.symbol,
-                                     &order.action,
-                                     &order.quantity,
-                                     &order.filled,
-                                     &order.price,
-                                     &order.user_id,
-                                     &status,
-                                     &order.time_placed,
-                                     &order.time_updated
-                                    ]).expect("FAILED TO EXEC INSERT ORDERS");
+        transaction.execute(&statement, &[ &order.order_id,
+                                          &order.symbol,
+                                          &order.action,
+                                          &order.quantity,
+                                          &order.filled,
+                                          &order.price,
+                                          &order.user_id,
+                                          &status,
+                                          &order.time_placed,
+                                          &order.time_updated
+                                         ]).expect("FAILED TO EXEC INSERT ORDERS");
     }
 
     transaction.commit().expect("Failed to commit buffered order insert transaction.");
 }
 
+/* Unlike the other write functions, this one cannot use prepared statements,
+ * since we are unsure which fields are actually being modified.
+ **/
 pub fn update_buffered_orders(orders: &Vec<DatabaseReadyOrder>, conn: &mut Client) {
 
     let mut transaction = conn.transaction().expect("Failed to initiate transaction!");
@@ -592,7 +604,6 @@ pub fn update_buffered_orders(orders: &Vec<DatabaseReadyOrder>, conn: &mut Clien
             panic!("Something went wrong with the buffered order update statement.");
         };
     }
-    // TODO: Figure out way to construct the partial updates.
     transaction.commit().expect("Failed to commit buffered order update transaction.");
 }
 
@@ -603,8 +614,16 @@ pub fn insert_buffered_pending(pending: &Vec<i32>, conn: &mut Client) {
 INSERT INTO PendingOrders
 VALUES ($1);";
 
+    let statement = match transaction.prepare(&query_string) {
+        Ok(stmt) => stmt,
+        Err(e) => {
+            eprintln!("{}", e);
+            panic!("Failed to insert new orders to database!");
+        }
+    };
+
     for order in pending {
-        transaction.execute(query_string, &[&order]).expect("FAILED TO EXEC INSERT PENDING");
+        transaction.execute(&statement, &[&order]).expect("FAILED TO EXEC INSERT PENDING");
     }
 
     transaction.commit().expect("Failed to commit buffered pending order insert transaction.");
@@ -616,8 +635,16 @@ pub fn delete_buffered_pending(pending: &Vec<i32>, conn: &mut Client) {
 DELETE FROM PendingOrders
 WHERE order_id=$1;";
 
+    let statement = match transaction.prepare(&query_string) {
+        Ok(stmt) => stmt,
+        Err(e) => {
+            eprintln!("{}", e);
+            panic!("Failed to insert new orders to database!");
+        }
+    };
+
     for order in pending {
-        transaction.execute(query_string, &[&order]).expect("FAILED TO EXEC DELETE PENDING");
+        transaction.execute(&statement, &[&order]).expect("FAILED TO EXEC DELETE PENDING");
     }
     transaction.commit().expect("Failed to commit buffered pending order delete transaction.");
 }
@@ -647,14 +674,22 @@ SET (total_buys, total_sells, filled_buys, filled_sells, latest_price) =
 ($1, $2, $3, $4, $5)
 WHERE Markets.symbol = $6;";
 
+    let statement = match transaction.prepare(&query_string) {
+        Ok(stmt) => stmt,
+        Err(e) => {
+            eprintln!("{}", e);
+            panic!("Failed to insert new orders to database!");
+        }
+    };
+
     for market in markets {
-        transaction.execute(query_string, &[&market.total_buys,
+        transaction.execute(&statement, &[  &market.total_buys,
                                             &market.total_sells,
                                             &market.filled_buys,
                                             &market.filled_sells,
                                             &market.last_price,
                                             &market.symbol
-                                           ]).expect("FAILED TO EXEC UPDATE MARKETS");
+                                         ]).expect("FAILED TO EXEC UPDATE MARKETS");
     }
     transaction.commit().expect("Failed to commit buffered market update transaction.");
 }
@@ -667,8 +702,16 @@ INSERT INTO ExecutedTrades
 (symbol, action, price, filled_OID, filled_UID, filler_OID, filler_UID, exchanged, execution_time)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9);";
 
+    let statement = match transaction.prepare(&query_string) {
+        Ok(stmt) => stmt,
+        Err(e) => {
+            eprintln!("{}", e);
+            panic!("Failed to insert new orders to database!");
+        }
+    };
+
     for trade in trades {
-        transaction.execute(query_string, &[&trade.symbol,
+        transaction.execute(&statement, &[  &trade.symbol,
                                             &trade.action,
                                             &trade.price,
                                             &trade.filled_oid,
@@ -677,7 +720,7 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9);";
                                             &trade.filler_uid,
                                             &trade.exchanged,
                                             &trade.execution_time,
-                                           ]).expect("FAILED TO EXEC INSERT TRADES");
+                                         ]).expect("FAILED TO EXEC INSERT TRADES");
     }
     transaction.commit().expect("Failed to commit buffered trade insert transaction.");
 }

--- a/src/database/NYSE.csv
+++ b/src/database/NYSE.csv
@@ -1,0 +1,3129 @@
+Symbol,Name,Last Sale,Net Change,% Change,Market Cap,Country,IPO Year,Volume,Sector,Industry
+add,A,Agilent Technologies Inc. Common Stock,$143.03,2.90,2.07%,43401484472.00,United States,1999,793457,Capital Goods,Electrical Products
+add,AA,Alcoa Corporation Common Stock ,$37.43,-0.55,-1.448%,6989107205.00,,2016,3285843,Basic Industries,Metal Fabrications
+add,AAC,Ares Acquisition Corporation Class A Ordinary Shares,$9.80,0.02,0.204%,1225000000.00,,2021,40547,Finance,Business Services
+add,AAIC,Arlington Asset Investment Corp Class A (new),$4.135,-0.055,-1.313%,138444683.00,United States,,137891,Finance,Finance/Investors Services
+add,AAIC^B,Arlington Asset Investment Corp 7.00% ,$25.15,0.05,0.199%,,United States,,104,,
+add,AAIC^C,Arlington Asset Investment Corp 8.250% Seies C Fixed-to-Floating Rate Cumulative Redeemable Preferred Stock   ,$25.25,0.09,0.358%,,United States,,2091,,
+add,AAN,Aarons Holdings Company Inc. Common Stock ,$35.93,-1.22,-3.284%,1291063959.00,United States,2020,162241,Miscellaneous,Diversified Commercial Services
+add,AAP,Advance Auto Parts Inc Advance Auto Parts Inc W/I,$195.835,-1.195,-0.607%,12815221106.00,United States,,697986,Consumer Services,Other Specialty Stores
+add,AAQC,Accelerate Acquisition Corp. Class A Common Stock,$9.7217,-0.0083,-0.085%,486085000.00,,2021,24696,,
+add,AAT,American Assets Trust Inc. Common Stock,$38.32,-0.25,-0.648%,2317298000.00,United States,2011,131465,Consumer Services,Real Estate Investment Trusts
+add,AB,AllianceBernstein Holding L.P.  Units,$45.4692,-0.7408,-1.603%,4569193042.00,United States,,264424,Finance,Investment Managers
+add,ABB,ABB Ltd Common Stock,$34.595,-0.135,-0.389%,70025803023.00,Switzerland,,935033,Consumer Durables,Electrical Products
+add,ABBV,AbbVie Inc. Common Stock,$116.33,2.33,2.044%,205464644347.00,United States,2012,4827265,Health Care,Other Pharmaceuticals
+add,ABC,AmerisourceBergen Corporation Common Stock,$120.7699,3.3699,2.87%,25048971551.00,United States,,521456,Health Care,Other Pharmaceuticals
+add,ABEV,Ambev S.A. American Depositary Shares (Each representing 1 Common Share),$3.825,0.035,0.923%,60202605630.00,,2013,15089233,Consumer Non-Durables,Beverages (Production/Distribution)
+add,ABG,Asbury Automotive Group Inc Common Stock,$175.50,-4.28,-2.381%,3394048203.00,United States,2002,70780,Consumer Services,Other Specialty Stores
+add,ABM,ABM Industries Incorporated Common Stock,$47.62,-0.92,-1.895%,3194811324.00,United States,,216234,Technology,Diversified Commercial Services
+add,ABR,Arbor Realty Trust Common Stock,$19.075,-0.145,-0.754%,2569189470.00,United States,2004,864337,Consumer Services,Real Estate Investment Trusts
+add,ABR^A,Arbor Realty Trust Preferred Series A,$25.105,-0.0047,-0.019%,,United States,,15294,,
+add,ABR^B,Arbor Realty Trust Cumulative Redeemable Preferred Series B,$25.09,-0.01,-0.04%,,United States,,2672,,
+add,ABR^C,Arbor Realty Trust Cumulative Redeemable Preferred Series C,$25.08,-0.01,-0.04%,,United States,,3015,,
+add,ABR^D,Arbor Realty Trust 6.375% Series D Cumulative Redeemable Preferred Stock Liquidation Preference $25.00 per Share,$25.56,0.04,0.157%,,United States,,125661,,
+add,ABT,Abbott Laboratories Common Stock,$110.14,1.09,1.00%,195698971101.00,United States,,5682627,Health Care,Medical/Dental Instruments
+add,AC,Associated Capital Group Inc. Common Stock,$38.75,0.04,0.103%,857190494.00,United States,2015,9406,Finance,Investment Bankers/Brokers/Service
+add,ACA,Arcosa Inc. Common Stock ,$60.04,-1.17,-1.911%,2892377887.00,,2018,128139,Capital Goods,Engineering & Construction
+add,ACC,American Campus Communities Inc Common Stock,$48.70,-0.03,-0.062%,6714064070.00,United States,2004,414545,Consumer Services,Real Estate Investment Trusts
+add,ACCO,Acco Brands Corporation Common Stock,$9.1075,-0.1825,-1.964%,869692088.00,United States,,160800,Consumer Services,Advertising
+add,ACEL,Accel Entertainment Inc. ,$12.63,-0.05,-0.394%,1179513439.00,United States,2017,129081,Consumer Services,Recreational Products/Toys
+add,ACH,Aluminum Corporation of China Limited American Depositary Shares,$13.6799,0.0899,0.662%,9314738548.00,China,2001,54806,Basic Industries,Aluminum
+add,ACI,Albertsons Companies Inc. Class A Common Stock,$20.895,-0.065,-0.31%,9747812391.00,United States,2020,1114636,Consumer Services,Food Chains
+add,ACIC,Atlas Crest Investment Corp. Class A Common Stock,$10.185,0.025,0.246%,636562500.00,United States,2020,1174643,,
+add,ACII,Atlas Crest Investment Corp. II Class A Common Stock,$9.79,-0.02,-0.204%,422193750.00,,2021,24113,,
+add,ACM,AECOM Common Stock,$63.80,-0.65,-1.009%,9339868806.00,United States,2007,489273,Consumer Services,Military/Government/Technical
+add,ACN,Accenture plc Class A Ordinary Shares (Ireland),$284.29,2.18,0.773%,180708143909.00,Ireland,2001,1243562,Technology,EDP Services
+add,ACND,Ascendant Digital Acquisition Corp. Class A Ordinary Shares,$9.98,0.01,0.10%,516465000.00,United States,2020,106167,Finance,Business Services
+add,ACP,Aberdeen Income Credit Strategies Fund Common Shares,$11.29,-0.08,-0.704%,196860806.00,United States,2011,396347,,
+add,ACP^A,Aberdeen Income Credit Strategies Fund 5.250% Series A Perpetual Preferred Stock,$26.16,-0.03,-0.115%,,United States,,19567,,
+add,ACR,ACRES Commercial Realty Corp. Common Stock,$17.68,-0.29,-1.614%,163547974.00,United States,,27001,Consumer Services,Real Estate Investment Trusts
+add,ACR^C,ACRES Commercial Realty Corp. 8.625% Fixed-to-Floating Series C Cumulative Redeemable Preferred Stock ,$25.4505,-0.0295,-0.116%,,United States,,10373,,
+add,ACR^D,ACRES Commercial Realty Corp. 7.875% Series D Cumulative Redeemable Preferred Stock,$25.075,0.155,0.622%,,United States,,32418,,
+add,ACRE,Ares Commercial Real Estate Corporation Common Stock,$16.61,-0.19,-1.131%,672723620.00,United States,2012,292290,Consumer Services,Real Estate Investment Trusts
+add,ACV,Virtus AllianzGI Diversified Income & Convertible Fund Common Shares of Beneficial Interest,$33.28,-0.11,-0.329%,344578458.00,United States,2015,25766,,
+add,ADC,Agree Realty Corporation Common Stock,$73.59,0.14,0.191%,4720475293.00,United States,,124228,Consumer Services,Real Estate Investment Trusts
+add,ADCT,ADC Therapeutics SA Common Shares,$22.33,0.69,3.189%,1713308037.00,,2020,224473,Health Care,Major Pharmaceuticals
+add,ADEX,Adit EdTech Acquisition Corp. Common Stock,$9.68,-0.01,-0.103%,333960000.00,,2021,15142,,
+add,ADF,Aldel Financial Inc. Class A Common Stock,$9.78,-0.02,-0.204%,146186550.00,,2021,43100,,
+add,ADM,Archer-Daniels-Midland Company Common Stock,$67.19,-0.92,-1.351%,37539194771.00,United States,,1080627,,
+add,ADNT,Adient plc Ordinary Shares ,$47.43,-1.33,-2.728%,4468299906.00,,2016,308882,Capital Goods,Auto Parts:O.E.M.
+add,ADS,Alliance Data Systems Corporation Common Stock,$111.80,-3.68,-3.187%,5559102728.00,United States,2001,631833,Finance,Diversified Financial Services
+add,ADT,ADT Inc. Common Stock,$11.49,-0.02,-0.174%,9533173696.00,United States,2018,2021912,Consumer Services,Diversified Commercial Services
+add,ADX,Adams Diversified Equity Fund Inc.,$19.53,0.05,0.257%,2167535136.00,United States,,66561,,
+add,AEB,AEGON N.V. Perp. Cap. Secs. Floating Rate (Netherlands),$25.47,-0.035,-0.137%,0.00,Netherlands,,11296,Finance,Life Insurance
+add,AEE,Ameren Corporation Common Stock,$86.035,0.675,0.791%,21986469576.00,United States,,991789,Public Utilities,Power Generation
+add,AEFC,Aegon Funding Company LLC 5.10% Subordinated Notes due 2049,$26.52,0.02,0.075%,0.00,,2019,41554,,
+add,AEG,AEGON N.V. Common Stock,$4.48,-0.03,-0.665%,9463593108.00,Netherlands,,1022920,Finance,Life Insurance
+add,AEL,American Equity Investment Life Holding Company Common Stock,$31.88,-0.40,-1.239%,3042254427.00,United States,2003,434122,Finance,Life Insurance
+add,AEL^A,American Equity Investment Life Holding Company Depositary Shares each representing a 1/1000th interest in a share of 5.95% Fixed-Rate Reset Non-Cumulative Preferred Stock Series A,$27.57,0.13,0.474%,,United States,,15268,,
+add,AEL^B,American Equity Investment Life Holding Company Depositary Shares each representing a 1/1000th interest in a share of 6.625% Fixed-Rate Reset Non-Cumulative Preferred Stock Series B,$28.30,-0.07,-0.247%,,United States,,17221,,
+add,AEM,Agnico Eagle Mines Limited Common Stock,$72.28,1.57,2.22%,17566909588.00,Canada,,730804,Basic Industries,Precious Metals
+add,AENZ,Aenza S.A.A. American Depositary Shares,$1.47,-0.04,-2.649%,256343849.00,,2018,135179,Capital Goods,Engineering & Construction
+add,AEO,American Eagle Outfitters Inc. Common Stock,$33.285,-0.395,-1.173%,5582453755.00,United States,,2402635,Consumer Services,Clothing/Shoe/Accessory Stores
+add,AER,AerCap Holdings N.V. Ordinary Shares,$57.64,-0.05,-0.087%,7535533179.00,Netherlands,2006,494963,Technology,Diversified Commercial Services
+add,AES,The AES Corporation Common Stock,$25.40,0.20,0.794%,16922936284.00,United States,,2793366,Public Utilities,Electric Utilities: Central
+add,AESC,The AES Corporation Corporate Units,$105.48,1.01,0.967%,0.00,United States,,31237,Public Utilities,Electric Utilities: Central
+add,AEVA,Aeva Technologies Inc. Common Stock,$11.52,0.21,1.857%,2435440343.00,,2020,1376472,Capital Goods,Auto Parts:O.E.M.
+add,AFB,AllianceBernstein National Municipal Income Fund Inc,$14.79,-0.03,-0.202%,425137603.00,United States,2002,49273,,
+add,AFG,American Financial Group Inc. Common Stock,$124.595,0.585,0.472%,10602989397.00,United States,,409135,Finance,Property-Casualty Insurers
+add,AFGB,American Financial Group Inc. 5.875% Subordinated Debentures due 2059,$28.4475,-0.1725,-0.603%,0.00,United States,2019,7081,Finance,Property-Casualty Insurers
+add,AFGC,American Financial Group Inc. 5.125% Subordinated Debentures due 2059,$26.93,-0.02,-0.074%,26877756.00,United States,2019,31810,Finance,Real Estate
+add,AFGD,American Financial Group Inc. 5.625% Subordinated Debentures due 2060,$28.13,-0.06,-0.213%,0.00,United States,2020,19850,,
+add,AFGE,American Financial Group Inc. 4.500% Subordinated Debentures due 2060,$27.32,0.05,0.183%,0.00,United States,2020,2389,,
+add,AFI,Armstrong Flooring Inc. Common Stock,$5.94,-0.15,-2.463%,128814020.00,,2016,79315,Capital Goods,Building Products
+add,AFL,AFLAC Incorporated Common Stock,$56.245,-0.345,-0.61%,38227883576.00,United States,,1185729,Finance,Accident &Health Insurance
+add,AFT,Apollo Senior Floating Rate Fund Inc. Common Stock,$15.31,-0.03,-0.196%,238423564.00,,2011,48264,,
+add,AG,First Majestic Silver Corp. Ordinary Shares (Canada),$18.29,0.80,4.574%,4600053757.00,Canada,,4806524,Basic Industries,Precious Metals
+add,AGAC,African Gold Acquisition Corporation Class A Ordinary Shares,$9.655,0.006,0.062%,499646250.00,,2021,5978,Finance,Business Services
+add,AGCB,Altimeter Growth Corp. 2 Class A Ordinary Shares,$10.55,0.04,0.381%,605042500.00,,2021,41392,Finance,Business Services
+add,AGCO,AGCO Corporation Common Stock,$130.025,-3.255,-2.442%,9797575147.00,United States,,484631,Capital Goods,Industrial Machinery/Components
+add,AGD,Aberdeen Global Dynamic Dividend Fund,$12.35,-0.03,-0.242%,154987325.00,United States,2006,34100,,
+add,AGI,Alamos Gold Inc. Class A Common Shares,$8.87,0.27,3.14%,3483597866.00,Canada,2015,1620222,Basic Industries,Precious Metals
+add,AGL,agilon health inc. Common Stock,$37.205,0.215,0.581%,14540925395.00,,2021,591194,Health Care,Managed Health Care
+add,AGM,Federal Agricultural Mortgage Corporation Common Stock,$101.53,0.47,0.465%,1092658042.00,United States,,27614,Finance,Finance Companies
+add,AGM^C,Federal Agricultural Mortgage Corporation Preferred Series C Fixed to Fltg,$27.41,0.1775,0.652%,,United States,,5573,,
+add,AGM^D,Federal Agricultural Mortgage Corporation 5.700% Non-Cumulative Preferred Stock Series D,$26.85,0.0928,0.347%,,United States,,1208,,
+add,AGM^E,Federal Agricultural Mortgage Corporation 5.750% Non-Cumulative Preferred Stock Series E,$27.10,0.10,0.37%,,United States,,11248,,
+add,AGM^F,Federal Agricultural Mortgage Corporation 5.250% Non-Cumulative Preferred Stock Series F,$26.7273,-0.0127,-0.047%,,United States,,150,,
+add,AGM^G,Federal Agricultural Mortgage Corporation 4.875% Non-Cumulative Preferred Stock Series G,$25.81,0.01,0.039%,,United States,,40346,,
+add,AGO,Assured Guaranty Ltd. Common Stock,$47.00,-1.01,-2.104%,3538630000.00,Bermuda,2004,253023,Finance,Property-Casualty Insurers
+add,AGO^B,Assured Guaranty Ltd.,$26.90,0.10,0.373%,,Bermuda,,516,,
+add,AGO^E,Assured Guaranty Ltd.,$25.6395,0.0295,0.115%,,Bermuda,,8626,,
+add,AGO^F,Assured Guaranty Ltd.,$25.7667,0.0567,0.221%,,Bermuda,,3133,,
+add,AGR,Avangrid Inc. Common Stock,$55.00,0.48,0.88%,21295499830.00,United States,2015,261107,Public Utilities,Electric Utilities: Central
+add,AGRO,Adecoagro S.A. Common Shares,$11.43,-0.07,-0.609%,1338293552.00,Luxembourg,2011,935898,,
+add,AGS,PlayAGS Inc. Common Stock,$10.18,-0.32,-3.048%,372891965.00,United States,2018,126444,Consumer Services,Recreational Products/Toys
+add,AGTI,Agiliti Inc. Common Stock,$21.00,0.02,0.095%,2735911332.00,,2021,324465,Health Care,Managed Health Care
+add,AGX,Argan Inc. Common Stock,$48.70,-0.49,-0.996%,767809411.00,United States,,71503,Capital Goods,Oilfield Services/Equipment
+add,AHC,A.H. Belo Corporation (TX) Common Stock,$6.62,-0.17,-2.504%,35434245.00,United States,,38643,Consumer Services,Newspapers/Magazines
+add,AHH,Armada Hoffler Properties Inc. Common Stock,$13.56,0.14,1.043%,817812984.00,United States,2013,374091,Consumer Services,Real Estate Investment Trusts
+add,AHH^A,Armada Hoffler Properties Inc. 6.75% Series A Cumulative Redeemable Perpetual Preferred Stock,$26.76,0.18,0.677%,,United States,,6224,,
+add,AHL^C,Aspen Insurance Holdings Limited 5.95% Fixed-to-Floating Rate Perpetual Non-Cumulative Preference Shares,$26.92,0.21,0.786%,,Bermuda,,17838,,
+add,AHL^D,Aspen Insurance Holdings Limited 5.625% Perpetual Non-Cumulative Preference Shares,$26.83,0.19,0.713%,,Bermuda,,17403,,
+add,AHL^E,Aspen Insurance Holdings Limited Depositary Shares each representing a 1/1000th interest in a share of 5.625% Perpetual Non-Cumulative Preference Shares,$26.455,0.175,0.666%,,Bermuda,,14769,,
+add,AHT,Ashford Hospitality Trust Inc Common Stock,$6.17,-0.50,-7.496%,947767357.00,United States,2003,84369594,Consumer Services,Real Estate Investment Trusts
+add,AHT^D,Ashford Hospitality Trust Inc 8.45% Series D Cumulative Preferred Stock,$27.35,0.33,1.221%,,United States,,12622,,
+add,AHT^F,Ashford Hospitality Trust Inc 7.375% Series F Cumulative Preferred Stock,$26.77,-0.06,-0.224%,,United States,,736,,
+add,AHT^G,Ashford Hospitality Trust Inc 7.375% Series G Cumulative Preferred Stock,$26.81,-0.19,-0.704%,,United States,,6252,,
+add,AHT^H,Ashford Hospitality Trust Inc 7.50% Series H Cumulative Preferred Stock,$26.80,-0.22,-0.814%,,United States,,5978,,
+add,AHT^I,Ashford Hospitality Trust Inc 7.50% Series I Cumulative Preferred Stock,$26.7066,-0.2234,-0.83%,,United States,,26285,,
+add,AI,C3.ai Inc. Class A Common Stock,$58.20,-3.90,-6.28%,5936092762.00,,2020,7670999,Technology,Computer Software: Prepackaged Software
+add,AIC,Arlington Asset Investment Corp 6.750% Notes due 2025,$25.3275,-0.0725,-0.285%,0.00,United States,2015,692,Consumer Services,Real Estate Investment Trusts
+add,AIF,Apollo Tactical Income Fund Inc. Common Stock,$15.24,0.00,0.00%,220431756.00,,2013,18910,,
+add,AIG,American International Group Inc. New Common Stock,$51.665,-0.495,-0.949%,44510727047.00,United States,,1615039,Finance,Life Insurance
+add,AIG^A,American International Group Inc. Depositary Shares Each Representing a 1/1000th Interest in a Share of Series A 5.85% Non-Cumulative Perpetual Preferred Stock,$28.03,0.135,0.484%,,United States,,18197,,
+add,AIN,Albany International Corporation Common Stock,$87.78,0.21,0.24%,2835294000.00,United States,,62280,Basic Industries,Textiles
+add,AIO,Virtus AllianzGI Artificial Intelligence & Technology Opportunities Fund Common Shares,$27.42,0.11,0.403%,941566660.00,,2019,59127,,
+add,AIR,AAR Corp. Common Stock,$39.8001,-0.4599,-1.142%,1405719154.00,United States,,264377,Capital Goods,Aerospace
+add,AIRC,Apartment Income REIT Corp. Common Stock,$50.055,0.045,0.09%,7849909112.00,,2020,295653,Consumer Services,Real Estate Investment Trusts
+add,AIT,Applied Industrial Technologies Inc. Common Stock,$94.00,-1.64,-1.715%,3652782378.00,United States,,43926,Capital Goods,Industrial Machinery/Components
+add,AIV,Apartment Investment and Management Company Common Stock,$7.61,0.01,0.132%,1142005159.00,United States,1994,2284060,Consumer Services,Real Estate Investment Trusts
+add,AIW,Arlington Asset Investment Corp 6.625% Notes due 2023,$25.3501,-0.1299,-0.51%,0.00,United States,,547,Consumer Services,Real Estate Investment Trusts
+add,AIZ,Assurant Inc. Common Stock,$162.34,-0.42,-0.258%,9832387201.00,United States,2004,194883,Finance,Specialty Insurers
+add,AIZN,Assurant Inc. 5.25% Subordinated Notes due 2061,$26.695,0.1249,0.47%,0.00,United States,2020,1568,Finance,Accident &Health Insurance
+add,AJAX,Ajax I Class A Ordinary Shares,$9.98,0.02,0.201%,892645461.00,United States,2020,337920,Finance,Business Services
+add,AJG,Arthur J. Gallagher & Co. Common Stock,$144.42,0.03,0.021%,29784744652.00,United States,,435369,Finance,Specialty Insurers
+add,AJRD,Aerojet Rocketdyne Holdings Inc. Common Stock,$48.97,0.39,0.803%,3921790706.00,United States,,1026854,Capital Goods,Military/Government/Technical
+add,AJX,Great Ajax Corp. Common Stock,$12.89,-0.18,-1.377%,296326238.00,United States,2015,36701,Consumer Services,Real Estate Investment Trusts
+add,AJXA,Great Ajax Corp. 7.25% Convertible Senior Notes due 2024,$26.35,0.00,0.00%,0.00,United States,2017,10,Consumer Services,Real Estate Investment Trusts
+add,AKO/A,Embotelladora Andina S.A.,$12.5699,0.0999,0.801%,,Chile,,1035,,
+add,AKO/B,Embotelladora Andina S.A.,$13.75,-0.2317,-1.657%,,Chile,,25153,,
+add,AKR,Acadia Realty Trust Common Stock,$22.60,-0.17,-0.747%,1950522403.00,United States,,302224,Consumer Services,Real Estate Investment Trusts
+add,AL,Air Lease Corporation Class A Common Stock,$45.855,-0.215,-0.467%,5233175646.00,United States,2011,300419,Technology,Diversified Commercial Services
+add,AL^A,Air Lease Corporation 6.150% Fixed-to-Floating Rate Non-Cumulative Perpetual Preferred Stock Series A,$27.11,0.01,0.037%,,United States,,8593,,
+add,ALB,Albemarle Corporation Common Stock,$167.995,-6.375,-3.656%,19608683159.00,United States,,649987,Basic Industries,Major Chemicals
+add,ALC,Alcon Inc. Ordinary Shares,$70.15,0.89,1.285%,35053955000.00,Switzerland,2019,560959,Health Care,Ophthalmic Goods
+add,ALE,Allete Inc.,$70.155,0.275,0.394%,3661312911.00,United States,,85093,Public Utilities,Power Generation
+add,ALEX,Alexander & Baldwin Inc. Common Stock REIT Holding Company,$19.69,-0.35,-1.747%,1426928039.00,United States,,104544,Consumer Services,Real Estate Investment Trusts
+add,ALG,Alamo Group Inc. Common Stock,$149.50,-1.44,-0.954%,1782520194.00,United States,,19279,Capital Goods,Industrial Machinery/Components
+add,ALIN^A,Altera Infrastructure L.P. 7.25% Series A ,$21.90,0.00,0.00%,,Bermuda,,9399,,
+add,ALIN^B,Altera Infrastructure L.P. 8.50% Series B ,$22.75,0.04,0.176%,,Bermuda,,14949,,
+add,ALIN^E,Altera Infrastructure L.P. 8.875% Series E ,$23.35,0.05,0.215%,,Bermuda,,1820,,
+add,ALK,Alaska Air Group Inc. Common Stock,$64.83,-0.79,-1.204%,8070154640.00,United States,,1201415,Transportation,Air Freight/Delivery Services
+add,ALL,Allstate Corporation (The) Common Stock,$131.52,-1.51,-1.135%,39369023720.00,United States,,866559,Finance,Property-Casualty Insurers
+add,ALL^B,Allstate Corporation (The) 5.100% Fixed-to-Floating Rate Subordinated Debentures due 2053,$26.98,-0.17,-0.626%,,United States,,20895,,
+add,ALL^G,Allstate Corporation (The) Depositary Shares each representing a 1/1000th interest in a share of Fixed Rate Noncumulative Perpetual Preferred Stock Series G,$27.885,0.065,0.234%,,United States,,25267,,
+add,ALL^H,Allstate Corporation (The) Depositary Shares each representing a 1/1000th interest in a share of Fixed Rate Noncumulative Perpetual Preferred Stock Series H,$27.95,0.12,0.431%,,United States,,43527,,
+add,ALL^I,Allstate Corporation (The) Depositary Shares each representing a 1/1000th interest in a share of Fixed Rate Noncumulative Perpetual Preferred Stock Series I,$27.33,-0.02,-0.073%,,United States,,14649,,
+add,ALLE,Allegion plc Ordinary Shares,$138.85,0.76,0.55%,12493458768.00,United States,2013,590258,Consumer Services,Diversified Commercial Services
+add,ALLY,Ally Financial Inc. Common Stock,$54.0633,-0.6267,-1.146%,20040215022.00,United States,2014,2839937,Finance,Diversified Financial Services
+add,ALLY^A,GMAC Capital Trust I Fixed Rate Floating Rate Trust Preferred Securities Series 2,$25.57,0.05,0.196%,,United States,,52482,,
+add,ALP^Q,Alabama Power Company 5.00% Class A Preferred Stock Cumulative Par Value $1 Per Share (Stated Capital $25 Per Share),$26.90,0.06,0.224%,,United States,,44692,,
+add,ALSN,Allison Transmission Holdings Inc. Common Stock,$41.50,-0.49,-1.167%,4546109864.00,United States,2012,1761772,Capital Goods,Auto Parts:O.E.M.
+add,ALTG,Alta Equipment Group Inc. Class A Common Stock,$13.03,-0.38,-2.834%,420847839.00,,2019,105505,Technology,Engineering & Construction
+add,ALTG^A,Alta Equipment Group Inc. Depositary Shares (each representing 1/1000th in a share of 10% Series A Cumulative Perpetual Preferred Stock),$27.54,-0.01,-0.036%,,,,6124,,
+add,ALUS,Alussa Energy Acquisition Corp. Class A Ordinary Shares,$10.08,0.01,0.099%,362250000.00,,2020,651191,Finance,Business Services
+add,ALV,Autoliv Inc. Common Stock,$104.01,0.16,0.154%,9092798624.00,Sweden,,178033,Capital Goods,Auto Parts:O.E.M.
+add,ALX,Alexander's Inc. Common Stock,$283.985,-0.235,-0.083%,1450393751.00,United States,,4733,Consumer Services,Real Estate Investment Trusts
+add,AM,Antero Midstream Corporation Common Stock,$10.39,0.09,0.874%,4959748373.00,United States,2017,3199920,Public Utilities,Natural Gas Distribution
+add,AMBC,Ambac Financial Group Inc. Common Stock,$15.55,-0.15,-0.955%,718364952.00,United States,,190458,Finance,Property-Casualty Insurers
+add,AMC,AMC Entertainment Holdings Inc. Class A Common Stock,$42.70,-6.64,-13.458%,21426016248.00,,2013,215870069,Consumer Services,Movies/Entertainment
+add,AMCR,Amcor plc Ordinary Shares,$12.065,-0.005,-0.041%,18601731918.00,,2019,2704099,Basic Industries,Containers/Packaging
+add,AME,AMETEK Inc.,$136.36,0.65,0.479%,31488138839.00,United States,,536548,Consumer Durables,Metal Fabrications
+add,AMG,Affiliated Managers Group Inc. Common Stock,$159.80,-1.06,-0.659%,6653538907.00,United States,,129704,Finance,Investment Managers
+add,AMH,American Homes 4 Rent Common Shares of Beneficial Interest,$39.25,0.45,1.16%,12669937641.00,,2013,707969,Consumer Services,Real Estate Investment Trusts
+add,AMH^E,American Homes 4 Rent 6.35% Series E Cumulative Redeemable Perpetual Preferred Shares of Beneficial Interest,$25.363,-0.007,-0.028%,,,,441241,,
+add,AMH^F,American Homes 4 Rent 5.875% Series F Cumulative Redeemable Perpetual Preferred Shares,$26.355,0.0023,0.009%,,,,1679,,
+add,AMH^G,American Homes 4 Rent Series G cumulative redeemable perpetual preferred shares of beneficial interest,$26.695,-0.125,-0.466%,,,,1533,,
+add,AMH^H,American Homes 4 Rent Series H cumulative redeemable perpetual Preferred Shares of Beneficial Interest,$27.75,0.00,0.00%,,,,26257,,
+add,AMK,AssetMark Financial Holdings Inc. Common Stock,$25.78,0.02,0.078%,1867999594.00,United States,2019,49269,Finance,Finance/Investors Services
+add,AMN,AMN Healthcare Services Inc AMN Healthcare Services Inc,$95.48,0.47,0.495%,4512107526.00,United States,,185689,Health Care,Assisted Living Services
+add,AMOV,America Movil S.A.B. de C.V. Class A American Depositary Shares,$15.983,0.2335,1.483%,52928518083.00,Mexico,,1951,Public Utilities,Telecommunications Equipment
+add,AMP,Ameriprise Financial Inc. Common Stock,$257.55,-3.17,-1.216%,29851301586.00,United States,,329565,Finance,Investment Managers
+add,AMPI,Advanced Merger Partners Inc. Class A Common Stock,$9.71,0.00,0.00%,348953125.00,,2021,30,,
+add,AMPY,Amplify Energy Corp. Common Stock,$3.95,0.10,2.597%,150007262.00,United States,2016,484999,Energy,Oil & Gas Production
+add,AMR,Alpha Metallurgical Resources Inc. Common Stock,$23.35,1.00,4.474%,429407481.00,United States,2018,226297,Energy,Coal Mining
+add,AMRC,Ameresco Inc. Class A Common Stock,$57.55,-1.02,-1.742%,2950612959.00,United States,2010,165196,Basic Industries,Water Supply
+add,AMRX,Amneal Pharmaceuticals Inc. Class A Common Stock,$6.06,0.18,3.061%,901246454.00,,2018,819989,Health Care,Major Pharmaceuticals
+add,AMT,American Tower Corporation (REIT) Common Stock,$270.245,3.235,1.212%,122879342950.00,United States,,903694,Consumer Services,Real Estate Investment Trusts
+add,AMWL,American Well Corporation Class A Common Stock,$13.985,0.245,1.783%,3370844435.00,United States,2020,2053782,Technology,Retail: Computer Software & Peripheral Equipment
+add,AMX,America Movil S.A.B. de C.V. American Depository Receipt Series L,$16.21,0.37,2.336%,53680240138.00,Mexico,,2288211,Public Utilities,Telecommunications Equipment
+add,AN,AutoNation Inc. Common Stock,$95.12,-1.38,-1.43%,7655238671.00,United States,,664669,Consumer Services,Other Specialty Stores
+add,ANAC,Arctos NorthStar Acquisition Corp. Class A Ordinary Shares,$9.80,0.00,0.00%,387406250.00,,2021,400,Health Care,Major Pharmaceuticals
+add,ANET,Arista Networks Inc. Common Stock,$367.61,7.88,2.191%,28056662412.00,,2014,442245,Technology,Computer peripheral equipment
+add,ANF,Abercrombie & Fitch Company Common Stock,$40.89,-0.61,-1.47%,2532501828.00,United States,,1000867,Consumer Services,Clothing/Shoe/Accessory Stores
+add,ANTM,Anthem Inc. Common Stock,$383.80,-2.16,-0.56%,93969843005.00,United States,,821439,Health Care,Medical Specialities
+add,AOD,Aberdeen Total Dynamic Dividend Fund Common Stock,$10.405,0.045,0.434%,1097529784.00,United States,2007,391682,,
+add,AON,Aon plc Class A Ordinary Shares (Ireland),$249.74,3.99,1.624%,56353144215.00,United States,,1191746,Finance,Specialty Insurers
+add,AONE,one Class A Ordinary Shares,$10.22,-0.01,-0.098%,274662500.00,United States,2020,198880,Finance,Business Services
+add,AOS,A.O. Smith Corporation Common Stock,$68.02,-0.42,-0.614%,10914233513.00,United States,,532140,Capital Goods,Industrial Machinery/Components
+add,AP,Ampco-Pittsburgh Corporation Common Stock,$6.68,-0.09,-1.329%,125962996.00,United States,,27242,Capital Goods,Metal Fabrications
+add,APAM,Artisan Partners Asset Management Inc. Class A Common Stock,$53.94,1.69,3.234%,4270033449.00,United States,2013,686698,Finance,Investment Managers
+add,APD,Air Products and Chemicals Inc. Common Stock,$298.6299,1.2799,0.43%,66091054735.00,United States,,360924,Basic Industries,Major Chemicals
+add,APG,APi Group Corporation Common Stock,$22.12,-0.63,-2.769%,4452362861.00,,2020,526730,Basic Industries,Engineering & Construction
+add,APGB,Apollo Strategic Growth Capital II Class A Ordinary Shares,$9.83,0.01,0.102%,847837500.00,,2021,28465,Finance,Business Services
+add,APH,Amphenol Corporation Common Stock,$68.195,0.055,0.081%,40754404025.00,United States,,1008659,Capital Goods,Electrical Products
+add,APLE,Apple Hospitality REIT Inc. Common Shares,$16.17,-0.12,-0.737%,3616521789.00,United States,2015,1034543,Consumer Services,Real Estate Investment Trusts
+add,APO,Apollo Global Management Inc. Class A Common Stock,$57.38,0.18,0.315%,13330485565.00,United States,2011,759394,Finance,Investment Managers
+add,APO^A,Apollo Global Management Inc. 6.375% Series A Preferred Shares,$26.11,0.01,0.038%,,United States,,4486,,
+add,APO^B,Apollo Global Management Inc 6.375% Series B Preferred Shares,$27.05,-0.04,-0.148%,,United States,,8716,,
+add,APRN,Blue Apron Holdings Inc. Class A Common Stock,$6.03,0.41,7.295%,108847832.00,United States,2017,2487685,Consumer Services,Catalog/Specialty Distribution
+add,APSG,Apollo Strategic Growth Capital Class A Ordinary Shares,$9.78,-0.10,-1.012%,998550225.00,United States,2020,221901,Finance,Business Services
+add,APTS,Preferred Apartment Communities Inc. Common Stock,$11.11,0.14,1.276%,556550995.00,United States,2011,568981,Consumer Services,Real Estate Investment Trusts
+add,APTV,Aptiv PLC Ordinary Shares,$155.48,-2.85,-1.80%,42051548215.00,United Kingdom,2011,911954,Capital Goods,Auto Parts:O.E.M.
+add,APTV^A,Aptiv PLC 5.50% Series A Mandatory Convertible Preferred Shares,$175.84,-2.60,-1.457%,,United Kingdom,,2479,,
+add,AQN,Algonquin Power & Utilities Corp. Common Shares,$15.955,0.145,0.917%,9761931069.00,,2016,650692,Public Utilities,Electric Utilities: Central
+add,AQNA,Algonquin Power & Utilities Corp. 6.875% Fixed-to-Floating Rate Subordinated Notes Series 2018-A due October 17 2078,$28.23,0.01,0.035%,0.00,,2018,7614,Public Utilities,Electric Utilities: Central
+add,AQNB,Algonquin Power & Utilities Corp. 6.20% Fixed-to-Floating Subordinated Notes Series 2019-A due July 1 2079,$28.50,-0.20,-0.697%,0.00,,2019,10528,Public Utilities,Electric Utilities: Central
+add,AQUA,Evoqua Water Technologies Corp. Common Stock,$32.55,-0.41,-1.244%,3902759062.00,United States,2017,591435,Capital Goods,Office Equipment/Supplies/Services
+add,AR,Antero Resources Corporation Common Stock,$13.365,-0.375,-2.729%,4189781728.00,,2013,4442931,Energy,Oil & Gas Production
+add,ARC,ARC Document Solutions Inc. Common Stock,$2.20,-0.03,-1.345%,93955121.00,United States,2004,468038,Miscellaneous,Business Services
+add,ARCH,Arch Resources Inc. Class A Common Stock,$57.67,-1.28,-2.171%,882008729.00,United States,2016,144377,Energy,Coal Mining
+add,ARCO,Arcos Dorados Holdings Inc. Class A Shares,$6.53,-0.03,-0.457%,1353445498.00,Argentina,2011,173345,Consumer Services,Restaurants
+add,ARD,Ardagh Group S.A. Common Shares,$24.39,-0.32,-1.295%,5765064300.00,,2017,56998,Consumer Durables,Containers/Packaging
+add,ARDC,Ares Dynamic Credit Allocation Fund Inc. Common Shares,$16.01,-0.02,-0.125%,366868173.00,United States,2012,77435,,
+add,ARE,Alexandria Real Estate Equities Inc. Common Stock,$193.3981,2.9781,1.564%,28526855643.00,United States,,414001,Consumer Services,Real Estate Investment Trusts
+add,ARES,Ares Management Corporation Class A Common Stock,$58.635,-0.155,-0.264%,9515427293.00,,2014,238347,Finance,Investment Managers
+add,ARES^A,Ares Management Corporation 7.00% Series A Preferred Stock,$25.40,-0.06,-0.236%,,,,81945,,
+add,ARGD,Argo Group International Holdings Ltd. 6.5% Senior Notes Due 2042,$25.58,0.0251,0.098%,0.00,Bermuda,,4093,Finance,Specialty Insurers
+add,ARGO,Argo Group International Holdings Ltd.,$53.34,0.18,0.339%,1856379698.00,Bermuda,,65463,Finance,Specialty Insurers
+add,ARGO^A,Argo Group International Holdings Ltd. Depositary Shares Each Representing a 1/1000th Interest in a 7.00% Resettable Fixed Rate Preference Share Series A,$27.74,-0.06,-0.216%,,Bermuda,,10132,,
+add,ARI,Apollo Commercial Real Estate Finance Inc,$16.39,-0.14,-0.847%,2292699743.00,United States,2009,495293,Consumer Services,Real Estate Investment Trusts
+add,ARL,American Realty Investors Inc. Common Stock,$12.42,0.22,1.803%,200608374.00,United States,,4929,Consumer Services,Building operators
+add,ARLO,Arlo Technologies Inc. Common Stock,$6.805,-0.085,-1.234%,553078947.00,United States,2018,289329,Miscellaneous,Diversified Manufacture
+add,ARMK,Aramark Common Stock,$37.57,0.35,0.94%,9578155536.00,,2013,1181910,Consumer Services,Restaurants
+add,ARNC,Arconic Corporation Common Stock ,$37.08,-0.31,-0.829%,4079985744.00,,2020,698785,,
+add,AROC,Archrock Inc. Common Stock,$9.465,-0.015,-0.158%,1458121167.00,United States,,491643,Energy,Oil & Gas Production
+add,ARR,ARMOUR Residential REIT Inc.,$12.145,-0.015,-0.123%,865258696.00,United States,,1643931,Consumer Services,Real Estate Investment Trusts
+add,ARR^C,ARMOUR Residential REIT Inc. 7% Series C Cumulative Redeemable Preferred Stock (liquidation preference $25.00 per share),$25.89,0.14,0.544%,,United States,,13606,,
+add,ARW,Arrow Electronics Inc. Common Stock,$121.425,0.315,0.26%,8959104661.00,United States,,278491,Technology,Electronic Components
+add,ASA,ASA  Gold and Precious Metals Limited,$24.68,0.67,2.791%,476074855.00,United States,,44594,Basic Industries,Precious Metals
+add,ASAI,Sendas Distribuidora S.A. ADS,$16.78,0.19,1.145%,4502939294.00,,2021,71485,Consumer Services,Food Chains
+add,ASAN,Asana Inc. Class A Common Stock,$45.9319,4.7819,11.621%,7515897978.00,,2020,4892249,Technology,Retail: Computer Software & Peripheral Equipment
+add,ASAQ,Atlantic Street Acquisition Corp Class A Common Stock,$9.73,0.00,0.00%,304062500.00,United States,2020,112296,,
+add,ASB,Associated Banc-Corp Common Stock,$22.17,-0.32,-1.423%,3387753803.00,United States,,575350,Finance,Major Banks
+add,ASB^C,Associated Banc-Corp Depositary shares each representing a 1/40th ownership interest in a share of 6.125% Non-Cumulative Perpetual Preferred Stock Series C,$25.00,0.00,0.00%,,United States,,1,,
+add,ASB^D,Associated Banc-Corp Depositary Shares each representing a 1/40th interest in a share of Associated Banc-Corp 5.375% Non-Cumulative Perpetual Preferred Stock Series D,$25.585,-0.02,-0.078%,,United States,,1989,,
+add,ASB^E,Associated Banc-Corp Depositary Shares each representing a 1/40th interest in a share of 5.875% Non-Cumulative Perpetual Preferred Stock Series E,$27.29,-0.20,-0.728%,,United States,,2015,,
+add,ASB^F,Associated Banc-Corp Depositary Shares each representing a 1/40th interest in a share of Associated Banc-Corp 5.625% Non-Cumulative Perpetual Preferred Stock Series F,$28.42,-0.41,-1.422%,,United States,,16938,,
+add,ASC,Ardmore Shipping Corporation Common Stock,$4.26,0.01,0.235%,142008689.00,,2013,215930,Transportation,Marine Transportation
+add,ASG,Liberty All-Star Growth Fund Inc.,$8.716,0.036,0.415%,371677286.00,United States,,141212,,
+add,ASGI,Aberdeen Standard Global Infrastructure Income Fund Common Shares of Beneficial Interest,$21.65,-0.05,-0.23%,189141155.00,,2020,15796,,
+add,ASGN,ASGN Incorporated Common Stock,$99.77,-0.46,-0.459%,5307764000.00,United States,1992,108366,Technology,Diversified Commercial Services
+add,ASH,Ashland Global Holdings Inc. Common Stock,$92.565,-1.195,-1.275%,5619519329.00,United States,,739044,Basic Industries,Specialty Chemicals
+add,ASIX,AdvanSix Inc. Common Stock ,$30.53,-0.82,-2.616%,856398740.00,United States,2016,75349,Basic Industries,Major Chemicals
+add,ASPL,Aspirational Consumer Lifestyle Corp. Class A Ordinary Shares,$10.07,0.06,0.599%,301780680.00,Singapore,2020,235388,Transportation,Transportation Services
+add,ASPN,Aspen Aerogels Inc. Common Stock,$21.425,-0.645,-2.923%,607404578.00,United States,2014,70738,Capital Goods,Wholesale Distributors
+add,ASR,Grupo Aeroportuario del Sureste S.A. de C.V. Common Stock,$185.81,3.45,1.892%,5574300000.00,Mexico,,46795,Transportation,Aerospace
+add,ASX,ASE Technology Holding Co. Ltd. American Depositary Shares (each representing Two Common Shares) ,$8.71,0.35,4.187%,7501900406.00,,2018,3263338,Technology,Semiconductors
+add,ASZ,Austerlitz Acquisition Corporation II Class A Ordinary Shares,$9.7964,-0.0336,-0.342%,1931290275.00,,2021,546832,,
+add,ATA,Americas Technology Acquisition Corp. Ordinary Shares,$10.01,0.02,0.20%,145145000.00,,2021,6226,Finance,Business Services
+add,ATAQ,Altimar Acquisition Corp. III Class A Ordinary Shares,$9.90,0.05,0.508%,192121875.00,,2021,24245,,
+add,ATC,Atotech Limited Common Shares,$23.71,-0.03,-0.126%,4615487139.00,,2021,291502,Basic Industries,Major Chemicals
+add,ATCO,Atlas Corp. Common Shares,$13.64,0.05,0.368%,3366507169.00,United Kingdom,,492492,Transportation,Marine Transportation
+add,ATCO^D,Atlas Corp. 7.95% Series D,$25.71,0.07,0.273%,,United Kingdom,,2648,,
+add,ATCO^E,Atlas Corp. 8.25% Series E,$25.735,0.0224,0.087%,,United Kingdom,,5949,,
+add,ATCO^G,Atlas Corp. 8.20% Series G,$25.60,-0.04,-0.156%,,United Kingdom,,7624,,
+add,ATCO^H,Atlas Corp. 7.875% Series H,$25.58,-0.03,-0.117%,,United Kingdom,,7111,,
+add,ATCO^I,Atlas Corp. Series I Fixed-to-Floating ,$26.7722,-0.0778,-0.29%,,United Kingdom,,8569,,
+add,ATEN,A10 Networks Inc. Common Stock,$10.54,0.28,2.729%,815116275.00,,2014,375356,Technology,EDP Services
+add,ATGE,Adtalem Global Education Inc. Common Stock,$38.845,0.905,2.385%,1919890663.00,United States,,155681,Miscellaneous,Other Consumer Services
+add,ATH,Athene Holding Ltd. Class A Common Shares,$62.695,0.165,0.264%,12021316163.00,Bermuda,2016,752980,Finance,Life Insurance
+add,ATH^A,Athene Holding Ltd. Depositary Shares Each Representing a 1/1000th Interest in a 6.35% Fixed-to-Floating Rate Perpetual Non-Cumulative Preference Share Series A,$29.235,0.065,0.223%,,Bermuda,,62885,,
+add,ATH^B,Athene Holding Ltd. Depositary Shares Each Representing a 1/1000th Interest in a 5.625% Fixed Rate Perpetual Non- Cumulative Preference Share Series B par value $1.00 per share,$27.2493,0.0698,0.257%,,Bermuda,,27900,,
+add,ATH^C,Athene Holding Ltd. Depositary Shares each representing a 1/1000th Interest in a Share of 6.375% Fixed-Rate Reset Perpetual Non-Cumulative Preference Shares Series C,$28.50,0.04,0.141%,,Bermuda,,57640,,
+add,ATH^D,Athene Holding Ltd. Depositary Shares Each Representing a 1/1000th Interest in a 4.875% Fixed-Rate Perpetual Non-Cumulative Preference Share Series D,$25.5451,0.0651,0.255%,,Bermuda,,68989,,
+add,ATHM,Autohome Inc. American Depositary Shares each representing four class A ordinary shares.,$71.54,0.87,1.231%,8941035934.00,,2013,307984,,
+add,ATHN,Athena Technology Acquisition Corp. Class A Common Stock,$9.73,-0.02,-0.205%,326603670.00,,2021,971,,
+add,ATI,Allegheny Technologies Incorporated Common Stock,$23.76,-0.86,-3.493%,3022344991.00,United States,,589323,Basic Industries,Steel/Iron Ore
+add,ATKR,Atkore Inc. Common Stock,$74.63,-3.09,-3.976%,3506438085.00,United States,2016,288539,Technology,Electrical Products
+add,ATMR,Altimar Acquisition Corp. II Class A Ordinary Shares,$9.78,0.02,0.205%,421762500.00,,2021,33247,Finance,Business Services
+add,ATO,Atmos Energy Corporation Common Stock,$101.29,0.14,0.138%,13235761208.00,United States,,323453,Public Utilities,Oil/Gas Transmission
+add,ATR,AptarGroup Inc. Common Stock,$144.86,2.69,1.892%,9519467078.00,United States,,130249,Capital Goods,Office Equipment/Supplies/Services
+add,ATTO,Atento S.A. Ordinary Shares,$20.565,0.425,2.11%,308475000.00,,2014,2925,Public Utilities,Telecommunications Equipment
+add,ATUS,Altice USA Inc. Class A Common Stock,$35.38,0.89,2.58%,16268240088.00,United States,2017,3122542,Public Utilities,Telecommunications Equipment
+add,AU,AngloGold Ashanti Limited Common Stock,$22.25,0.63,2.914%,9284320668.00,South Africa,,2402738,Basic Industries,Precious Metals
+add,AUD,Audacy Common Stock,$4.365,-0.155,-3.429%,615841446.00,United States,,237693,Consumer Services,Broadcasting
+add,AUS,Austerlitz Acquisition Corporation I Class A Ordinary Shares,$9.97,0.02,0.201%,982757157.00,,2021,491830,,
+add,AUY,Yamana Gold Inc. Ordinary Shares (Canada),$5.20,0.13,2.564%,5020850115.00,Canada,,8706736,Basic Industries,Precious Metals
+add,AVA,Avista Corporation Common Stock,$45.19,0.34,0.758%,3132316290.00,United States,,207768,Public Utilities,Power Generation
+add,AVAL,Grupo Aval Acciones y Valores S.A. ADR (Each representing 20 preferred shares),$5.96,0.07,1.188%,6639743108.00,,2014,21632,Finance,Commercial Banks
+add,AVAN,Avanti Acquisition Corp. Class A Ordinary Shares,$9.75,-0.03,-0.307%,731250000.00,Cayman Islands,2020,182401,Finance,Business Services
+add,AVB,AvalonBay Communities Inc. Common Stock,$214.62,3.86,1.831%,29961947193.00,United States,,1544070,Consumer Services,Real Estate Investment Trusts
+add,AVD,American Vanguard Corporation Common Stock ($0.10 Par Value),$17.71,-0.19,-1.061%,545972044.00,United States,,51850,Basic Industries,Agricultural Chemicals
+add,AVK,Advent Convertible and Income Fund,$19.0984,-0.1616,-0.839%,659376500.00,United States,2003,200806,,
+add,AVLR,Avalara Inc. Common Stock,$134.675,4.355,3.342%,11577937968.00,United States,2018,658382,Technology,EDP Services
+add,AVNS,Avanos Medical Inc. Common Stock,$40.02,0.41,1.035%,1923851565.00,United States,2014,190021,Health Care,Industrial Specialties
+add,AVNT,Avient Corporation Common Stock,$50.30,-0.68,-1.334%,4592257107.00,United States,,114455,Basic Industries,Major Chemicals
+add,AVTR,Avantor Inc. Common Stock,$33.495,1.625,5.099%,19498719779.00,,2019,4021480,Basic Industries,Industrial Specialties
+add,AVTR^A,Avantor Inc. Series A Mandatory Convertible Preferred Stock,$103.52,4.41,4.45%,,,,19885,,
+add,AVY,Avery Dennison Corporation Common Stock,$217.185,-0.935,-0.429%,18028033623.00,United States,,187730,Miscellaneous,Office Equipment/Supplies/Services
+add,AVYA,Avaya Holdings Corp. Common Stock,$28.00,-0.08,-0.285%,2368055928.00,,,393535,Technology,Retail: Computer Software & Peripheral Equipment
+add,AWF,Alliancebernstein Global High Income Fund,$12.3999,0.1099,0.894%,1069239372.00,United States,1993,249122,,
+add,AWI,Armstrong World Industries Inc Common Stock,$107.61,-0.16,-0.148%,5153132553.00,United States,,351817,,
+add,AWK,American Water Works Company Inc. Common Stock,$159.81,2.21,1.402%,29000592213.00,United States,2008,249448,Public Utilities,Water Supply
+add,AWP,Aberdeen Global Premier Properties Fund Common Shares of Beneficial Interest,$6.80,-0.03,-0.439%,580774067.00,United States,2007,529929,,
+add,AWR,American States Water Company Common Stock,$81.07,0.54,0.671%,2992538288.00,United States,,63353,Public Utilities,Water Supply
+add,AX,Axos Financial Inc. Common Stock,$48.12,-0.32,-0.661%,2850546804.00,United States,2018,255821,Finance,Savings Institutions
+add,AXL,American Axle & Manufacturing Holdings Inc. Common Stock,$11.905,-0.415,-3.369%,1357031212.00,United States,,744586,Capital Goods,Auto Parts:O.E.M.
+add,AXP,American Express Company Common Stock,$162.46,-1.63,-0.993%,130504582473.00,United States,,1829703,Finance,Finance: Consumer Services
+add,AXR,AMREP Corporation Common Stock,$14.45,-0.25,-1.701%,102567834.00,United States,,2893,Consumer Services,Building operators
+add,AXS,Axis Capital Holdings Limited Common Stock,$51.91,-0.16,-0.307%,4399900373.00,Bermuda,2003,175368,Finance,Property-Casualty Insurers
+add,AXS^E,Axis Capital Holdings Limited Depositary Shares each representing 1/100th interest in a share of a 5.50% Series E Preferred Shares,$25.51,0.01,0.039%,,Bermuda,,39399,,
+add,AXTA,Axalta Coating Systems Ltd. Common Shares,$31.45,-0.24,-0.757%,7326189000.00,United States,2014,1651906,Basic Industries,Paints/Coatings
+add,AYI,Acuity Brands Inc. ,$185.47,-1.18,-0.632%,6622284247.00,United States,,90695,Consumer Durables,Building Products
+add,AYX,Alteryx Inc. Class A Common Stock,$81.88,3.07,3.895%,5496551833.00,United States,2017,1070799,Technology,Computer Software: Prepackaged Software
+add,AZEK,The AZEK Company Inc. Class A Common Stock,$41.875,0.275,0.661%,7202053529.00,United States,2020,959322,,
+add,AZO,AutoZone Inc. Common Stock,$1374.24,-12.61,-0.909%,29711068800.00,United States,,154213,,
+add,AZRE,Azure Power Global Limited Equity Shares,$20.84,1.52,7.867%,1001036729.00,India,2016,245251,Public Utilities,Electric Utilities: Central
+add,AZUL,Azul S.A. American Depositary Shares (each representing three preferred shares),$28.26,-0.07,-0.247%,3255769800.00,Brazil,2017,729817,Transportation,Air Freight/Delivery Services
+add,AZZ,AZZ Inc.,$53.795,-0.505,-0.93%,1345666593.00,United States,,80297,Consumer Non-Durables,Telecommunications Equipment
+add,B,Barnes Group Inc. Common Stock,$54.395,-0.895,-1.619%,2755274722.00,United States,,117921,Capital Goods,Office Equipment/Supplies/Services
+add,BA,Boeing Company (The) Common Stock,$248.53,0.47,0.189%,145342846200.00,United States,,13119195,Capital Goods,Aerospace
+add,BABA,Alibaba Group Holding Limited American Depositary Shares each representing eight Ordinary share,$213.00,-0.32,-0.15%,577762500000.00,China,2014,9399326,Consumer Services,Catalog/Specialty Distribution
+add,BAC,Bank of America Corporation Common Stock,$41.75,-0.57,-1.347%,360187794046.00,United States,,32067621,Finance,Major Banks
+add,BAC^B,Bank of America Corporation Depositary Shares each representing a 1/1000th interest in a share of 6.000% Non-Cumulative Preferred Stock Series GG,$27.64,-0.05,-0.181%,,United States,,47600,,
+add,BAC^E,Bank of America Corporation Depositary Sh repstg 1/1000th Perp Pfd Ser E,$25.485,0.065,0.256%,,United States,,14581,,
+add,BAC^K,Bank of America Corporation Depositary Shares each representing a 1/1000th interest in a share of 5.875% Non- Cumulative Preferred Stock Series HH,$27.63,0.02,0.072%,,United States,,35173,,
+add,BAC^L,Bank of America Corporation Non Cumulative Perpetual Conv Pfd Ser L,$1406.00,-4.65,-0.33%,,United States,,24096,,
+add,BAC^M,Bank of America Corporation Depositary Shares each representing a 1/1000th interest in a share of 5.375% Non-Cumulative Preferred Stock Series KK,$27.78,0.01,0.036%,,United States,,57866,,
+add,BAC^N,Bank of America Corporation Depositary shares each representing 1/1000th interest in a share of 5.000% Non-Cumulative Preferred Stock Series LL,$27.26,0.06,0.221%,,United States,,55354,,
+add,BAC^O,Bank of America Corporation Depositary shares each representing 1/1000th interest in a share of 4.375% Non-Cumulative Preferred Stock Series NN,$25.79,0.16,0.624%,,United States,,227407,,
+add,BAC^P,Bank of America Corporation Depositary Shares each representing a 1/1000th interest in a share of 4.125% Non-Cumulative Preferred Stock Series PP,$25.48,0.02,0.079%,,United States,,37870,,
+add,BAH,Booz Allen Hamilton Holding Corporation Common Stock,$88.24,0.85,0.973%,11948363271.00,United States,2010,582821,Consumer Services,Professional Services
+add,BAK,Braskem SA ADR,$23.41,0.81,3.584%,9328515567.00,Brazil,,225429,Basic Industries,Major Chemicals
+add,BALY,Bally's Corporation Common Stock,$52.62,-1.08,-2.011%,2343920487.00,,2019,278873,Consumer Services,Recreational Products/Toys
+add,BAM,Brookfield Asset Management Inc. Common Stock,$49.915,0.365,0.737%,78758011382.00,Canada,,1725150,Consumer Services,Building operators
+add,BAMH,Brookfield Finance Inc. 4.625% Subordinated Notes due October 16 2080,$25.43,0.12,0.474%,0.00,,2020,38078,Consumer Services,Building operators
+add,BAMI,Brookfield Finance Inc. 4.50% Perpetual Subordinated Notes,$24.9888,0.0188,0.075%,0.00,,2020,35899,Consumer Services,Building operators
+add,BANC,Banc of California Inc. Common Stock,$18.30,0.05,0.274%,926931582.00,United States,,242588,Finance,Major Banks
+add,BANC^E,Banc of California Inc. Depositary Shares Each Representing a 1/40th Interest in a Share of 7.000% Non-Cumulative Perpetual Preferred Stock Series E,$25.43,0.06,0.236%,,United States,,1965,,
+add,BAP,Credicorp Ltd. Common Stock,$125.27,-0.12,-0.096%,9991660470.00,Peru,,804829,Finance,Major Banks
+add,BARK,The Original BARK Company Common Stock,$12.3101,0.3101,2.584%,2052518171.00,,2020,7612006,,
+add,BAX,Baxter International Inc. Common Stock,$83.79,1.44,1.749%,42133968493.00,United States,,2257271,Health Care,Medical/Dental Instruments
+add,BB,BlackBerry Limited Common Stock,$13.875,-1.285,-8.476%,7856290554.00,Canada,,65565312,Technology,Computer Software: Prepackaged Software
+add,BBAR,Banco BBVA Argentina S.A. ADS,$4.115,-0.005,-0.121%,840364802.00,Argentina,,506495,Finance,Commercial Banks
+add,BBD,Banco Bradesco Sa American Depositary Shares,$5.52,0.04,0.73%,59014251160.00,Brazil,,20715023,Finance,Commercial Banks
+add,BBDC,Barings BDC Inc. Common Stock,$10.515,0.015,0.143%,686798634.00,United States,,198915,Finance,Investment Managers
+add,BBDO,Banco Bradesco Sa American Depositary Shares (each representing one Common Share),$4.72,0.04,0.855%,50461461137.00,Brazil,,7420,Finance,Commercial Banks
+add,BBL,BHP Group PlcSponsored ADR,$61.00,0.46,0.76%,154238500000.00,Australia,,1695084,Energy,Coal Mining
+add,BBN,BlackRock Taxable Municipal Bond Trust Common Shares of Beneficial Interest,$25.355,0.075,0.297%,1450748166.00,United States,2010,109333,,
+add,BBU,Brookfield Business Partners L.P. Limited Partnership Units ,$43.75,0.24,0.552%,3441763588.00,,2016,9335,Capital Goods,Building Products
+add,BBVA,Banco Bilbao Vizcaya Argentaria S.A. Common Stock,$6.365,-0.005,-0.078%,42390178082.00,Spain,,1372376,Finance,Commercial Banks
+add,BBW,Build-A-Bear Workshop Inc. Common Stock,$17.22,-0.08,-0.462%,277861093.00,United States,2004,267588,Consumer Services,Recreational Products/Toys
+add,BBY,Best Buy Co. Inc. Common Stock,$112.575,-2.415,-2.10%,28196997187.00,United States,,2826301,Consumer Services,Consumer Electronics/Video Chains
+add,BC,Brunswick Corporation Common Stock,$93.99,-1.54,-1.612%,7321611496.00,United States,,629517,Consumer Non-Durables,Recreational Products/Toys
+add,BC^A,Brunswick Corporation 6.500% Senior Notes due 2048,$27.5359,-0.3641,-1.305%,,United States,,5089,,
+add,BC^B,Brunswick Corporation 6.625% Senior Notes due 2049,$28.04,-0.11,-0.391%,,United States,,12696,,
+add,BC^C,Brunswick Corporation 6.375% Notes due 2049,$28.16,-0.15,-0.53%,,United States,,18733,,
+add,BCAT,BlackRock Capital Allocation Trust Common Shares of Beneficial Interest,$21.87,0.23,1.063%,2443684647.00,United States,2020,133857,,
+add,BCC,Boise Cascade L.L.C. Common Stock,$61.88,-2.57,-3.988%,2433790337.00,United States,2013,368519,,
+add,BCE,BCE Inc. Common Stock,$50.78,0.20,0.395%,45936346552.00,Canada,,603645,,
+add,BCEI,Bonanza Creek Energy Inc. Common Stock,$48.45,0.91,1.914%,1526021995.00,United States,2017,287682,Energy,Oil & Gas Production
+add,BCH,Banco De Chile Banco De Chile ADS,$20.47,0.30,1.487%,10339098240.00,Chile,,82850,Finance,Commercial Banks
+add,BCO,Brinks Company (The) Common Stock,$74.26,-1.22,-1.616%,3694748823.00,United States,,133296,Miscellaneous,Diversified Manufacture
+add,BCS,Barclays PLC Common Stock,$10.27,-0.03,-0.291%,43636261128.00,United Kingdom,,4536515,Finance,Commercial Banks
+add,BCSF,Bain Capital Specialty Finance Inc. Common Stock,$15.92,-0.05,-0.313%,1027831259.00,United States,2018,149567,Finance,Finance/Investors Services
+add,BCX,BlackRock Resources Common Shares of Beneficial Interest,$10.10,0.06,0.598%,891991539.00,United States,2011,364594,Finance,Finance/Investors Services
+add,BDC,Belden Inc Common Stock,$53.52,-0.27,-0.502%,2394422075.00,United States,,84067,Basic Industries,Telecommunications Equipment
+add,BDJ,Blackrock Enhanced Equity Dividend Trust,$10.56,-0.01,-0.095%,1964196263.00,United States,2005,268531,,
+add,BDN,Brandywine Realty Trust Common Stock,$15.02,0.03,0.20%,2566300032.00,United States,,941926,Consumer Services,Real Estate Investment Trusts
+add,BDX,Becton Dickinson and Company Common Stock,$244.98,1.63,0.67%,71244717110.00,United States,,689541,Health Care,Medical/Dental Instruments
+add,BDXB,Becton Dickinson and Company Depositary Shares each Representing a 1/20th Interest in a Share of 6.00% Mandatory Convertible Preferred Stock Series B,$54.7225,0.1225,0.224%,0.00,United States,,30980,Health Care,Medical/Dental Instruments
+add,BE,Bloom Energy Corporation Class A Common Stock,$24.985,-0.375,-1.479%,4307160627.00,,2018,1595013,Consumer Durables,Electrical Products
+add,BEDU,Bright Scholar Education Holdings Limited American Depositary Shares each  representing one Class A Ordinary Share,$4.06,-0.11,-2.638%,484704212.00,China,2017,8092,Miscellaneous,Other Consumer Services
+add,BEKE,KE Holdings Inc American Depositary Shares (each representing three Class A Ordinary Shares),$47.01,-0.68,-1.426%,55984098291.00,China,2020,2412021,Finance,Real Estate
+add,BEN,Franklin Resources Inc. Common Stock,$34.495,-0.295,-0.848%,17396611054.00,United States,,1136631,Finance,Investment Managers
+add,BEP,Brookfield Renewable Partners L.P. ,$39.61,0.38,0.969%,10888127869.00,,,98928,Public Utilities,Electric Utilities: Central
+add,BEP^A,Brookfield Renewable Partners L.P. 5.25% Class A Preferred Limited Partnership Units Series 17,$26.42,-0.08,-0.302%,,,,19188,,
+add,BEPC,Brookfield Renewable Corporation Class A Subordinate Voting Shares ,$42.71,0.66,1.57%,7354762924.00,,2020,435014,,
+add,BEPH,Brookfield BRP Holdings (Canada) Inc. 4.625% Perpetual Subordinated Notes,$24.99,0.07,0.281%,0.00,,,13607,,
+add,BERY,Berry Global Group Inc. Common Stock,$66.12,-0.26,-0.392%,8919588000.00,United States,2012,456223,Consumer Non-Durables,Plastic Products
+add,BEST,BEST Inc. American Depositary Shares each representing one Class A Ordinary Share,$1.35,-0.09,-6.25%,523395000.00,Cayman Islands,2017,3788969,,
+add,BF/A,Brown Forman Corporation,$70.54,0.23,0.327%,,United States,,42999,,
+add,BF/B,Brown Forman Corporation,$75.51,0.32,0.426%,,United States,,652407,,
+add,BFAM,Bright Horizons Family Solutions Inc. Common Stock,$147.98,0.95,0.646%,9031171307.00,United States,2013,275573,Miscellaneous,Other Consumer Services
+add,BFK,BlackRock Municipal Income Trust,$15.18,-0.01,-0.066%,680725423.00,United States,,100098,,
+add,BFLY,Butterfly Network Inc. Class A Common Stock,$14.11,-0.24,-1.672%,2699164111.00,,2020,2466390,Health Care,Biotechnology: Electromedical & Electrotherapeutic Apparatus
+add,BFS,Saul Centers Inc. Common Stock,$46.26,-0.15,-0.323%,1087110000.00,United States,1993,21311,Consumer Services,Real Estate Investment Trusts
+add,BFS^D,Saul Centers Inc. Depositary Shares each representing 1/100th of a share of 6.125% Series D Cumulative Redeemable Preferred Stock,$26.25,-0.34,-1.279%,,United States,,530,,
+add,BFS^E,Saul Centers Inc. Depositary shares each representing a 1/100th fractional interest in a share of 6.000% Series E Cumulative Redeemable Preferred Stock,$26.61,-0.32,-1.188%,,United States,,1350,,
+add,BFZ,BlackRock California Municipal Income Trust,$14.875,-0.015,-0.101%,466207535.00,United States,2001,14504,,
+add,BG,Bunge Limited Bunge Limited,$87.75,-1.04,-1.171%,12410866319.00,United States,2001,382389,Consumer Non-Durables,Packaged Foods
+add,BGB,Blackstone Strategic Credit Fund Common Shares,$13.63,0.01,0.073%,608775527.00,,2012,66164,Finance,Trusts Except Educational Religious and Charitable
+add,BGH,Barings Global Short Duration High Yield Fund Common Shares of Beneficial Interests,$16.75,-0.07,-0.416%,336077243.00,United States,2012,41736,,
+add,BGIO,BlackRock 2022 Global Income Opportunity Trust Common Shares of Beneficial Interest,$9.375,0.015,0.16%,207630675.00,United States,2017,22256,,
+add,BGR,BlackRock Energy and Resources Trust,$10.21,0.20,1.998%,297197489.00,United States,2004,221506,,
+add,BGS,B&G Foods Inc. B&G Foods Inc. Common Stock,$32.675,-0.945,-2.811%,2115775096.00,United States,,1159969,Consumer Non-Durables,Packaged Foods
+add,BGSF,BGSF Inc. Common Stock,$12.18,-0.02,-0.164%,125893820.00,United States,,67534,Technology,Professional Services
+add,BGSX,Build Acquisition Corp. Class A Common Stock,$9.62,0.00,0.00%,247715000.00,,2021,107,,
+add,BGT,BlackRock Floating Rate Income Trust,$12.6232,-0.0068,-0.054%,282704895.00,United States,2004,112358,,
+add,BGX,Blackstone Long Short Credit Income Fund Common Shares,$14.46,-0.02,-0.138%,183754745.00,,2011,51937,Finance,Trusts Except Educational Religious and Charitable
+add,BGY,Blackrock Enhanced International Dividend Trust,$6.65,0.06,0.91%,693182507.00,United States,2007,457636,,
+add,BH,Biglari Holdings Inc. Class B Common Stock,$180.00,-0.01,-0.006%,558532800.00,United States,2018,5280,Consumer Services,Restaurants
+add,BHC,Bausch Health Companies Inc. Common Stock,$31.58,0.33,1.056%,11318134059.00,Canada,,1029976,,
+add,BHE,Benchmark Electronics Inc. Common Stock,$30.45,-0.11,-0.36%,1090609350.00,United States,,87512,Technology,Electrical Products
+add,BHK,Blackrock Core Bond Trust Blackrock Core Bond Trust,$16.12,0.03,0.186%,869434231.00,United States,2001,88689,,
+add,BHLB,Berkshire Hills Bancorp Inc. Common Stock,$27.70,-0.30,-1.071%,1418328945.00,United States,,170305,Finance,Savings Institutions
+add,BHP,BHP Group Limited American Depositary Shares (Each representing two Ordinary Shares),$75.265,0.845,1.135%,190307552500.00,Australia,,1350222,Basic Industries,Precious Metals
+add,BHR,Braemar Hotels & Resorts Inc. Common Stock,$6.44,0.02,0.312%,314085755.00,United States,2013,724870,Consumer Services,Real Estate Investment Trusts
+add,BHR^B,Braemar Hotels & Resorts Inc. 5.50% Series B Cumulative Convertible Preferred Stock par value $0.01 per share,$24.18,0.03,0.124%,,United States,,13151,,
+add,BHR^D,Braemar Hotels & Resorts Inc. 8.25% Series D Cumulative Preferred Stock  par value $0.01 per share,$25.84,0.01,0.039%,,United States,,3170,,
+add,BHV,BlackRock Virginia Municipal Bond Trust,$18.135,-0.725,-3.844%,29181500.00,United States,2002,1508,,
+add,BHVN,Biohaven Pharmaceutical Holding Company Ltd. Common Shares,$103.45,5.79,5.929%,6731896921.00,United States,2017,647344,Health Care,Major Pharmaceuticals
+add,BIF,Boulder Growth & Income Fund Inc.,$13.74,-0.02,-0.145%,1350243265.00,United States,,50593,,
+add,BIG,Big Lots Inc. Common Stock,$65.89,-4.58,-6.499%,2312836649.00,United States,,771398,Consumer Services,Department/Specialty Retail Stores
+add,BIGZ,BlackRock Innovation and Growth Trust Common Shares of Beneficial Interest,$20.572,0.312,1.54%,0.00,,2021,320847,,
+add,BILL,Bill.com Holdings Inc. Common Stock,$156.025,1.055,0.681%,14571815077.00,,2019,527480,Technology,Computer Software: Prepackaged Software
+add,BIO,Bio-Rad Laboratories Inc. Class A Common Stock,$604.62,23.46,4.037%,17995676297.00,United States,,176591,Capital Goods,Biotechnology: Laboratory Analytical Instruments
+add,BIO/B,Bio-Rad Laboratories Inc.,$579.60,0.00,0.00%,,United States,,9,,
+add,BIP,Brookfield Infrastructure Partners LP Limited Partnership Units,$55.0003,-0.2997,-0.542%,16254708582.00,Bermuda,,213122,Consumer Services,Marine Transportation
+add,BIP^A,Brookfield Infrastructure Partners LP 5.125% Class A Preferred Limited Partnership Units Series 13,$25.90,-0.24,-0.918%,,Bermuda,,10885,,
+add,BIP^B,Brookfield Infrastructure Partners LP 5.000% Class A Preferred Limited Partnership Units Series 14,$25.04,-0.03,-0.12%,,Bermuda,,44426,,
+add,BIPC,Brookfield Infrastructure Partners LP Class A Subordinate Voting Shares ,$68.74,-0.65,-0.937%,3089889259.00,,2020,103987,,
+add,BIPH,Brookfield Infrastructure Corporation 5.000% Subordinated Notes due 2081,$25.32,0.03,0.119%,0.00,,2021,24661,Health Care,Medical/Dental Instruments
+add,BIT,BlackRock Multi-Sector Income Trust Common Shares of Beneficial Interest,$18.86,-0.02,-0.106%,707959061.00,,2013,135534,,
+add,BITE,Bite Acquisition Corp. Common Stock,$9.66,0.002,0.021%,223351275.00,,2021,17524,,
+add,BJ,BJ's Wholesale Club Holdings Inc. Common Stock,$47.26,0.03,0.064%,6480942396.00,United States,2018,610925,Consumer Services,Department/Specialty Retail Stores
+add,BK,The Bank of New York Mellon Corporation Common Stock,$49.985,-0.635,-1.254%,43760910137.00,United States,,2161144,Finance,Investment Managers
+add,BKD,Brookdale Senior Living Inc. Common Stock,$7.31,0.01,0.137%,1353564549.00,United States,2005,1254135,Health Care,Hospital/Nursing Management
+add,BKE,Buckle Inc. (The) Common Stock,$39.235,-0.015,-0.038%,1953467138.00,United States,,414452,Consumer Services,Clothing/Shoe/Accessory Stores
+add,BKH,Black Hills Corporation Common Stock,$69.07,0.02,0.029%,4342550184.00,United States,,140525,Public Utilities,Electric Utilities: Central
+add,BKI,Black Knight Inc. Common Stock ,$74.48,1.22,1.665%,11664597463.00,,2017,622229,Technology,EDP Services
+add,BKN,BlackRock Investment Quality Municipal Trust Inc. (The),$18.49,0.16,0.873%,317825072.00,United States,1993,34757,,
+add,BKR,Baker Hughes Company Class A Common Stock,$25.575,-0.235,-0.91%,26638677754.00,,2017,4374291,Energy,Oilfield Services/Equipment
+add,BKT,BlackRock Income Trust Inc. (The),$6.2601,0.0301,0.483%,399376301.00,United States,,88858,,
+add,BKU,BankUnited Inc. Common Stock,$46.15,-1.37,-2.883%,4303155728.00,United States,2011,254284,Finance,Savings Institutions
+add,BLD,TopBuild Corp. Common Stock,$187.86,-6.96,-3.573%,6210914228.00,United States,2015,534836,Capital Goods,Engineering & Construction
+add,BLE,BlackRock Municipal Income Trust II,$15.41,-0.07,-0.452%,363182849.00,United States,2002,97765,,
+add,BLK,BlackRock Inc. Common Stock,$868.65,-2.29,-0.263%,132492058229.00,United States,1999,271286,Finance,Investment Bankers/Brokers/Service
+add,BLL,Ball Corporation Common Stock,$80.48,-0.42,-0.519%,26417923850.00,United States,,2097919,Consumer Durables,Containers/Packaging
+add,BLUA,BlueRiver Acquisition Corp. Class A Ordinary Shares,$9.72,-0.06,-0.613%,357088500.00,,2021,3075,Finance,Business Services
+add,BLW,Blackrock Limited Duration Income Trust,$17.22,0.11,0.643%,614101448.00,United States,2003,76715,Finance,Major Banks
+add,BLX,Banco Latinoamericano de Comercio Exterior S.A.,$15.10,0.01,0.066%,599515300.00,Panama,1992,61101,Finance,Commercial Banks
+add,BMA,Banco Macro S.A.  ADR (representing Ten Class B Common Shares),$18.36,0.05,0.273%,1173204000.00,Argentina,,279964,Finance,Commercial Banks
+add,BME,Blackrock Health Sciences Trust,$47.87,0.31,0.652%,590768792.00,United States,2005,26133,,
+add,BMEZ,BlackRock Health Sciences Trust II Common Shares of Beneficial Interest,$28.943,0.043,0.149%,2260157770.00,,2020,117993,,
+add,BMI,Badger Meter Inc. Common Stock,$93.26,-0.19,-0.203%,2720908529.00,United States,,29999,Capital Goods,Industrial Machinery/Components
+add,BML^G,Bank of America Corporation Bank of America Corporation Depositary Shares (Each representing a 1/1200th interest in a share of Floating Rate Non-Cumulative Preferred Stock  Series 1),$22.50,0.14,0.626%,,United States,,7810,,
+add,BML^H,Bank of America Corporation Bank of America Corporation Depositary Shares (Each representing a 1/1200th interest in a Share of Floating Rate Non-Cumulative Preferred Stock Series 2),$22.79,-0.09,-0.393%,,United States,,3246,,
+add,BML^J,Bank of America Corporation Bank of America Corporation Depositary Shares (Each representing a 1/1200th interest in a Share of Floating Rate Non-Cumulative Preferred Stock Series 4),$25.40,-0.04,-0.157%,,United States,,2402,,
+add,BML^L,Bank of America Corporation Bank of America Corporation Depositary Shares (Each representing a 1/1200th Interest in a Share of Floating Rate Non-Cumulative Preferred Stock Series 5),$25.37,0.02,0.079%,,United States,,2601,,
+add,BMO,Bank Of Montreal Common Stock,$105.12,0.20,0.191%,68047205979.00,Canada,,508212,,
+add,BMY,Bristol-Myers Squibb Company Common Stock,$67.335,1.935,2.959%,150348534243.00,United States,,11497561,Health Care,Major Pharmaceuticals
+add,BNED,Barnes & Noble Education Inc Common Stock,$9.37,0.14,1.517%,481420415.00,United States,2015,285688,Consumer Services,Other Specialty Stores
+add,BNL,Broadstone Net Lease Inc. Common Stock,$24.89,0.28,1.138%,3629256424.00,United States,2020,1930471,Consumer Services,Real Estate Investment Trusts
+add,BNS,Bank Nova Scotia Halifax Pfd 3 Ordinary Shares,$66.93,0.11,0.165%,81243382080.00,Canada,,833583,Finance,Major Banks
+add,BNY,BlackRock New York Municipal Income Trust,$14.945,0.045,0.302%,193927426.00,United States,,70715,,
+add,BOAC,Bluescape Opportunities Acquisition Corp. Class A Ordinary Shares,$9.88,-0.16,-1.594%,750262500.00,United States,2020,76568,Finance,Business Services
+add,BOAS,BOA Acquisition Corp. Class A Common Stock,$9.665,-0.024,-0.248%,277868750.00,,2021,61474,,
+add,BOE,Blackrock Enhanced Global Dividend Trust Common Shares of Beneficial Interest,$12.6753,0.0753,0.598%,811775316.00,United States,2005,420148,,
+add,BOH,Bank of Hawaii Corporation Common Stock,$88.325,-0.525,-0.591%,3567828667.00,United States,,118078,Finance,Major Banks
+add,BOOT,Boot Barn Holdings Inc. Common Stock,$75.69,-0.39,-0.513%,2214055572.00,United States,2014,412269,Consumer Services,Clothing/Shoe/Accessory Stores
+add,BORR,Borr Drilling Limited Common Shares,$0.9288,-0.0136,-1.443%,254051785.00,,2019,1781294,Energy,Oil & Gas Production
+add,BOX,Box Inc. Class A Common Stock,$25.0301,0.4001,1.624%,4074631507.00,United States,2015,1377435,Technology,Computer Software: Prepackaged Software
+add,BP,BP p.l.c. Common Stock,$27.56,-0.03,-0.109%,92958693735.00,United Kingdom,,7616543,Energy,Integrated oil Companies
+add,BPMP,BP Midstream Partners LP Common Units representing Limited Partner Interests,$14.85,0.09,0.61%,1556198919.00,United States,2017,193549,Energy,Oil & Gas Production
+add,BPT,BP Prudhoe Bay Royalty Trust Common Stock,$4.67,0.03,0.647%,99938000.00,United States,,167116,Energy,Integrated oil Companies
+add,BQ,Boqii Holding Limited American Depositary Shares representing Class A Ordinary Shares,$4.51,-0.29,-6.042%,406157584.00,,2020,150894,Consumer Services,Other Specialty Stores
+add,BR,Broadridge Financial Solutions Inc.Common Stock,$161.125,2.055,1.292%,18710751479.00,United States,,259955,Miscellaneous,Business Services
+add,BRBR,BellRing Brands Inc. Class A Common Stock,$28.35,-0.29,-1.013%,1120120719.00,United States,2019,115176,Consumer Non-Durables,Beverages (Production/Distribution)
+add,BRC,Brady Corporation Common Stock,$59.36,-1.17,-1.933%,3090464607.00,United States,,113242,Miscellaneous,Diversified Manufacture
+add,BRFS,BRF S.A.,$5.475,0.065,1.201%,4448291022.00,Brazil,,4004374,Consumer Non-Durables,Meat/Poultry/Fish
+add,BRK/A,Berkshire Hathaway Inc.,$428035.84000000003,-5089.16,-1.175%,,United States,,1238,,
+add,BRK/B,Berkshire Hathaway Inc.,$285.20,-3.38,-1.171%,,United States,,2905907,,
+add,BRMK,Broadmark Realty Capital Inc. Common Stock,$10.955,0.015,0.137%,1452339165.00,United States,2019,712053,Consumer Services,Real Estate Investment Trusts
+add,BRO,Brown & Brown Inc. Common Stock,$51.76,0.04,0.077%,14588463919.00,United States,,313912,Finance,Specialty Insurers
+add,BRT,BRT Apartments Corp. (MD) Common Stock,$17.75,-0.11,-0.616%,312097806.00,United States,,30217,Consumer Services,Real Estate Investment Trusts
+add,BRW,Saba Capital Income & Opportunities Fund SBI,$4.655,0.005,0.108%,569153490.00,United States,,469085,,
+add,BRX,Brixmor Property Group Inc. Common Stock,$24.10,-0.19,-0.782%,7156649095.00,,2013,858592,Consumer Services,Real Estate Investment Trusts
+add,BSA,BrightSphere Investment Group Inc. 5.125% Notes due 2031,$25.28,0.0102,0.04%,0.00,United Kingdom,2016,3697,Finance,Finance/Investors Services
+add,BSAC,Banco Santander - Chile ADS,$21.59,0.53,2.517%,10171379672.00,Chile,,734056,Finance,Commercial Banks
+add,BSBR,Banco Santander Brasil SA American Depositary Shares each representing one unit,$8.98,0.05,0.56%,67052663220.00,Brazil,2009,501304,Finance,Commercial Banks
+add,BSIG,BrightSphere Investment Group Inc. Common Stock,$22.325,0.065,0.292%,1771590552.00,United Kingdom,2014,177769,Finance,Finance/Investors Services
+add,BSL,Blackstone Senior Floating Rate Term Fund Common Shares of Beneficial Interest,$16.15,0.00,0.00%,218372193.00,United States,2010,33735,,
+add,BSM,Black Stone Minerals L.P. Common units representing limited partner interests,$10.055,0.025,0.249%,2086935471.00,United States,2015,374835,Energy,Oil & Gas Production
+add,BSMX,Banco Santander Mexico S.A. Institucion de Banca Multiple Grupo Financiero Santander Mexico,$6.54,0.20,3.155%,8861772895.00,Mexico,2012,1450207,Finance,Commercial Banks
+add,BSN,Broadstone Acquisition Corp. Class A Ordinary Shares,$9.9248,-0.0052,-0.052%,,United Kingdom,2020,94849,Finance,Business Services
+add,BST,BlackRock Science and Technology Trust Common Shares of Beneficial Interest,$59.4295,0.6695,1.139%,1484362183.00,United States,2014,128785,,
+add,BSTZ,BlackRock Science and Technology Trust II Common Shares of Beneficial Interest,$38.87,0.78,2.048%,3035356823.00,,2019,80418,Finance,Trusts Except Educational Religious and Charitable
+add,BSX,Boston Scientific Corporation Common Stock,$42.745,0.415,0.98%,60736834497.00,United States,,2896945,Health Care,Medical/Dental Instruments
+add,BSX^A,Boston Scientific Corporation 5.50% Mandatory Convertible Preferred Stock Series A,$115.66,1.52,1.332%,,United States,,2111,,
+add,BTA,BlackRock Long-Term Municipal Advantage Trust BlackRock Long-Term Municipal Advantage Trust Common Shares of Beneficial Interest,$13.45,0.04,0.298%,180596391.00,United States,2006,23112,,
+add,BTCM,BIT Mining Limited ADS,$7.73,-0.24,-3.011%,432829098.00,,2013,1004409,Consumer Services,Movies/Entertainment
+add,BTI,British American Tobacco  Industries p.l.c. Common Stock ADR,$40.105,0.175,0.438%,92025630065.00,United Kingdom,,1935216,Consumer Non-Durables,Farming/Seeds/Milling
+add,BTO,John Hancock Financial Opportunities Fund Common Stock,$40.64,-3.02,-6.917%,762918383.00,United States,1994,132146,,
+add,BTT,BlackRock Municipal 2030 Target Term Trust,$25.88,0.10,0.388%,1824684177.00,United States,2012,48195,Finance,Investment Managers
+add,BTU,Peabody Energy Corporation Common Stock ,$8.995,0.385,4.472%,920611688.00,United States,2017,5371374,Energy,Coal Mining
+add,BTZ,BlackRock Credit Allocation Income Trust,$15.183,-0.067,-0.439%,1419291642.00,United States,2006,196242,,
+add,BUD,Anheuser-Busch Inbev SA Sponsored ADR (Belgium),$78.535,-0.005,-0.006%,154890607100.00,Belgium,,564366,Consumer Non-Durables,Beverages (Production/Distribution)
+add,BUI,BlackRock Utility Infrastructure & Power Opportunities Trust,$26.525,-0.125,-0.469%,517741873.00,United States,2011,34429,,
+add,BUR,Burford Capital Limited Ordinary Shares,$11.11,-0.19,-1.681%,2433644133.00,,2020,42033,Consumer Non-Durables,Farming/Seeds/Milling
+add,BURL,Burlington Stores Inc. Common Stock,$303.595,-1.395,-0.457%,20213403675.00,,2013,197316,Consumer Non-Durables,Apparel
+add,BV,BrightView Holdings Inc. Common Stock,$17.38,-0.13,-0.742%,1828106019.00,United States,2018,51320,Miscellaneous,Business Services
+add,BVH,Bluegreen Vacations Holding Corporation Class A Common Stock,$20.26,-0.31,-1.507%,445346446.00,United States,2017,21646,Consumer Services,Hotels/Resorts
+add,BVN,Buenaventura Mining Company Inc.,$10.86,0.23,2.164%,2758297376.00,Peru,1996,1087327,Basic Industries,Precious Metals
+add,BW,Babcock & Wilcox Enterprises Inc. Common Stock,$8.26,-0.41,-4.729%,708108481.00,United States,2015,538660,Capital Goods,Industrial Machinery/Components
+add,BW^A,Babcock & Wilcox Enterprises Inc. 7.75% Series A Cumulative Perpetual Preferred Stock,$25.53,0.16,0.631%,,United States,,40099,,
+add,BWA,BorgWarner Inc. Common Stock,$52.22,-0.90,-1.694%,12524849923.00,United States,,1120240,Capital Goods,Auto Parts:O.E.M.
+add,BWG,BrandywineGLOBAL Global Income Opportunities Fund Inc.,$12.80,-0.10,-0.775%,214935501.00,United States,2012,112082,,
+add,BWSN,Babcock & Wilcox Enterprises Inc. 8.125% Senior Notes due 2026,$26.21,0.00,0.00%,0.00,United States,2021,12283,Capital Goods,Building Products
+add,BWXT,BWX Technologies Inc. Common Stock,$64.09,-0.08,-0.125%,6097596624.00,United States,,135875,,
+add,BX,The Blackstone Group Inc. Common Stock,$93.73,-0.47,-0.499%,66054052524.00,United States,2007,3056053,Finance,Investment Managers
+add,BXC,Bluelinx Holdings Inc. Common Stock,$42.14,-1.67,-3.812%,398983290.00,United States,2004,261499,Capital Goods,Wholesale Distributors
+add,BXMT,Blackstone Mortgage Trust Inc. Common Stock,$33.295,-0.195,-0.582%,4895395380.00,United States,,772343,Consumer Services,Real Estate Investment Trusts
+add,BXMX,Nuveen S&P 500 Buy-Write Income Fund Common Shares of Beneficial Interest,$14.70,0.15,1.031%,1530076504.00,United States,,196914,,
+add,BXP,Boston Properties Inc. Common Stock,$122.61,0.23,0.188%,19136264038.00,United States,1997,930553,Consumer Services,Real Estate Investment Trusts
+add,BXS,BancorpSouth Bank Common Stock,$30.24,-0.40,-1.305%,3103999497.00,United States,,491132,Finance,Major Banks
+add,BXS^A,BancorpSouth Bank 5.50% Series A Non-Cumulative Perpetual Preferred Stock,$26.80,-0.04,-0.149%,,United States,,5820,,
+add,BY,Byline Bancorp Inc. Common Stock,$22.59,-0.17,-0.747%,872640699.00,United States,2017,100288,Finance,Major Banks
+add,BYD,Boyd Gaming Corporation Common Stock,$61.70,-0.70,-1.122%,6915390728.00,United States,1993,455789,Consumer Services,Movies/Entertainment
+add,BYM,Blackrock Municipal Income Quality Trust Common Shares of Beneficial Interest,$15.71,0.00,0.00%,414842549.00,United States,2002,38672,,
+add,BZH,Beazer Homes USA Inc. Common Stock,$21.02,-1.07,-4.844%,657802802.00,United States,1994,1255498,Capital Goods,Homebuilding
+add,C,Citigroup Inc. Common Stock,$77.02,-1.12,-1.433%,159203999913.00,United States,,12564938,Finance,Major Banks
+add,C^J,Citigroup Inc. Dep Shs Repstg 1/1000 Pfd Ser J Fixed/Fltg,$28.91,0.02,0.069%,,United States,,52515,,
+add,C^K,Citigroup Inc. Dep Shs Repstg 1/1000th Pfd Ser K,$28.74,0.05,0.174%,,United States,,41271,,
+add,C^N,Citigroup Capital XIII 7.875% Fixed rate Floating Rate trust Preferred Securities (TruPS),$27.82,0.02,0.072%,,United States,,44101,,
+add,CAAP,Corporacion America Airports SA Common Shares,$5.37,-0.20,-3.591%,862487847.00,,2018,308414,Transportation,Aerospace
+add,CABO,Cable One Inc. Common Stock,$1775.00,2.44,0.138%,10712487100.00,United States,2015,20006,Consumer Services,Telecommunications Equipment
+add,CACI,CACI International Inc. Class A Common Stock,$264.60,3.97,1.523%,6231522100.00,United States,,118396,Technology,EDP Services
+add,CADE,Cadence Bancorporation Class A Common Stock,$21.84,-0.34,-1.533%,2723988365.00,United States,2017,326581,Finance,Major Banks
+add,CAE,CAE Inc. Ordinary Shares,$31.82,0.23,0.728%,9335267213.00,Canada,,265029,,
+add,CAF,Morgan Stanley China A Share Fund Inc. Common Stock,$23.53,0.03,0.128%,514870871.00,United States,2006,26005,,
+add,CAG,ConAgra Brands Inc. Common Stock,$37.265,-0.045,-0.121%,17885219924.00,United States,,2878620,Consumer Non-Durables,Packaged Foods
+add,CAH,Cardinal Health Inc. Common Stock,$59.96,1.40,2.391%,17397269703.00,United States,,1951782,Health Care,Other Pharmaceuticals
+add,CAI,CAI International Inc. Common Stock,$37.86,-1.59,-4.03%,655133642.00,United States,,170724,Technology,Diversified Commercial Services
+add,CAI^A,CAI International Inc. 8.50% Series A Fixed-to-Floating Rate Cumulative Redeemable Perpetual Preferred Stock,$27.20,0.31,1.153%,,United States,,8414,,
+add,CAI^B,CAI International Inc. 8.50% Series B Fixed-to-Floating Rate Cumulative Redeemable Perpetual Preferred Stock,$27.40,-0.19,-0.689%,,United States,,3339,,
+add,CAJ,Canon Inc. American Depositary Shares,$24.12,0.32,1.345%,25224060317.00,Japan,,127320,Miscellaneous,Industrial Machinery/Components
+add,CAL,Caleres Inc. Common Stock,$26.57,-0.82,-2.994%,1018220349.00,United States,,296694,Consumer Non-Durables,Shoe Manufacturing
+add,CALX,Calix Inc Common Stock,$45.94,-0.15,-0.325%,2887490663.00,United States,2010,170769,Technology,Computer Software: Prepackaged Software
+add,CANG,Cango Inc. American Depositary Shares  each representing two (2) Class A Ordinary Shares,$5.415,-0.135,-2.432%,790343314.00,,2018,326966,Technology,Computer Software: Prepackaged Software
+add,CANO,Cano Health Inc. Class A Common Stock,$14.70,-0.06,-0.407%,1267875000.00,,2020,827242,Health Care,Medical/Nursing Services
+add,CAP,Capitol Investment Corp. V Class A Common Stock,$9.92,0.01,0.101%,427800000.00,,2007,222003,,
+add,CAPL,CrossAmerica Partners LP Common Units representing limited partner interests,$19.73,0.32,1.649%,747271146.00,United States,2012,81872,,
+add,CARR,Carrier Global Corporation Common Stock ,$45.96,-0.23,-0.498%,39939171060.00,,2020,2001999,Capital Goods,Wholesale Distributors
+add,CARS,Cars.com Inc. Common Stock ,$14.045,0.045,0.321%,964099250.00,,2017,216831,,
+add,CAS,Cascade Acquisition Corp. Class A Common Stock,$9.87,-0.03,-0.303%,283762500.00,,2021,1602,,
+add,CAT,Caterpillar Inc. Common Stock,$226.42,-8.23,-3.507%,124029966956.00,United States,,4745630,Capital Goods,Construction/Ag Equipment/Trucks
+add,CATO,Cato Corporation (The) Class A Common Stock,$16.0801,-0.6699,-3.999%,363307219.00,United States,,48110,,
+add,CB,Chubb Limited  Common Stock,$165.83,-1.47,-0.879%,74572188052.00,Switzerland,,1269579,Finance,Property-Casualty Insurers
+add,CBAH,CBRE Acquisition Holdings Inc. Class A Common Stock,$9.75,-0.06,-0.612%,412059375.00,,2021,35218,,
+add,CBB,Cincinnati Bell Inc. Common Stock,$15.43,0.01,0.065%,785704025.00,United States,,125583,Public Utilities,Telecommunications Equipment
+add,CBB^B,Cincinnati Bell Inc. Preferred Stock,$50.4076,0.0939,0.187%,,United States,,349,,
+add,CBD,Companhia Brasileira de Distribuicao American Depsitary Shares; each representing one Common Share,$7.92,0.10,1.279%,2125344411.00,Brazil,2020,611645,Consumer Services,Food Chains
+add,CBH,Virtus AllianzGI Convertible & Income 2024 Target Term Fund Common Shares of Beneficial Interest,$10.49,0.10,0.962%,191531833.00,United States,2017,6757,,
+add,CBRE,CBRE Group Inc Common Stock Class A,$88.165,-0.875,-0.983%,29593233789.00,United States,,764247,Finance,Real Estate
+add,CBT,Cabot Corporation Common Stock,$62.33,-0.49,-0.78%,3530005385.00,United States,,93331,Basic Industries,Specialty Chemicals
+add,CBU,Community Bank System Inc. Common Stock,$79.22,-0.79,-0.987%,4268631778.00,United States,,59392,Finance,Major Banks
+add,CBZ,CBIZ Inc. Common Stock,$32.73,-0.15,-0.456%,1739468580.00,United States,,62798,Miscellaneous,Business Services
+add,CC,Chemours Company (The) Common Stock,$37.26,-0.62,-1.637%,6167510497.00,United States,2015,871333,Basic Industries,Industrial Specialties
+add,CCAC,CITIC Capital Acquisition Corp. Class A Ordinary Shares,$9.95,-0.01,-0.10%,343275000.00,,2020,94672,Finance,Business Services
+add,CCEP,Coca-Cola Europacific Partners plc Ordinary Shares,$61.49,-0.26,-0.421%,28026602487.00,,2016,651132,Consumer Non-Durables,Beverages (Production/Distribution)
+add,CCI,Crown Castle International Corp. (REIT) Common Stock,$200.13,3.04,1.542%,86494113854.00,United States,,2049881,,
+add,CCIV,Churchill Capital Corp IV Class A Common Stock,$25.41,-1.08,-4.077%,6574837500.00,United States,2020,10804658,,
+add,CCJ,Cameco Corporation Common Stock,$21.68,0.33,1.546%,8620907524.00,Canada,1996,2727881,Basic Industries,Precious Metals
+add,CCK,Crown Holdings Inc.,$100.53,0.84,0.843%,13561392147.00,United States,,706024,Consumer Durables,Containers/Packaging
+add,CCL,Carnival Corporation Common Stock,$29.84,-0.61,-2.003%,35525728997.00,United States,1987,26372978,,
+add,CCM,Concord Medical Services Holdings Limited ADS (Each represents three ordinary shares),$2.97,0.01,0.338%,128939574.00,China,2009,22707,Health Care,Medical/Nursing Services
+add,CCO,Clear Channel Outdoor Holdings Inc. Common Stock,$2.725,-0.105,-3.71%,1283020432.00,United States,2005,7942162,Technology,Advertising
+add,CCS,Century Communities Inc. Common Stock,$66.815,-6.865,-9.317%,2253114250.00,United States,2014,2297486,Capital Goods,Homebuilding
+add,CCU,Compania Cervecerias Unidas S.A. Common Stock,$18.39,0.13,0.712%,3397578908.00,Chile,,320521,Consumer Non-Durables,Beverages (Production/Distribution)
+add,CCV,Churchill Capital Corp V Class A Common Stock,$10.07,0.1279,1.286%,0.00,,2021,90439,,
+add,CCVI,Churchill Capital Corp VI Class A Common Stock,$9.945,0.025,0.252%,686205000.00,,2021,21303,,
+add,CCX,Churchill Capital Corp II Class A Common Stock,$11.57,1.40,13.766%,997912500.00,,2019,5038223,,
+add,CCZ,Comcast Holdings ZONES,$68.96,0.905,1.33%,0.00,United States,,353,Consumer Services,Television Services
+add,CDAY,Ceridian HCM Holding Inc. Common Stock,$87.42,1.21,1.404%,13046361657.00,United States,2018,568761,Technology,EDP Services
+add,CDE,Coeur Mining Inc. Common Stock,$11.03,0.47,4.451%,2835919848.00,United States,,3572988,Basic Industries,Precious Metals
+add,CDR,Cedar Realty Trust Inc. Common Stock,$15.21,-0.07,-0.458%,207283523.00,United States,,57090,Consumer Services,Real Estate Investment Trusts
+add,CDR^B,Cedar Realty Trust Inc. 7.25% Series B Cumulative Redeemable Preferred Stock,$25.26,-0.1999,-0.785%,,United States,,876,,
+add,CDR^C,Cedar Realty Trust Inc. 6.50% Series C Cumulative Redeemable Preferred Stock,$25.16,0.03,0.119%,,United States,,12324,,
+add,CE,Celanese Corporation Celanese Corporation Common Stock,$161.52,-0.76,-0.468%,18192411091.00,United States,2005,395212,Basic Industries,Major Chemicals
+add,CEA,China Eastern Airlines Corporation Ltd. Common Stock,$22.04,-0.31,-1.387%,7220087655.00,China,1997,7273,Transportation,Air Freight/Delivery Services
+add,CEE,The Central and Eastern Europe Fund Inc. (The) Common Stock,$28.14,0.059,0.21%,181871634.00,United States,,7727,,
+add,CEIX,CONSOL Energy Inc. Common Stock ,$17.88,1.03,6.113%,606782153.00,,2017,382809,,
+add,CELP,Cypress Environmental Partners L.P. Common Units representing limited partner interests,$2.55,-0.01,-0.391%,31444828.00,,2014,49420,Energy,Oilfield Services/Equipment
+add,CEM,ClearBridge MLP and Midstream Fund Inc. Common Stock,$31.41,0.39,1.257%,442346779.00,United States,2010,143470,,
+add,CEN,Center Coast Brookfield MLP & Energy Infrastructure Fund,$13.905,0.165,1.201%,68550885.00,United States,2013,11864,Finance,Finance Companies
+add,CEPU,Central Puerto S.A. American Depositary Shares (each represents ten Common Shares),$2.73,-0.06,-2.151%,410911519.00,,2018,436765,Public Utilities,Electric Utilities: Central
+add,CEQP,Crestwood Equity Partners LP,$32.175,0.685,2.175%,2021627901.00,United States,,494799,Energy,Oilfield Services/Equipment
+add,CEQP^,Crestwood Equity Partners LP Preferred Units representing limited partner interests,$9.384,-0.1159,-1.22%,,United States,,213167,,
+add,CF,CF Industries Holdings Inc. Common Stock,$53.80,-1.70,-3.063%,11540901835.00,United States,2005,1635896,Basic Industries,Agricultural Chemicals
+add,CFG,Citizens Financial Group Inc. Common Stock,$47.455,-0.985,-2.033%,20212515695.00,United States,2014,2549806,Finance,Major Banks
+add,CFG^D,Citizens Financial Group Inc. Depositary Shares each representing a 1/40th Interest in a Share of 6.350% Fixed-to-Floating Rate Non-Cumulative Perpetual Preferred Stock Series D,$28.67,0.01,0.035%,,United States,,15315,,
+add,CFG^E,Citizens Financial Group Inc. Depositary Shares Each Representing 1/40th Interest in a Share of 5.000% Fixed-Rate Non-Cumulative Perpetual Preferred Stock Series E,$26.50,0.00,0.00%,,United States,,44290,,
+add,CFR,Cullen/Frost Bankers Inc. Common Stock,$116.48,-2.21,-1.862%,7401756078.00,United States,,165174,Finance,Major Banks
+add,CFR^B,Cullen/Frost Bankers Inc. Depositary Shares each representing a 1/40th ownership interest in a share of 4.450% non-cumulative perpetual preferred stock Series B,$25.47,0.00,0.00%,,United States,,32726,,
+add,CFX,Colfax Corporation Common Stock,$45.91,0.61,1.347%,6225273466.00,United States,2008,1069534,Capital Goods,Fluid Controls
+add,CFXA,Colfax Corporation 5.75% Tangible Equity Units,$186.96,0.18,0.096%,0.00,United States,2019,10395,Capital Goods,Fluid Controls
+add,CGA,China Green Agriculture Inc. Common Stock,$12.025,-0.615,-4.866%,102063739.00,China,,25680,Basic Industries,Agricultural Chemicals
+add,CGAU,Centerra Gold Inc. Common Shares,$8.275,0.075,0.915%,2455162354.00,,2021,85817,Basic Industries,Precious Metals
+add,CHAA,Catcha Investment Corp. Class A Ordinary Shares,$9.71,-0.04,-0.41%,364125000.00,,2021,31260,Finance,Business Services
+add,CHCT,Community Healthcare Trust Incorporated Common Stock,$50.46,-0.07,-0.139%,1232088077.00,United States,2015,34043,Consumer Services,Real Estate Investment Trusts
+add,CHD,Church & Dwight Company Inc. Common Stock,$84.5575,0.0175,0.021%,20737380358.00,United States,,1205539,Consumer Non-Durables,Package Goods/Cosmetics
+add,CHE,Chemed Corp,$485.65,3.18,0.659%,7746328758.00,United States,,23900,Health Care,Medical/Nursing Services
+add,CHGG,Chegg Inc. Common Stock,$76.03,1.49,1.999%,10791324513.00,,2013,495883,Miscellaneous,Service to the Health Industry
+add,CHH,Choice Hotels International Inc. Common Stock,$121.48,-0.03,-0.025%,6749512378.00,United States,,104137,Consumer Services,Hotels/Resorts
+add,CHMI,Cherry Hill Mortgage Investment Corporation Common Stock,$10.48,0.00,0.00%,179137113.00,,2013,161829,Consumer Services,Real Estate Investment Trusts
+add,CHMI^A,Cherry Hill Mortgage Investment Corporation 8.20% Series A Cumulative Redeemable Preferred Stock,$25.99,-0.105,-0.402%,,,,2426,,
+add,CHMI^B,Cherry Hill Mortgage Investment Corporation 8.250% Series B Fixed-to-Floating Rate Cumulative Redeemable Preferred Stock,$25.8612,0.0412,0.16%,,,,2385,,
+add,CHN,China Fund Inc. (The) Common Stock,$30.375,0.075,0.248%,317215693.00,United States,,1982,,
+add,CHPT,ChargePoint Holdings Inc. Common Stock,$28.09,-0.22,-0.777%,8587703199.00,,2019,2808747,,
+add,CHRA,Charah Solutions Inc. Common Stock,$6.02,0.09,1.518%,183177722.00,United States,2018,86938,Public Utilities,Medical Specialities
+add,CHS,Chico's FAS Inc. Common Stock,$5.335,-0.275,-4.902%,654079675.00,United States,,2447859,Consumer Services,Clothing/Shoe/Accessory Stores
+add,CHT,Chunghwa Telecom Co. Ltd.,$41.63,0.23,0.556%,32294249946.00,Taiwan,,49742,Public Utilities,Telecommunications Equipment
+add,CHWY,Chewy Inc. Class A Common Stock,$79.56,1.79,2.302%,33048874175.00,,2019,7174402,Consumer Services,Catalog/Specialty Distribution
+add,CI,Cigna Corporation Common Stock,$239.43,-2.58,-1.066%,82028718000.00,United States,,1262569,Health Care,Medical Specialities
+add,CIA,Citizens Inc. Class A Common Stock ($1.00 Par),$5.005,-0.065,-1.282%,248266048.00,United States,,41915,Finance,Life Insurance
+add,CIB,BanColombia S.A. Common Stock,$31.39,0.11,0.352%,7547937383.00,Colombia,,411036,Finance,Commercial Banks
+add,CIEN,Ciena Corporation Common Stock,$59.02,-1.06,-1.764%,9145864440.00,United States,1997,1188392,Public Utilities,Telecommunications Equipment
+add,CIF,MFS Intermediate High Income Fund Common Stock,$3.005,-0.01,-0.332%,57896364.00,United States,,79914,,
+add,CIG,Comp En De Mn Cemig ADS American Depositary Shares,$2.67,0.02,0.755%,4519538827.00,Brazil,,4627236,Public Utilities,Electric Utilities: Central
+add,CII,Blackrock Capital and Income Fund Inc.,$20.765,0.105,0.508%,916180871.00,United States,2004,88826,,
+add,CIM,Chimera Investment Corporation Common Stock,$15.465,-0.155,-0.992%,3565535658.00,United States,2007,1868220,Consumer Services,Real Estate Investment Trusts
+add,CIM^A,Chimera Investment Corporation 8.00% Series A Cumulative Redeemable Preferred Stock,$25.42,0.00,0.00%,,United States,,8999,,
+add,CIM^B,Chimera Investment Corporation 8.00% Series B Fixed-to-Floating Rate Cumulative Redeemable Preferred Stock,$25.75,0.14,0.547%,,United States,,25663,,
+add,CIM^C,Chimera Investment Corporation 7.75% Series C Fixed-to-Floating Rate  Cumulative Redeemable  Preferred Stock,$25.405,-0.095,-0.373%,,United States,,34277,,
+add,CIM^D,Chimera Investment Corporation 8.00% Series D Fixed-to-Floating Rate Cumulative Redeemable Preferred Stock,$25.4116,0.2116,0.84%,,United States,,51673,,
+add,CINR,Ciner Resources LP Common Units representing Limited Partner Interests,$14.10,0.24,1.732%,278889371.00,,2013,26145,Basic Industries,Specialty Chemicals
+add,CIO,City Office REIT Inc. Common Stock,$12.855,0.005,0.039%,557869939.00,,2014,124170,Consumer Services,Real Estate Investment Trusts
+add,CIO^A,City Office REIT Inc. 6.625% Series A Cumulative Redeemable Preferred Stock,$25.69,-0.03,-0.117%,,,,1018,,
+add,CIR,CIRCOR International Inc. Common Stock,$37.11,-0.81,-2.136%,751361531.00,United States,,43742,Capital Goods,Fluid Controls
+add,CIT,CIT Group Inc (DEL) Common Stock,$52.67,-0.68,-1.275%,5217819967.00,United States,,403887,Finance,Major Banks
+add,CIT^B,CIT Group Inc (DEL) 5.625 % Non-Cumulative Perpetual Preferred Stock Series B,$26.745,-0.065,-0.242%,,United States,,9334,,
+add,CIXX,CI Financial Corp. Common Shares,$18.13,-0.19,-1.037%,3723891049.00,,,13326,,
+add,CL,Colgate-Palmolive Company Common Stock,$83.505,0.945,1.145%,70642622974.00,United States,,3313517,Consumer Non-Durables,Package Goods/Cosmetics
+add,CLAA,Colonnade Acquisition Corp. II Class A Ordinary Shares,$9.79,-0.01,-0.102%,403837500.00,,2021,2247,,
+add,CLAS,Class Acceleration Corp. Class A Common Stock,$9.72,0.01,0.103%,314381250.00,,2021,13303,,
+add,CLB,Core Laboratories N.V. Common Stock,$48.32,1.39,2.962%,2237515391.00,Netherlands,1995,267799,Energy,Oilfield Services/Equipment
+add,CLDR,Cloudera Inc. Common Stock,$15.815,-0.025,-0.158%,4621373456.00,Canada,2017,3762283,Technology,Computer Software: Prepackaged Software
+add,CLDT,Chatham Lodging Trust (REIT) Common Shares of Beneficial Interest,$13.69,-0.24,-1.723%,665579297.00,United States,2010,128864,Consumer Services,Real Estate Investment Trusts
+add,CLF,Cleveland-Cliffs Inc. Common Stock,$23.00,-0.22,-0.947%,11486252624.00,United States,,70622445,,
+add,CLH,Clean Harbors Inc. Common Stock,$94.42,-0.49,-0.516%,5152017575.00,United States,,273505,,
+add,CLI,Mack-Cali Realty Corporation Common Stock,$17.88,0.14,0.789%,1622264004.00,United States,,891459,Consumer Services,Real Estate Investment Trusts
+add,CLII,Climate Change Crisis Real Impact I Acquisition Corporation Class A Common Stock,$13.775,0.985,7.701%,396031250.00,United States,2020,455662,Consumer Services,Automotive Aftermarket
+add,CLIM,Climate Real Impact Solutions II Acquisition Corporation Class A Common Stock,$9.95,0.02,0.201%,240292500.00,,2021,18744,,
+add,CLNC,Colony Credit Real Estate Inc. Class A Common Stock,$10.46,-0.05,-0.476%,1357315583.00,,2018,250407,Consumer Services,Real Estate Investment Trusts
+add,CLNY,Colony Capital Inc.,$8.045,-0.145,-1.77%,3919167108.00,United States,2014,2428203,Consumer Services,Real Estate Investment Trusts
+add,CLNY^G,Colony Capital Inc. 7.50% Series G cumulative redeemable perpetual preferred stock,$25.41,0.11,0.435%,,United States,,2420,,
+add,CLNY^H,Colony Capital Inc. 7.125% Series H cumulative redeemable perpetual preferred stock,$25.29,0.011,0.044%,,United States,,8590,,
+add,CLNY^I,Colony Capital Inc. 7.15% Series I Cumulative Redeemable Perpetual Preferred Stock,$25.28,0.20,0.797%,,United States,,53053,,
+add,CLNY^J,Colony Capital Inc. 7.125% Series J Cumulative Redeemable Perpetual Preferred Stock,$25.31,0.01,0.04%,,United States,,22944,,
+add,CLPR,Clipper Realty Inc. Common Stock,$7.95,0.08,1.017%,127702663.00,United States,2017,122929,Consumer Services,Real Estate Investment Trusts
+add,CLR,Continental Resources Inc. Common Stock,$35.40,-0.06,-0.169%,13010724769.00,United States,2007,733489,Energy,Oil & Gas Production
+add,CLS,Celestica Inc. Common Stock,$8.445,-0.005,-0.059%,1084338000.00,Canada,1998,77981,,
+add,CLVT,Clarivate Plc Ordinary Shares,$26.045,-0.345,-1.307%,15936885051.00,,2019,31753959,Consumer Services,Movies/Entertainment
+add,CLW,Clearwater Paper Corporation Common Stock,$28.075,-0.195,-0.69%,468419640.00,United States,,109871,Basic Industries,Paper
+add,CLX,Clorox Company (The) Common Stock,$176.24,0.54,0.307%,21919327448.00,United States,,963647,Consumer Durables,Specialty Chemicals
+add,CM,Canadian Imperial Bank of Commerce Common Stock,$119.33,0.16,0.134%,53590282726.00,Canada,,327135,Finance,Commercial Banks
+add,CMA,Comerica Incorporated Common Stock,$73.94,-2.17,-2.851%,10322968879.00,United States,,1130148,Finance,Major Banks
+add,CMC,Commercial Metals Company Common Stock,$32.83,0.01,0.03%,3956355447.00,United States,,927617,Basic Industries,Steel/Iron Ore
+add,CMCM,Cheetah Mobile Inc. American Depositary Shares each representing 10 Class Ordinary Shares,$2.7511,0.2011,7.886%,385998626.00,,2014,1475761,Technology,Computer Software: Prepackaged Software
+add,CMG,Chipotle Mexican Grill Inc. Common Stock,$1343.00,14.43,1.086%,37806093297.00,United States,2006,154770,Consumer Services,Restaurants
+add,CMI,Cummins Inc. Common Stock,$252.17,-4.60,-1.791%,36867904094.00,United States,,879599,Capital Goods,Construction/Ag Equipment/Trucks
+add,CMO,Capstead Mortgage Corporation Common Stock,$6.74,-0.08,-1.173%,652754913.00,United States,,347021,Consumer Services,Real Estate Investment Trusts
+add,CMO^E,Capstead Mortgage Corporation Pfd Ser E,$25.49,0.07,0.275%,,United States,,18329,,
+add,CMP,Compass Minerals Intl Inc Common Stock,$66.04,-0.12,-0.181%,2245437993.00,United States,2003,135434,Basic Industries,Precious Metals
+add,CMRE,Costamare Inc. Common Stock $0.0001 par value,$11.54,0.32,2.852%,1413921236.00,Greece,2010,438187,Transportation,Marine Transportation
+add,CMRE^B,Costamare Inc. Perpetual Preferred Stock Series B (Marshall Islands),$25.60,0.00,0.00%,,Greece,,30,,
+add,CMRE^C,Costamare Inc. Perpetual Preferred Series C (Marshall Islands),$26.09,0.05,0.192%,,Greece,,3890,,
+add,CMRE^D,Costamare Inc. 8.75% Series D Cumulative Redeemable Perpetual Preferred Stock,$26.17,0.0658,0.252%,,Greece,,541,,
+add,CMRE^E,Costamare Inc. 8.875% Series E Cumulative Redeemable Perpetual Preferred Stock par value $0.0001,$27.316,0.256,0.946%,,Greece,,9412,,
+add,CMS,CMS Energy Corporation Common Stock,$60.35,0.42,0.701%,17468884446.00,United States,,2407096,Public Utilities,Power Generation
+add,CMS^B,CMS Energy Corporation Preferred Stock,$108.50,-0.10,-0.092%,,United States,,71,,
+add,CMSA,CMS Energy Corporation 5.625% Junior Subordinated Notes due 2078,$27.3282,0.0182,0.067%,0.00,United States,2018,3453,Public Utilities,Power Generation
+add,CMSC,CMS Energy Corporation 5.875% Junior Subordinated Notes due 2078,$27.82,0.06,0.216%,0.00,United States,2018,4965,Public Utilities,Power Generation
+add,CMSD,CMS Energy Corporation 5.875% Junior Subordinated Notes due 2079,$27.7296,0.0996,0.36%,0.00,United States,2019,29017,Public Utilities,Power Generation
+add,CMU,MFS Municipal Income Trust Common Stock,$4.69,0.01,0.214%,132845723.00,United States,1987,50300,,
+add,CNA,CNA Financial Corporation Common Stock,$47.59,-0.05,-0.105%,12928149396.00,United States,,67146,Finance,Property-Casualty Insurers
+add,CNC,Centene Corporation Common Stock,$71.02,-0.64,-0.893%,41385823863.00,United States,,2173088,Health Care,Medical Specialities
+add,CND,Concord Acquisition Corp. Class A Common Stock,$9.82,0.00,0.00%,346174640.00,,2021,5769,,
+add,CNF,CNFinance Holdings Limited American Depositary Shares each representing  twenty (20) Ordinary Shares,$3.165,-0.035,-1.094%,217062543.00,,2018,220,Finance,Finance: Consumer Services
+add,CNHI,CNH Industrial N.V. Common Shares,$17.46,-0.44,-2.458%,23645074137.00,,2013,3127680,Capital Goods,Construction/Ag Equipment/Trucks
+add,CNI,Canadian National Railway Company Common Stock,$110.415,0.455,0.414%,78173820000.00,Canada,,1567187,,
+add,CNK,Cinemark Holdings Inc Cinemark Holdings Inc. Common Stock,$22.28,-0.93,-4.007%,2663374527.00,United States,2007,2603147,Consumer Services,Movies/Entertainment
+add,CNMD,CONMED Corporation Common Stock,$136.065,2.465,1.845%,3958422165.00,United States,1987,116022,Health Care,Biotechnology: Electromedical & Electrotherapeutic Apparatus
+add,CNNE,Cannae Holdings Inc. Common Stock,$34.94,0.16,0.46%,3202469200.00,,2017,300910,Consumer Services,Catalog/Specialty Distribution
+add,CNO,CNO Financial Group Inc. Common Stock,$24.75,-0.48,-1.902%,3256289957.00,United States,,893163,Finance,Life Insurance
+add,CNO^A,CNO Financial Group Inc. 5.125% Subordinated Debentures due 2060,$25.99,0.00,0.00%,,United States,,803,,
+add,CNP,CenterPoint Energy Inc (Holding Co) Common Stock,$25.95,0.18,0.698%,15063867385.00,United States,,3034258,Public Utilities,Power Generation
+add,CNP^B,CenterPoint Energy Inc. Depositary Shares Each Representing a 1/20th Interest in a Share of 7.00% Series B Mandatory Convertible Preferred Stock,$46.67,0.18,0.387%,,United States,,59687,,
+add,CNQ,Canadian Natural Resources Limited Common Stock,$37.015,-0.015,-0.041%,43856741555.00,Canada,,1722511,Energy,Oil & Gas Production
+add,CNR,Cornerstone Building Brands Inc. Common Stock,$18.25,-0.36,-1.934%,2294179231.00,United States,,484274,Capital Goods,Metal Fabrications
+add,CNS,Cohen & Steers Inc Common Stock,$74.11,-0.24,-0.323%,3575115980.00,United States,2004,35609,Finance,Investment Managers
+add,CNX,CNX Resources Corporation Common Stock,$14.645,0.205,1.42%,3225855468.00,United States,1999,1068183,Energy,Oil & Gas Production
+add,CO,Global Cord Blood Corporation Common Stock,$5.70,0.02,0.352%,692841128.00,Hong Kong,,273857,Health Care,Managed Health Care
+add,CODI,D/B/A Compass Diversified Holdings Shares of Beneficial Interest,$25.63,-0.29,-1.119%,1663387000.00,United States,2006,60975,,
+add,CODI^A,Compass Diversified Holdings 7.250% Series A Preferred Shares representing beneficial interest in Compass Diversified Holdings,$25.85,0.2766,1.082%,,United States,,6072,,
+add,CODI^B,Compass Diversified Holdings 7.875% Series B Fixed-to-Floating Rate Cumulative Preferred Shares representing beneficial interests in Compass Diversified Holdings,$26.2936,0.2236,0.858%,,United States,,5419,,
+add,CODI^C,Compass Diversified Holdings 7.875% Series C Cumulative Preferred Shares,$26.0315,0.0815,0.314%,,United States,,7345,,
+add,COE,China Online Education Group American depositary shares each representing 15 Class A ordinary shares,$11.29,-1.16,-9.317%,242783671.00,China,2016,157945,Miscellaneous,Service to the Health Industry
+add,COF,Capital One Financial Corporation Common Stock,$158.89,-1.71,-1.065%,71737141709.00,United States,1994,2935707,Finance,Finance Companies
+add,COF^G,Capital One Financial Corporation Depositary Shares Each Representing a 1/40th Interest in a Share of Fixed Rate Non-Cumulative Perpetual Preferred Stock Series G,$25.60,-0.05,-0.195%,,United States,,13976,,
+add,COF^H,Capital One Financial Corporation Depositary Shares Each Representing 1/40th Interest in a Share of Fixed Rate Non-Cumulative Perpetual Preferred Stock Series H,$25.76,0.00,0.00%,,United States,,39679,,
+add,COF^I,Capital One Financial Corporation Depositary shares each representing a 1/40th interest in a share of Fixed Rate Non-Cumulative Perpetual Preferred Stock Series I of the Issuer,$26.38,0.01,0.038%,,United States,,116158,,
+add,COF^J,Capital One Financial Corporation Depositary Shares Each Representing a 1/40th Interest in a Share of Fixed Rate Non- Cumulative Perpetual Preferred Stock Series J,$25.87,-0.04,-0.154%,,United States,,79497,,
+add,COF^K,Capital One Financial Corporation Depositary Shares Each Representing a 1/40th Ownership Interest in a Share of Fixed Rate Non-Cumulative Perpetual Preferred Stock Series K,$26.2714,0.1095,0.419%,,United States,,1860,,
+add,COF^L,Capital One Financial Corporation Depositary Shares Each Representing a 1/40th Interest in a Share of Fixed Rate Non-Cumulative Perpetual Preferred Stock Series L,$25.17,0.03,0.119%,,United States,,61391,,
+add,COG,Cabot Oil & Gas Corporation Common Stock,$17.325,0.105,0.61%,6924181936.00,United States,1990,6089972,Energy,Oil & Gas Production
+add,COLD,Americold Realty Trust Common Shares,$39.42,0.16,0.408%,9955069878.00,United States,2018,1155900,Finance,Real Estate
+add,COMP,Compass Inc. Class A Common Stock,$14.74,-0.18,-1.206%,5807163332.00,,2021,425678,Technology,EDP Services
+add,COO,The Cooper Companies Inc. Common Stock,$373.56,1.15,0.309%,18397062708.00,United States,,200273,Health Care,Ophthalmic Goods
+add,COP,ConocoPhillips Common Stock,$60.335,0.655,1.098%,81417162422.00,United States,,8120674,Energy,Integrated oil Companies
+add,COR,CoreSite Realty Corporation Common Stock,$138.10,2.57,1.896%,5936207233.00,United States,2010,337714,Consumer Services,Real Estate Investment Trusts
+add,CORR,CorEnergy Infrastructure Trust Inc. Common Stock,$7.54,0.57,8.178%,102932468.00,United States,,727091,Consumer Services,Real Estate Investment Trusts
+add,CORR^A,CorEnergy Infrastructure Trust Inc. Depositary Shares each representing a 1/100th fractional interest of a share of 7.375% Series A Cumulative Redeemable Preferred Stock,$24.39,0.29,1.203%,,United States,,11041,,
+add,COTY,Coty Inc. Class A Common Stock,$8.68,-0.12,-1.364%,6649809489.00,United States,2013,5438291,Consumer Non-Durables,Package Goods/Cosmetics
+add,COUR,Coursera Inc. Common Stock,$44.20,0.79,1.82%,6001054730.00,,2021,719419,Miscellaneous,Other Consumer Services
+add,CP,Canadian Pacific Railway Limited Common Stock,$80.16,-0.29,-0.36%,53435344174.00,Canada,,856065,,
+add,CPA,Copa Holdings S.A. Copa Holdings S.A. Class A Common Stock,$75.675,-0.985,-1.285%,3214761934.00,Panama,2005,185338,Transportation,Air Freight/Delivery Services
+add,CPAC,Cementos Pacasmayo S.A.A. American Depositary Shares (Each representing five Common Shares),$7.905,-0.095,-1.188%,733816945.00,Peru,,25087,Capital Goods,Building Materials
+add,CPB,Campbell Soup Company Common Stock,$45.735,-0.185,-0.403%,13858132622.00,United States,,3620987,Consumer Non-Durables,Packaged Foods
+add,CPE,Callon Petroleum Company Common Stock,$48.51,-2.12,-4.187%,2244308844.00,United States,,1724111,Energy,Oil & Gas Production
+add,CPF,Central Pacific Financial Corp New,$27.30,-0.81,-2.882%,772386069.00,United States,,165017,Finance,Major Banks
+add,CPG,Crescent Point Energy Corporation Ordinary Shares (Canada),$4.61,0.05,1.096%,2681518145.00,Canada,,5256831,Energy,Oil & Gas Production
+add,CPK,Chesapeake Utilities Corporation Common Stock,$118.51,0.00,0.00%,2077722771.00,United States,,23188,Public Utilities,Oil & Gas Production
+add,CPLG,CorePoint Lodging Inc. Common Stock ,$10.425,-0.085,-0.809%,610107206.00,,2018,58511,Consumer Services,Real Estate Investment Trusts
+add,CPNG,Coupang Inc. Class A Common Stock,$38.04,0.26,0.688%,65906590350.00,,2021,2689110,Capital Goods,Recreational Products/Toys
+add,CPRI,Capri Holdings Limited Ordinary Shares,$53.43,-1.12,-2.053%,8085402625.00,Hong Kong,2011,1392247,,
+add,CPS,Cooper-Standard Holdings Inc. Common Stock,$31.29,0.19,0.611%,530142653.00,United States,,67462,Capital Goods,Auto Parts:O.E.M.
+add,CPSR,Capstar Special Purpose Acquisition Corp. Class A Common Stock,$9.83,0.00,0.00%,339135000.00,,2020,2221,,
+add,CPT,Camden Property Trust Common Stock,$135.02,2.19,1.649%,13189109243.00,United States,1993,539967,Consumer Services,Real Estate Investment Trusts
+add,CPTK,Crown PropTech Acquisitions Class A Ordinary Shares,$9.69,0.00,0.00%,334305000.00,,2021,6848,Finance,Business Services
+add,CPUH,Compute Health Acquisition Corp. Class A Common Stock,$9.80,-0.02,-0.204%,1056562500.00,,2021,206131,,
+add,CR,Crane Co. Common Stock,$91.37,0.34,0.374%,5336787843.00,United States,,175863,Capital Goods,Office Equipment/Supplies/Services
+add,CRC,California Resources Corporation Common Stock,$32.575,-0.195,-0.595%,2714137925.00,,2020,792493,Energy,Oil & Gas Production
+add,CRD/A,Crawford & Company,$9.45,0.20,2.162%,,United States,,26042,,
+add,CRD/B,Crawford & Company,$9.22,0.22,2.444%,,United States,,2011,,
+add,CRH,CRH PLC American Depositary Shares,$52.13,0.23,0.443%,40836044154.00,Ireland,,293133,Capital Goods,Building Materials
+add,CRHC,Cohn Robbins Holdings Corp. Class A Ordinary Shares,$9.90,0.00,0.00%,1024650000.00,United States,2020,448686,Finance,Business Services
+add,CRI,Carter's Inc. Common Stock,$103.02,-0.39,-0.377%,4528437469.00,United States,2003,243010,Consumer Services,Clothing/Shoe/Accessory Stores
+add,CRK,Comstock Resources Inc. Common Stock,$6.235,0.215,3.571%,1449077709.00,United States,,4844864,Energy,Oil & Gas Production
+add,CRL,Charles River Laboratories International Inc. Common Stock,$354.0675,8.1575,2.358%,17792888221.00,United States,2000,276808,Consumer Services,EDP Services
+add,CRM,Salesforce.com Inc Common Stock,$240.02,3.93,1.665%,222258520000.00,United States,2004,3785846,Technology,Computer Software: Prepackaged Software
+add,CRS,Carpenter Technology Corporation Common Stock,$44.25,-0.88,-1.95%,2125432992.00,United States,,234884,Basic Industries,Steel/Iron Ore
+add,CRT,Cross Timbers Royalty Trust Common Stock,$10.06,-0.015,-0.149%,60360000.00,United States,1992,28631,Energy,Oil & Gas Production
+add,CRU,Crucible Acquisition Corporation Class A Common Stock,$9.71,0.0002,0.002%,314057813.00,,2021,3326,,
+add,CRY,CryoLife Inc. Common Stock,$28.90,0.13,0.452%,1129932547.00,United States,,50821,Health Care,Medical/Dental Instruments
+add,CS,Credit Suisse Group American Depositary Shares,$10.705,-0.075,-0.696%,25306729598.00,Switzerland,,3221789,Finance,Investment Bankers/Brokers/Service
+add,CSAN,Cosan S.A. ADS,$19.89,0.46,2.367%,148529508080.00,,2021,300767,Consumer Durables,Automotive Aftermarket
+add,CSL,Carlisle Companies Incorporated Common Stock,$187.10,0.52,0.279%,9765097567.00,United States,,246664,,
+add,CSLT,Castlight Health Inc. Class B Common Stock,$1.955,-0.095,-4.634%,308731135.00,,2014,1219326,Health Care,Managed Health Care
+add,CSPR,Casper Sleep Inc. Common Stock,$9.79,-0.31,-3.069%,405700968.00,,2020,599893,Consumer Durables,Home Furnishings
+add,CSR,D/B/A Centerspace Common Stock,$75.63,0.10,0.132%,999844104.00,United States,,39747,,
+add,CSR^C,D/B/A Centerspace 6.625% Series C ,$26.55,0.2703,1.029%,,United States,,6378,,
+add,CSTA,Constellation Acquisition Corp I Class A Ordinary Shares,$9.735,0.005,0.051%,385749375.00,,2021,16557,Finance,Business Services
+add,CSTM,Constellium SE Ordinary Shares (France),$19.81,-0.27,-1.345%,2773312519.00,Netherlands,2013,1209678,Basic Industries,Aluminum
+add,CSU,Capital Senior Living Corporation Common Stock,$41.37,0.71,1.746%,90284854.00,United States,1997,8503,Health Care,Hospital/Nursing Management
+add,CSV,Carriage Services Inc. Common Stock,$37.945,-0.775,-2.002%,690599000.00,United States,,62178,Miscellaneous,Other Consumer Services
+add,CTA^A,E.I. du Pont de Nemours and Company Preferred Stock,$93.50,-0.40,-0.426%,,United States,,547,,
+add,CTA^B,E.I. du Pont de Nemours and Company Preferred Stock,$116.50,1.50,1.304%,,United States,,352,,
+add,CTAC,Cerberus Telecom Acquisition Corp. Class A Ordinary Shares,$9.94,0.03,0.303%,330151762.00,United States,2020,605188,Finance,Business Services
+add,CTBB,Qwest Corporation 6.5% Notes due 2056,$25.35,0.00,0.00%,0.00,United States,2016,41583,,
+add,CTDD,Qwest Corporation 6.75% Notes due 2057,$26.64,0.04,0.15%,0.00,United States,2017,18656,,
+add,CTK,CooTek (Cayman) Inc. American Depositary Shares each representing 50 Class A Ordinary Shares,$1.8611,-0.0289,-1.529%,120230190.00,,2018,240474,Technology,EDP Services
+add,CTLT,Catalent Inc. Common Stock,$108.91,1.61,1.50%,18551898537.00,United States,2014,731025,Health Care,Major Pharmaceuticals
+add,CTO,CTO Realty Growth Inc. Common Stock,$55.565,-0.205,-0.368%,331088998.00,United States,,37040,Consumer Services,Real Estate
+add,CTOS,Custom Truck One Source Inc. Common Stock,$9.39,-0.09,-0.949%,2311895270.00,Cayman Islands,2017,160075,Technology,Diversified Commercial Services
+add,CTR,ClearBridge MLP and Midstream Total Return Fund Inc. Common Stock,$26.795,0.425,1.612%,194622455.00,United States,2012,14590,,
+add,CTS,CTS Corporation Common Stock,$37.17,-0.35,-0.933%,1202388541.00,United States,,80727,Capital Goods,Industrial Machinery/Components
+add,CTT,CatchMark Timber Trust Inc. Class A Common Stock,$12.21,-0.29,-2.32%,597114556.00,United States,2013,113696,Consumer Services,Real Estate Investment Trusts
+add,CTVA,Corteva Inc. Common Stock ,$44.605,-0.885,-1.945%,32878390105.00,,2019,1931579,Basic Industries,Major Chemicals
+add,CUBB,Customers Bancorp Inc 5.375% Subordinated Notes Due 2034,$26.66,-0.05,-0.187%,0.00,United States,2019,5402,Finance,Major Banks
+add,CUBE,CubeSmart Common Shares,$46.47,0.43,0.934%,9364485557.00,United States,,327052,Consumer Services,Real Estate Investment Trusts
+add,CUBI,Customers Bancorp Inc Common Stock,$40.35,-2.06,-4.857%,1301943752.00,United States,,299865,Finance,Major Banks
+add,CUBI^C,Customers Bancorp Inc Fixed-to-Floating Rate Non-Cumulative Perpetual Preferred Stock Series C,$25.52,0.2225,0.88%,,United States,,6778,,
+add,CUBI^D,Customers Bancorp Inc Fixed-to-Floating Rate Non-Cumulative Perpetual Preferred Stock Series D,$25.3978,0.1978,0.785%,,United States,,3850,,
+add,CUBI^E,Customers Bancorp Inc Fixed-to-Floating Rate Non-Cumulative Perpetual Preferred Stock Series E,$25.20,0.01,0.04%,,United States,,2150,,
+add,CUBI^F,Customers Bancorp Inc Fixed-to-Floating Rate Non-Cumulative Perpetual Preferred Stock Series F,$25.44,0.23,0.912%,,United States,,9255,,
+add,CUK,Carnival Plc ADS ADS,$25.99,-0.42,-1.59%,30099864949.00,United States,,1300474,,
+add,CULP,Culp Inc. Common Stock,$17.11,-0.18,-1.041%,210595988.00,United States,,20232,Basic Industries,Textiles
+add,CURO,CURO Group Holdings Corp. Common Stock,$17.53,-0.50,-2.773%,729664846.00,,2017,159433,Finance,Diversified Financial Services
+add,CUZ,Cousins Properties Incorporated Common Stock,$39.47,0.58,1.491%,5867346106.00,United States,,878280,Consumer Services,Real Estate Investment Trusts
+add,CVA,Covanta Holding Corporation Common Stock,$17.465,-0.175,-0.992%,2322370441.00,United States,,1244653,,
+add,CVE,Cenovus Energy Inc Common Stock,$10.07,0.16,1.615%,20315838070.00,Canada,,14121714,,
+add,CVEO,Civeo Corporation (Canada) Common Shares,$17.50,-0.09,-0.512%,250125155.00,,2014,19598,,
+add,CVI,CVR Energy Inc. Common Stock,$23.385,0.075,0.322%,2350908058.00,United States,2007,499223,Energy,Integrated oil Companies
+add,CVII,Churchill Capital Corp VII Class A Common Stock,$9.7704,0.0004,0.004%,1685394000.00,,2021,308115,,
+add,CVNA,Carvana Co. Class A Common Stock,$266.78,2.27,0.858%,45988356482.00,United States,2017,1136431,Consumer Services,Other Specialty Stores
+add,CVS,CVS Health Corporation Common Stock,$85.60,0.65,0.765%,112698209758.00,United States,,3316237,Health Care,Managed Health Care
+add,CVX,Chevron Corporation Common Stock,$108.62,0.84,0.779%,209425788023.00,United States,,9256671,Energy,Integrated oil Companies
+add,CW,Curtiss-Wright Corporation Common Stock,$126.85,0.39,0.308%,5193014856.00,United States,,78783,Capital Goods,Industrial Machinery/Components
+add,CWEN,Clearway Energy Inc. Class C Common Stock,$27.915,0.355,1.288%,5634271704.00,United States,2015,355788,Public Utilities,Electric Utilities: Central
+add,CWH,Camping World Holdings Inc. Class A Commom Stock,$39.99,0.15,0.377%,3541948012.00,United States,2016,1276587,Capital Goods,Recreational Products/Toys
+add,CWK,Cushman & Wakefield plc Ordinary Shares,$18.26,-0.09,-0.49%,4070335358.00,,2018,914463,Finance,Real Estate
+add,CWT,California Water Service Group Common Stock,$57.84,0.73,1.278%,2940296400.00,United States,,67695,Public Utilities,Water Supply
+add,CX,Cemex S.A.B. de C.V. Sponsored ADR,$8.305,-0.075,-0.895%,12232410183.00,Mexico,,4594533,Capital Goods,Building Materials
+add,CXE,MFS High Income Municipal Trust Common Stock,$5.35,-0.03,-0.558%,168640287.00,United States,1989,31112,,
+add,CXH,MFS Investment Grade Municipal Trust Common Stock,$10.14,-0.01,-0.099%,92377884.00,United States,1989,8921,,
+add,CXP,Columbia Property Trust Inc. Common Stock,$19.12,0.07,0.367%,2196297670.00,United States,2013,749289,Consumer Services,Real Estate Investment Trusts
+add,CXW,CoreCivic Inc. Common Stock,$10.82,-0.30,-2.698%,1301396231.00,United States,,3712029,Consumer Services,Real Estate Investment Trusts
+add,CYD,China Yuchai International Limited Common Stock,$17.08,1.53,9.839%,697859593.00,Singapore,1994,97692,Capital Goods,Construction/Ag Equipment/Trucks
+add,CYH,Community Health Systems Inc. Common Stock,$16.695,1.375,8.975%,2206069687.00,United States,2000,3026249,Health Care,Hospital/Nursing Management
+add,D,Dominion Energy Inc. Common Stock,$77.41,0.91,1.19%,62433048927.00,United States,,1943231,Public Utilities,Electric Utilities: Central
+add,DAC,Danaos Corporation Common Stock,$71.47,3.82,5.647%,1472233901.00,Greece,2006,416919,Transportation,Marine Transportation
+add,DAL,Delta Air Lines Inc. Common Stock,$46.295,-0.225,-0.484%,29612451986.00,United States,,8530542,Transportation,Air Freight/Delivery Services
+add,DAN,Dana Incorporated Common Stock ,$25.945,-0.705,-2.645%,3765744501.00,United States,,415613,Capital Goods,Auto Parts:O.E.M.
+add,DAO,Youdao Inc. American Depositary Shares each representing one Class A Ordinary Share,$25.59,0.76,3.061%,3172672664.00,,2019,247943,Consumer Services,Other Consumer Services
+add,DAR,Darling Ingredients Inc. Common Stock,$75.09,0.40,0.536%,12252599071.00,United States,,1248072,Consumer Non-Durables,Farming/Seeds/Milling
+add,DASH,DoorDash Inc. Class A Common Stock,$144.70,7.72,5.636%,47148737474.00,,2020,2880658,Capital Goods,Industrial Machinery/Components
+add,DAVA,Endava plc American Depositary Shares (each representing one Class A Ordinary Share),$104.55,0.49,0.471%,5762518420.00,,2018,33178,Technology,EDP Services
+add,DB,Deutsche Bank AG Common Stock,$14.355,-0.245,-1.678%,29668528296.00,Germany,,2764925,Finance,Commercial Banks
+add,DBD,Diebold Nixdorf Incorporated Common Stock,$13.54,-1.01,-6.942%,1059210600.00,United States,,373668,Technology,EDP Services
+add,DBI,Designer Brands Inc. Class A Common Stock,$16.795,-0.415,-2.411%,1223820092.00,United States,,783547,Consumer Services,Clothing/Shoe/Accessory Stores
+add,DBL,DoubleLine Opportunistic Credit Fund Common Shares of Beneficial Interest,$19.9544,0.0944,0.475%,298757556.00,United States,2012,15114,,
+add,DCF,BNY Mellon Alcentra Global Credit Income 2024 Target Term Fund Inc. Common Stock,$9.44,0.08,0.855%,141251966.00,,2017,86889,,
+add,DCI,Donaldson Company Inc. Common Stock,$61.61,-0.56,-0.901%,7737274353.00,United States,,160728,Capital Goods,Pollution Control Equipment
+add,DCO,Ducommun Incorporated Common Stock,$55.51,0.12,0.217%,657771129.00,United States,,34017,Capital Goods,Military/Government/Technical
+add,DCP,DCP Midstream  LP Common Units ,$30.165,1.225,4.233%,6285256984.00,United States,,531664,Public Utilities,Natural Gas Distribution
+add,DCP^B,DCP Midstream LP 7.875% Series B Fixed-to-Floating Rate Cumulative Redeemable Perpetual Preferred Units,$24.71,0.11,0.447%,,United States,,7178,,
+add,DCP^C,DCP Midstream LP 7.95% Series C Fixed-to-Floating Rate Cumulative Redeemable Perpetual Preferred Units,$24.98,0.03,0.12%,,United States,,11828,,
+add,DCUE,Dominion Energy Inc. 2019 Series A Corporate Units,$100.86,0.60,0.598%,0.00,United States,2019,10890,Public Utilities,Electric Utilities: Central
+add,DD,DuPont de Nemours Inc. Common Stock,$82.985,-1.185,-1.408%,44159831753.00,,2017,1347082,Capital Goods,Wholesale Distributors
+add,DDD,3D Systems Corporation Common Stock,$29.25,-0.61,-2.043%,3657705451.00,United States,,2277127,Technology,Computer peripheral equipment
+add,DDF,Delaware Investments Dividend & Income Fund Inc. Common Stock,$12.01,-0.02,-0.166%,91410020.00,United States,1993,15252,,
+add,DDS,Dillard's Inc. Common Stock,$167.40,-12.09,-6.736%,3582360000.00,United States,,342694,Consumer Services,Department/Specialty Retail Stores
+add,DDT,Dillard's Capital Trust I,$25.73,0.02,0.078%,0.00,United States,,4191,Consumer Services,Department/Specialty Retail Stores
+add,DE,Deere & Company Common Stock,$341.615,-7.915,-2.264%,106564097759.00,United States,,1740657,Capital Goods,Industrial Machinery/Components
+add,DEA,Easterly Government Properties Inc. Common Stock,$21.78,0.11,0.508%,1826709356.00,United States,2015,235446,Consumer Services,Real Estate Investment Trusts
+add,DECK,Deckers Outdoor Corporation Common Stock,$325.70,1.89,0.584%,9058701591.00,United States,1993,222024,Consumer Non-Durables,Shoe Manufacturing
+add,DEH,D8 Holdings Corp. Class A Ordinary Shares,$9.89,-0.01,-0.101%,426506250.00,Hong Kong,2020,102190,Finance,Business Services
+add,DEI,Douglas Emmett Inc. Common Stock,$36.60,0.44,1.217%,6422226083.00,United States,2006,641739,Consumer Services,Real Estate Investment Trusts
+add,DELL,Dell Technologies Inc. Class C Common Stock ,$104.01,0.05,0.048%,79431413438.00,,2018,1270410,Technology,Computer Manufacturing
+add,DEN,Denbury Inc. Common Stock,$70.10,-0.20,-0.284%,3505465674.00,,2020,340978,Energy,Oil & Gas Production
+add,DEO,Diageo plc Common Stock,$195.02,0.60,0.309%,114013412069.00,United Kingdom,,339554,Consumer Non-Durables,Beverages (Production/Distribution)
+add,DESP,Despegar.com Corp. Ordinary Shares,$14.12,0.20,1.437%,989802511.00,,2017,279062,Transportation,Other Consumer Services
+add,DEX,Delaware Enhanced Global Dividend Common Shares of Beneficial Interest,$10.7017,0.1417,1.342%,127334167.00,United States,2007,72177,,
+add,DFIN,Donnelley Financial Solutions Inc. Common Stock ,$31.49,0.22,0.704%,1053818896.00,,2016,109836,Finance,Investment Managers
+add,DFNS,LGL Systems Acquisition Corp. Common Stock,$9.97,0.00,0.00%,214978125.00,United States,2020,21257,,
+add,DFP,Flaherty & Crumrine Dynamic Preferred and Income Fund Inc. Common Stock,$30.0873,0.0673,0.224%,577741991.00,,2013,18249,,
+add,DFS,Discover Financial Services Common Stock,$122.47,-0.56,-0.455%,37339575432.00,United States,,1272775,Finance,Finance: Consumer Services
+add,DG,Dollar General Corporation Common Stock,$206.26,1.33,0.649%,48719744367.00,United States,2009,1090253,Consumer Services,Department/Specialty Retail Stores
+add,DGNR,Dragoneer Growth Opportunities Corp. Class A Ordinary Shares,$10.10,0.05,0.498%,871125000.00,United States,2020,401902,Finance,Business Services
+add,DGX,Quest Diagnostics Incorporated Common Stock,$128.145,0.645,0.506%,15578043931.00,United States,,625852,Health Care,Medical Specialities
+add,DHF,BNY Mellon High Yield Strategies Fund Common Stock,$3.17,-0.03,-0.938%,230483371.00,United States,1998,671768,,
+add,DHI,D.R. Horton Inc. Common Stock,$87.68,-3.00,-3.308%,31607195647.00,United States,,5362720,,
+add,DHR,Danaher Corporation Common Stock,$246.21,5.51,2.289%,175616389598.00,United States,,1959571,Health Care,Medical Specialities
+add,DHR^A,Danaher Corporation 4.75% Mandatory Convertible Preferred Stock Series A,$1654.64,0.00,0.00%,,United States,,493,,
+add,DHR^B,Danaher Corporation 5.00% Mandatory Convertible Preferred Stock Series B,$1366.00,7.41,0.545%,,United States,,7944,,
+add,DHT,DHT Holdings Inc.,$6.49,0.12,1.884%,1113028536.00,Jersey,2005,1561212,Transportation,Marine Transportation
+add,DHX,DHI Group Inc. Common Stock,$3.33,-0.06,-1.77%,173748288.00,United States,2007,363561,Technology,Diversified Commercial Services
+add,DIAX,Nuveen Dow 30SM Dynamic Overwrite Fund Common Shares of Beneficial Interest,$17.39,0.04,0.231%,632420634.00,,2014,40973,,
+add,DIN,Dine Brands Global Inc. Common Stock,$92.40,-2.46,-2.593%,1585338124.00,United States,,132525,Consumer Services,Restaurants
+add,DIS,Walt Disney Company (The) Common Stock,$176.50,0.46,0.261%,320688508237.00,United States,,4242907,Consumer Services,Services-Misc. Amusement & Recreation
+add,DK,Delek US Holdings Inc. Common Stock,$23.78,-0.23,-0.958%,1756764717.00,United States,2017,508800,Energy,Integrated oil Companies
+add,DKL,Delek Logistics Partners L.P. Common Units representing Limited Partner Interests,$44.38,1.13,2.613%,1928015252.00,United States,2012,18427,Energy,Oil & Gas Production
+add,DKS,Dick's Sporting Goods Inc Common Stock,$97.695,-1.585,-1.596%,8721171786.00,United States,2002,1069893,Consumer Services,Other Specialty Stores
+add,DLB,Dolby Laboratories Common Stock,$98.69,0.93,0.951%,10003302287.00,United States,2005,145518,Technology,EDP Services
+add,DLNG,Dynagas LNG Partners LP Common Units,$2.73,0.0299,1.107%,100452553.00,Greece,,14193,,
+add,DLNG^A,Dynagas LNG Partners LP 9.00% Series A Cumulative Redeemable Preferred Units,$25.4095,0.1195,0.473%,,Greece,,4300,,
+add,DLNG^B,Dynagas LNG Partners LP 8.75% Series B Fixed to Floating Rate Cumulative Redeemable Perpetual Preferred Units liquidation preference $25.00 per Uni,$24.119,0.0275,0.114%,,Greece,,3678,,
+add,DLR,Digital Realty Trust Inc. Common Stock,$163.84,2.96,1.84%,46135327457.00,United States,2004,841801,Consumer Services,Real Estate Investment Trusts
+add,DLR^J,Digital Realty Trust Inc. 5.250% Series J Cumulative Redeemable Preferred Stock,$26.555,0.005,0.019%,,United States,,1156,,
+add,DLR^K,Digital Realty Trust Inc. 5.850% Series K Cumulative Redeemable Preferred Stock par value $0.01 per share,$28.39,-0.045,-0.158%,,United States,,9389,,
+add,DLR^L,Digital Realty Trust Inc. 5.200% Series L Cumulative Redeemable Preferred Stock,$27.99,0.02,0.072%,,United States,,15630,,
+add,DLX,Deluxe Corporation Common Stock,$47.25,-0.51,-1.068%,1994024419.00,United States,,80621,Technology,Advertising
+add,DLY,DoubleLine Yield Opportunities Fund Common Shares of Beneficial Interest,$19.95,0.10,0.504%,956518291.00,,2020,94556,,
+add,DM,Desktop Metal Inc. Class A Common Stock,$12.87,-0.60,-4.454%,3291825627.00,,2019,5103007,Technology,Computer peripheral equipment
+add,DMB,BNY Mellon Municipal Bond Infrastructure Fund Inc. Common Stock,$14.70,-0.01,-0.068%,270321872.00,,2013,13133,,
+add,DMO,Western Asset Mortgage Opportunity Fund Inc. Common Stock,$15.515,0.205,1.339%,171085674.00,United States,2010,53812,,
+add,DMS,Digital Media Solutions Inc. Class A Ordinary Shares,$10.35,-0.08,-0.767%,634260037.00,United States,2018,7968,Technology,Advertising
+add,DMYI,dMY Technology Group Inc. III Class A Common Stock,$10.54,-0.06,-0.566%,395250000.00,United States,2021,609822,,
+add,DMYQ,dMY Technology Group Inc. IV Class A Common Stock,$9.93,-0.02,-0.201%,428231250.00,,2021,112050,,
+add,DNB,Dun & Bradstreet Holdings Inc. Common Stock,$21.29,0.44,2.11%,9184704040.00,United States,2020,1453538,Technology,EDP Services
+add,DNMR,Danimer Scientific Inc. Common Stock,$24.86,-1.30,-4.969%,2126437763.00,,2020,1792909,Consumer Non-Durables,Plastic Products
+add,DNOW,NOW Inc. Common Stock,$10.75,-0.07,-0.647%,1185241282.00,,2014,270144,Energy,Metal Fabrications
+add,DNP,DNP Select Income Fund Inc. Common Stock,$10.53,0.03,0.286%,3256955841.00,United States,1987,551298,,
+add,DNZ,D and Z Media Acquisition Corp. Class A Common Stock,$9.75,-0.04,-0.409%,350390625.00,,2021,59996,,
+add,DOC,Physicians Realty Trust Common Shares of Beneficial Interest,$19.52,0.20,1.035%,4205962981.00,United States,2013,1305427,Consumer Services,Real Estate Investment Trusts
+add,DOCN,DigitalOcean Holdings Inc. Common Stock,$41.27,0.63,1.55%,4397874201.00,,2021,108143,Technology,Retail: Computer Software & Peripheral Equipment
+add,DOOR,Masonite International Corporation Ordinary Shares (Canada),$116.04,-1.11,-0.948%,2843073528.00,Canada,,92234,,
+add,DOV,Dover Corporation Common Stock,$150.43,-0.23,-0.153%,21650979527.00,United States,,323657,Capital Goods,Industrial Machinery/Components
+add,DOW,Dow Inc. Common Stock ,$68.035,-0.805,-1.169%,50821426686.00,,2019,3015591,Basic Industries,Industrial Specialties
+add,DPG,Duff & Phelps Utility and Infrastructure Fund Inc.,$15.23,0.01,0.066%,577670945.00,United States,2011,185786,,
+add,DPZ,Domino's Pizza Inc Common Stock,$448.31,5.60,1.265%,17407156866.00,United States,2004,349521,Consumer Non-Durables,Food Distributors
+add,DQ,DAQO New Energy Corp. American Depositary Shares each representing five ordinary shares,$67.92,-0.83,-1.207%,4993042354.00,China,2010,1961331,Technology,Semiconductors
+add,DRD,DRDGOLD Limited American Depositary Shares,$12.91,0.40,3.197%,1103951903.00,South Africa,,271918,Basic Industries,Precious Metals
+add,DRE,Duke Realty Corporation Common Stock,$49.63,0.81,1.659%,18610518950.00,United States,,680642,Consumer Services,Real Estate Investment Trusts
+add,DRH,Diamondrock Hospitality Company Common Stock,$10.315,-0.145,-1.386%,2168746956.00,United States,2005,890801,Consumer Services,Real Estate Investment Trusts
+add,DRH^A,Diamondrock Hospitality Company 8.250% Series A Cumulative Redeemable Preferred Stock,$28.8945,0.0845,0.293%,,United States,,2391,,
+add,DRI,Darden Restaurants Inc. Common Stock,$136.78,-1.89,-1.363%,17896660950.00,United States,,735203,Consumer Services,Restaurants
+add,DRQ,Dril-Quip Inc. Common Stock,$37.83,-0.16,-0.421%,1340305324.00,United States,1997,82244,Energy,Metal Fabrications
+add,DRUA,Dominion Energy Inc. 2016 Series A 5.25% Enhanced Junior Subordinated Notes due 2076,$25.335,0.005,0.02%,0.00,United States,2016,52609,Public Utilities,Electric Utilities: Central
+add,DS,Drive Shack Inc.,$3.48,-0.05,-1.416%,320404216.00,United States,,1460496,Consumer Services,Movies/Entertainment
+add,DS^B,Drive Shack Inc. Preferred Series B,$25.635,-0.085,-0.33%,,United States,,4161,,
+add,DS^C,Drive Shack Inc. Preferred Series C,$24.20,-0.30,-1.224%,,United States,,6314,,
+add,DS^D,Drive Shack Inc. Pfd Ser D,$24.50,0.38,1.575%,,United States,,7002,,
+add,DSE,Duff & Phelps Select MLP and Midstream Energy Fund Inc.,$9.81,0.09,0.926%,25735113.00,United States,2014,17061,,
+add,DSL,DoubleLine Income Solutions Fund Common Shares of Beneficial Interests,$18.4699,0.0799,0.434%,1883871213.00,,2013,209676,,
+add,DSM,BNY Mellon Strategic Municipal Bond Fund Inc. Common Stock,$8.18,0.00,0.00%,404267960.00,United States,1989,51816,,
+add,DSSI,Diamond S Shipping Inc. Common Stock ,$10.36,-0.16,-1.521%,420562428.00,,2019,197564,Consumer Services,Transportation Services
+add,DSU,Blackrock Debt Strategies Fund Inc. Common Stock,$11.3811,-0.0989,-0.861%,530266015.00,United States,1998,142916,,
+add,DSX,Diana Shipping inc. common stock,$5.17,0.17,3.40%,473235960.00,Greece,2005,1771842,Transportation,Marine Transportation
+add,DSX^B,Diana Shipping Inc. Perpetual Preferred Shares Series B (Marshall Islands),$25.82,0.174,0.678%,,Greece,,4303,,
+add,DT,Dynatrace Inc. Common Stock,$54.37,1.14,2.142%,15422276407.00,United States,2019,867687,Technology,EDP Services
+add,DTB,DTE Energy Company 2020 Series G 4.375% Junior Subordinated Debentures due 2080,$26.12,0.04,0.153%,0.00,United States,2020,13878,Public Utilities,Electric Utilities: Central
+add,DTE,DTE Energy Company Common Stock,$138.49,-0.50,-0.36%,26829302225.00,United States,,700736,Public Utilities,Electric Utilities: Central
+add,DTF,DTF Tax-Free Income Inc. Common Stock,$15.01,0.06,0.401%,105513786.00,United States,1991,5567,,
+add,DTJ,DTE Energy Company 2016 Series B 5.375% Junior Subordinated Debentures due 2076,$25.07,-0.01,-0.04%,0.00,United States,2016,29912,Public Utilities,Electric Utilities: Central
+add,DTLA^,Brookfield DTLA Inc. 7.625% Series A Cumulative Redeemable Preferred Stock,$14.84,-0.142,-0.948%,,,,1625,,
+add,DTP,DTE Energy Company 6.25% Corporate Units,$50.98,-0.37,-0.721%,0.00,United States,,4729,Public Utilities,Electric Utilities: Central
+add,DTW,DTE Energy Company 2017 Series E 5.25% Junior Subordinated Debentures due 2077,$26.23,0.04,0.153%,0.00,United States,2017,12368,Public Utilities,Electric Utilities: Central
+add,DTY,DTE Energy Company 2016 Series F 6.00% Junior Subordinated Debentures due 2076,$25.70,-0.02,-0.078%,0.00,United States,2016,6485,,
+add,DUK,Duke Energy Corporation (Holding Company) Common Stock,$101.71,0.32,0.316%,78237260015.00,United States,,1120730,Public Utilities,Power Generation
+add,DUK^A,Duke Energy Corporation Depositary Shares each representing a 1/1000th interest in a share of 5.75% Series A Cumulative Redeemable Perpetual Preferred Stock,$28.38,0.09,0.318%,,United States,,52342,,
+add,DUKB,Duke Energy Corporation 5.625% Junior Subordinated Debentures due 2078,$27.71,0.02,0.072%,0.00,United States,2018,34301,Public Utilities,Power Generation
+add,DUKH,Duke Energy Corporation 5.125% Junior Subordinated Debentures due 2073,$26.33,0.045,0.171%,0.00,United States,,4282,Public Utilities,Power Generation
+add,DV,DoubleVerify Holdings Inc. Common Stock,$34.36,-1.37,-3.834%,5401456872.00,,2021,381744,Technology,Computer Software: Prepackaged Software
+add,DVA,DaVita Inc. Common Stock,$121.84,1.40,1.162%,12939408000.00,United States,,324457,Health Care,Medical/Nursing Services
+add,DVD,Dover Motorsports Inc. Common Stock,$2.2601,0.0001,0.004%,82370680.00,United States,1996,11204,Consumer Services,Services-Misc. Amusement & Recreation
+add,DVN,Devon Energy Corporation Common Stock,$29.42,-0.51,-1.704%,19914398000.00,United States,,9531211,Energy,Oil & Gas Production
+add,DWIN,Delwinds Insurance Acquisition Corp. Class A Common Stock,$9.785,-0.005,-0.051%,252342919.00,,2021,61650,,
+add,DX,Dynex Capital Inc. Common Stock,$20.36,-0.02,-0.098%,628708025.00,United States,,565550,Consumer Services,Real Estate Investment Trusts
+add,DX^C,Dynex Capital Inc. 6.900% Series C Fixed-to-Floating Rate Cumulative Redeemable Preferred Stock,$25.58,-0.18,-0.699%,,United States,,21802,,
+add,DXC,DXC Technology Company Common Stock ,$41.27,0.86,2.128%,10515883487.00,,,1744520,Technology,EDP Services
+add,DY,Dycom Industries Inc. Common Stock,$79.27,-2.69,-3.282%,2439826836.00,United States,,243836,Basic Industries,Water Supply
+add,DYFN,Angel Oak Dynamic Financial Strategies Income Term Trust Common Shares of Beneficial Interest,$20.15,0.0929,0.463%,81708250.00,,2020,19339,Finance,Finance/Investors Services
+add,E,ENI S.p.A. Common Stock,$25.57,0.27,1.067%,45675047275.00,Italy,,120230,Energy,Oil & Gas Production
+add,EAF,GrafTech International Ltd. Common Stock,$12.15,-0.59,-4.631%,3247266919.00,United States,2018,2097272,Consumer Durables,Metal Fabrications
+add,EAI,Entergy Arkansas LLC First Mortgage Bonds 4.875% Series Due September 1 2066,$25.44,0.00,0.00%,0.00,United States,2016,13155,,
+add,EARN,Ellington Residential Mortgage REIT Common Shares of Beneficial Interest,$13.45,0.59,4.588%,166020640.00,United States,2013,356207,Consumer Services,Real Estate Investment Trusts
+add,EAT,Brinker International Inc. Common Stock,$60.75,-2.68,-4.225%,2779368269.00,United States,,1133240,Consumer Services,Restaurants
+add,EB,Eventbrite Inc. Class A Common Stock,$20.73,-0.59,-2.767%,1942800322.00,United States,2018,496785,Technology,EDP Services
+add,EBF,Ennis Inc. Common Stock,$21.52,0.00,0.00%,561742672.00,United States,,37961,Consumer Services,Office Equipment/Supplies/Services
+add,EBR,Centrais Electricas Brasileiras S A American Depositary Shares (Each representing one Common Share),$8.89,-0.02,-0.224%,13947795790.00,,2016,547083,Public Utilities,Electric Utilities: Central
+add,EBS,Emergent Biosolutions Inc. Common Stock,$65.61,0.55,0.845%,3515743212.00,United States,2006,257802,Health Care,Major Pharmaceuticals
+add,EC,Ecopetrol S.A. American Depositary Shares,$13.185,0.065,0.495%,27106180968.00,Colombia,,642807,Energy,Oil & Gas Production
+add,ECC           ,Eagle Point Credit Company Inc. Common Stock,$13.95,-0.30,-2.105%,451350716.00,United States,2014,332715,Finance,Trusts Except Educational Religious and Charitable
+add,ECCB,Eagle Point Credit Company Inc. 7.75% Series B Term Preferred Stock due 2026,$25.3806,-0.0194,-0.076%,0.00,United States,2016,12088,Finance,Trusts Except Educational Religious and Charitable
+add,ECCW,Eagle Point Credit Company Inc. 6.75% Notes due 2031,$25.87,0.0418,0.162%,0.00,United States,2021,6672,Finance,Trusts Except Educational Religious and Charitable
+add,ECCX,Eagle Point Credit Company Inc. 6.6875% Notes due 2028,$25.53,0.03,0.118%,0.00,United States,2018,1870,Finance,Trusts Except Educational Religious and Charitable
+add,ECCY,Eagle Point Credit Company Inc. 6.75% Notes due 2027,$25.70,0.038,0.148%,0.00,United States,2017,1734,Finance,Trusts Except Educational Religious and Charitable
+add,ECL,Ecolab Inc. Common Stock,$213.69,0.93,0.437%,61101962151.00,United States,,640625,Consumer Non-Durables,Package Goods/Cosmetics
+add,ECOM          ,ChannelAdvisor Corporation Common Stock,$24.34,-0.44,-1.776%,723697618.00,United States,2013,74935,Technology,Computer Software: Prepackaged Software
+add,ED,Consolidated Edison Inc. Common Stock,$77.10,0.22,0.286%,26430902192.00,United States,,789339,Public Utilities,Power Generation
+add,EDD,Morgan Stanley Emerging Markets Domestic Debt Fund Inc. Morgan Stanley Emerging Markets Domestic Debt Fund Inc. Common Stock,$6.26,0.00,0.00%,413736703.00,United States,2007,135661,,
+add,EDF,Stone Harbor Emerging Markets Income Fund Common Shares of Beneficial Interest,$8.7299,0.1099,1.275%,145578678.00,United States,2010,129589,,
+add,EDI,Stone Harbor Emerging Markets Total Income Fund Common Shares of Beneficial Interests,$9.16,-0.03,-0.326%,90483927.00,United States,2012,45991,,
+add,EDN,Empresa Distribuidora Y Comercializadora Norte S.A. (Edenor) Empresa Distribuidora Y Comercializadora Norte S.A. (Edenor) American Depositary Shares,$4.97,-0.50,-9.141%,225254092.00,Argentina,2007,195992,Public Utilities,Electric Utilities: Central
+add,EDR,Endeavor Group Holdings Inc. Class A Common Stock,$29.63,0.51,1.751%,7688925799.00,,2021,245014,Consumer Services,Services-Misc. Amusement & Recreation
+add,EDU,New Oriental Education & Technology Group Inc. Sponsored ADR representing 1 Ordinary Share (Cayman Islands),$9.775,0.755,8.37%,16633715454.00,China,2006,67691521,Miscellaneous,Other Consumer Services
+add,EEA,The European Equity Fund Inc. Common Stock,$11.81,-0.02,-0.169%,83559199.00,United States,,740,,
+add,EEX,Emerald Holding Inc. Common Stock,$5.44,0.03,0.555%,392220812.00,United States,2017,224040,Technology,Advertising
+add,EFC,Ellington Financial Inc. Common Stock ,$19.31,-0.01,-0.052%,845424318.00,United States,2010,375148,Finance,Finance: Consumer Services
+add,EFC^A,Ellington Financial Inc. 6.750% Series A Fixed-to-Floating Rate Cumulative Redeemable Preferred Stock,$25.65,0.12,0.47%,,United States,,2349,,
+add,EFF,Eaton vance Floating-Rate Income Plus Fund Common Shares of Beneficial Interest,$16.41,-0.02,-0.122%,124821385.00,,2013,9932,Finance,Investment Managers
+add,EFL,Eaton Vance Floating-Rate 2022 Target Term Trust Common Shares of Beneficial Interest,$9.4198,-0.0202,-0.214%,222510861.00,United States,2017,32057,,
+add,EFR,Eaton Vance Senior Floating-Rate Fund Common Shares of Beneficial Interest,$14.22,0.0906,0.641%,523983011.00,United States,2003,80029,,
+add,EFT,Eaton Vance Floating Rate Income Trust Common Shares of Beneficial Interest,$14.30,-0.02,-0.14%,570050767.00,United States,2004,59184,,
+add,EFX,Equifax Inc. Common Stock,$228.70,0.06,0.026%,27833367696.00,United States,,187771,Technology,Advertising
+add,EGF,Blackrock Enhanced Government Fund Inc. Common Stock,$12.65,0.00,0.00%,53911466.00,United States,2005,6044,,
+add,EGHT,8x8 Inc Common Stock,$25.735,1.385,5.688%,2828068741.00,United States,,1245653,Technology,EDP Services
+add,EGO,Eldorado Gold Corporation Ordinary Shares,$11.6801,0.3301,2.908%,2123524291.00,Canada,,890537,Basic Industries,Precious Metals
+add,EGP,EastGroup Properties Inc. Common Stock,$170.43,2.87,1.713%,6820870551.00,United States,,124462,Consumer Services,Real Estate Investment Trusts
+add,EGY,VAALCO Energy Inc.  Common Stock,$3.134,-0.116,-3.569%,181554384.00,United States,,251040,Energy,Oil & Gas Production
+add,EHC,Encompass Health Corporation Common Stock,$83.28,0.49,0.592%,8289891905.00,United States,,445263,Health Care,Medical Specialities
+add,EHI,Western Asset Global High Income Fund Inc Common Stock,$10.48,0.04,0.383%,237867673.00,United States,2003,13848,,
+add,EHT,Eaton Vance 2021 Target Term Trust Common Shares of Beneficial Interest,$9.83,-0.01,-0.102%,211006081.00,United States,2016,52355,,
+add,EIC,Eagle Point Income Company Inc. Common Stock,$15.60,0.00,0.00%,0.00,,2019,4730,Finance,Finance/Investors Services
+add,EIG,Employers Holdings Inc Common Stock,$42.53,-0.03,-0.07%,1213048741.00,United States,2007,71690,Finance,Property-Casualty Insurers
+add,EIX,Edison International Common Stock,$57.59,0.70,1.23%,21851837472.00,United States,,1470525,Public Utilities,Electric Utilities: Central
+add,EL,Estee Lauder Companies Inc. (The) Common Stock,$298.33,0.49,0.165%,108148167370.00,United States,1995,615260,Consumer Non-Durables,Package Goods/Cosmetics
+add,ELAN,Elanco Animal Health Incorporated Common Stock,$33.595,-0.305,-0.90%,15890299377.00,United States,2018,3157787,Health Care,Major Pharmaceuticals
+add,ELAT,Elanco Animal Health Incorporated 5.00% Tangible Equity Units,$51.37,-0.83,-1.59%,0.00,United States,2020,2796,Health Care,Major Pharmaceuticals
+add,ELC,Entergy Louisiana Inc. Collateral Trust Mortgage Bonds 4.875 % Series due September 1 2066,$25.405,-0.005,-0.02%,0.00,United States,2016,5798,,
+add,ELF,e.l.f. Beauty Inc. Common Stock,$27.86,-0.24,-0.854%,1438966632.00,United States,2016,186414,Consumer Non-Durables,Package Goods/Cosmetics
+add,ELP,Companhia Paranaense de Energia (COPEL) American Depositary Shares (each representing one Unit consisting one Common Share and four non-voting Class B Preferred Shares),$6.00,0.00,0.00%,16419322500.00,Brazil,2021,287399,Public Utilities,Electric Utilities: Central
+add,ELS,Equity Lifestyle Properties Inc. Common Stock,$76.44,0.39,0.513%,13936161581.00,United States,,468121,Consumer Services,Real Estate Investment Trusts
+add,ELVT,Elevate Credit Inc. Common Stock,$3.66,-0.11,-2.918%,130854809.00,United States,2017,265776,Finance,Finance Companies
+add,ELY,Callaway Golf Company Common Stock,$35.255,-0.515,-1.44%,6510608645.00,United States,1992,1355136,Consumer Non-Durables,Recreational Products/Toys
+add,EMD,Western Asset Emerging Markets Debt Fund Inc Common Stock,$13.9901,-0.1799,-1.27%,849842782.00,United States,,181103,,
+add,EME,EMCOR Group Inc. Common Stock,$124.66,-3.09,-2.419%,6801001198.00,United States,,135394,Capital Goods,Engineering & Construction
+add,EMF,Templeton Emerging Markets Fund Common Stock,$19.89,0.00,0.00%,321544584.00,United States,1987,16452,,
+add,EMN,Eastman Chemical Company Common Stock,$124.99,-1.75,-1.381%,17039077015.00,United States,,252102,Basic Industries,Major Chemicals
+add,EMO,ClearBridge Energy Midstream Opportunity Fund Inc. Common Stock,$24.7247,0.3347,1.372%,335006779.00,United States,2011,41460,,
+add,EMP,Entergy Mississippi LLC First Mortgage Bonds 4.90% Series Due October 1 2066,$25.53,-0.11,-0.429%,0.00,United States,2016,138865,,
+add,EMPW,Empower Ltd. Class A Ordinary Shares,$10.30,-0.07,-0.675%,321875000.00,United States,2020,377775,Finance,Business Services
+add,EMR,Emerson Electric Company Common Stock,$97.76,-0.14,-0.143%,58626672000.00,United States,,1661543,Capital Goods,Industrial Machinery/Components
+add,ENB,Enbridge Inc Common Stock,$39.74,-0.03,-0.075%,80496405540.00,Canada,,3444826,Energy,Oil & Gas Production
+add,ENBA,Enbridge Inc 6.375% Fixed-to-Floating Rate Subordinated Notes Series 2018-B due 2078,$27.41,0.09,0.329%,0.00,Canada,2018,22929,Energy,Oil & Gas Production
+add,ENBL,Enable Midstream Partners LP Common Units representing limited partner interests,$9.48,0.17,1.826%,4132010998.00,,2014,715758,,
+add,ENIA,Enel Americas S.A. American Depositary Shares,$6.69,-0.05,-0.742%,14354291266.00,Chile,,1190049,Public Utilities,Electric Utilities: Central
+add,ENIC,Enel Chile S.A. American Depositary Shares (Each representing 50 shares of Common Stock),$2.995,0.035,1.182%,4143076776.00,,2016,936451,Public Utilities,Electric Utilities: Central
+add,ENJ,Entergy New Orleans LLC First Mortgage Bonds 5.0% Series due December 1 2052,$25.48,0.00,0.00%,0.00,United States,,100,Public Utilities,Power Generation
+add,ENLC,EnLink Midstream LLC Common Units representing Limited Partner Interests,$6.20,0.35,5.983%,3038346809.00,,,2159319,Public Utilities,Natural Gas Distribution
+add,ENO,Entergy New Orleans LLC First Mortgage Bonds 5.50% Series due April 1 2066,$25.53,0.03,0.118%,0.00,United States,2016,10647,,
+add,ENPC,Executive Network Partnering Corporation Class A Common Stock,$9.75,-0.03,-0.307%,432744000.00,,2020,262559,,
+add,ENR,Energizer Holdings Inc. Common Stock,$44.19,-0.17,-0.383%,3021155185.00,United States,2015,327161,Basic Industries,Metal Fabrications
+add,ENR^A,Energizer Holdings Inc. 7.50% Series A Mandatory Convertible Preferred Stock,$94.72,0.34,0.36%,,United States,,7006,,
+add,ENS,EnerSys Common Stock,$94.49,-2.01,-2.083%,4047184247.00,United States,2004,85946,Consumer Non-Durables,Telecommunications Equipment
+add,ENV,Envestnet Inc Common Stock,$79.15,0.95,1.215%,4307550531.00,United States,2010,726898,Technology,EDP Services
+add,ENVA,Enova International Inc. Common Stock,$35.32,-1.30,-3.55%,1298066229.00,United States,2014,192150,Finance,Finance: Consumer Services
+add,ENZ,Enzo Biochem Inc. Common Stock ($0.01 Par Value),$3.405,0.205,6.406%,164218271.00,United States,,1576972,Health Care,Medical Specialities
+add,EOD,Wells Fargo Global Dividend Opportunity Fund,$5.945,0.015,0.253%,257082542.00,United States,2007,346344,,
+add,EOG,EOG Resources Inc. Common Stock,$86.3074,0.4974,0.58%,50369440707.00,United States,,2440967,Energy,Oil & Gas Production
+add,EOI,Eaton Vance Enhance Equity Income Fund Eaton Vance Enhanced Equity Income Fund Shares of Beneficial Interest,$18.44,0.01,0.054%,725132679.00,United States,2004,39157,,
+add,EOS,Eaton Vance Enhance Equity Income Fund II Common Stock,$22.565,0.175,0.782%,1123407348.00,,2005,72540,,
+add,EOT,Eaton Vance Municipal Income Trust EATON VANCE NATIONAL MUNICIPAL OPPORTUNITIES TRUST,$22.56,-0.16,-0.704%,345905441.00,United States,2009,28751,,
+add,EP^C,El Paso Corporation Preferred Stock,$50.40,-0.44,-0.865%,,United States,,4750,,
+add,EPAC,Enerpac Tool Group Corp. Common Stock,$26.125,-0.045,-0.172%,1570648376.00,United States,,115878,Capital Goods,Industrial Machinery/Components
+add,EPAM,EPAM Systems Inc. Common Stock,$506.02,13.04,2.645%,28541939691.00,United States,2012,203281,Technology,EDP Services
+add,EPC,Edgewell Personal Care Company Common Stock,$45.56,-0.20,-0.437%,2476579137.00,,,149314,Consumer Non-Durables,Package Goods/Cosmetics
+add,EPD,Enterprise Products Partners L.P. Common Stock,$25.03,0.23,0.927%,54695020433.00,United States,,4018796,Public Utilities,Natural Gas Distribution
+add,EPR,EPR Properties Common Stock,$53.385,-0.205,-0.383%,3991515251.00,United States,1997,474338,Consumer Services,Real Estate Investment Trusts
+add,EPR^C,EPR Properties 5.75% Series C Cumulative Convertible Preferred Shares,$26.25,-0.07,-0.266%,,United States,,53838,,
+add,EPR^E,EPR Properties Series E Cumulative Conv Pfd Shs Ser E,$35.988,0.008,0.022%,,United States,,4775,,
+add,EPR^G,EPR Properties 5.750% Series G Cumulative Redeemable Preferred Shares,$25.84,0.04,0.155%,,United States,,23635,,
+add,EPRT,Essential Properties Realty Trust Inc. Common Stock,$28.52,0.15,0.529%,3351007224.00,United States,2018,513445,Consumer Services,Real Estate Investment Trusts
+add,EPWR,Empowerment & Inclusion Capital I Corp. Class A Common Stock,$9.69,-0.06,-0.615%,334305000.00,,2021,1702,,
+add,EQC,Equity Commonwealth Common Shares of Beneficial Interest,$28.14,0.12,0.428%,3430880859.00,United States,,720230,Consumer Services,Real Estate Investment Trusts
+add,EQC^D,Equity Commonwealth 6.50% Pfd Conv Shs Ser D,$31.51,-0.37,-1.161%,,United States,,1657,,
+add,EQD,Equity Distribution Acquisition Corp. Class A Common Stock,$9.85,-0.02,-0.203%,509737500.00,United States,2020,93092,,
+add,EQH,Equitable Holdings Inc. Common Stock,$30.365,-0.655,-2.112%,13004501932.00,United States,2018,2647296,,
+add,EQH^A,Equitable Holdings Inc. Depositary Shares,$26.84,0.12,0.449%,,United States,,17756,,
+add,EQH^C,Equitable Holdings Inc. Depositary Shares each representing a 1/1000th interest in a share of Fixed Rate Noncumulative Perpetual Preferred Stock Series C,$25.13,-0.11,-0.436%,,United States,,21751,,
+add,EQHA,EQ Health Acquisition Corp. Class A Common Stock,$9.78,0.02,0.205%,268948631.00,,2021,1116,,
+add,EQNR,Equinor ASA,$22.995,0.085,0.371%,74671524196.00,Norway,,1814183,Energy,Integrated oil Companies
+add,EQR,Equity Residential Common Shares of Beneficial Interest,$81.04,1.69,2.13%,30309395914.00,United States,,2180626,Consumer Services,Real Estate Investment Trusts
+add,EQS,Equus Total Return Inc. Common Stock,$1.95,0.012,0.619%,26360385.00,United States,,51962,,
+add,EQT,EQT Corporation Common Stock,$22.6101,0.2101,0.938%,6310597477.00,United States,,2735489,Energy,Oil & Gas Production
+add,ERF,Enerplus Corporation Common Stock,$7.155,0.115,1.634%,1837046966.00,Canada,,1481399,Energy,Oil & Gas Production
+add,ERJ,Embraer S.A. Common Stock,$15.68,2.05,15.04%,2902622972.00,Brazil,2000,7387541,Capital Goods,Aerospace
+add,ES,Eversource Energy (D/B/A) Common Stock,$83.25,0.69,0.836%,28593557987.00,United States,,920667,Public Utilities,Electric Utilities: Central
+add,ESE,ESCO Technologies Inc. Common Stock,$88.995,-1.855,-2.042%,2317508472.00,United States,,77694,Capital Goods,Telecommunications Equipment
+add,ESGC,Eros STX Global Corporation A Ordinary Shares,$1.385,-0.025,-1.773%,524818799.00,,2013,6449588,Consumer Services,Movies/Entertainment
+add,ESI,Element Solutions Inc. Common Stock,$23.905,0.105,0.441%,5915448421.00,United States,2014,814846,Basic Industries,Industrial Specialties
+add,ESM,ESM Acquisition Corporation Class A Ordinary Shares,$9.73,-0.09,-0.916%,373316583.00,,2021,28808,Finance,Major Banks
+add,ESNT,Essent Group Ltd. Common Shares,$47.52,-1.04,-2.142%,5362670634.00,,2013,340111,Finance,Property-Casualty Insurers
+add,ESRT,Empire State Realty Trust Inc. Class A Common Stock,$12.77,-0.03,-0.234%,3655095753.00,United States,2013,1363854,Consumer Services,Real Estate Investment Trusts
+add,ESS,Essex Property Trust Inc. Common Stock,$313.54,3.50,1.129%,20379758241.00,United States,1994,150047,Consumer Services,Real Estate Investment Trusts
+add,ESTC,Elastic N.V. Ordinary Shares,$134.90,3.42,2.601%,12213034577.00,United States,2018,491218,Technology,Computer Software: Prepackaged Software
+add,ESTE,Earthstone Energy Inc. Class A Common Stock,$10.09,-0.11,-1.078%,792427039.00,United States,,64292,Energy,Oil & Gas Production
+add,ET,Energy Transfer LP Common Units ,$11.0564,0.1864,1.715%,29902875502.00,United States,,9206191,Public Utilities,Natural Gas Distribution
+add,ET^C,Energy Transfer L.P. 7.375% Series C Fixed-to-Floating Rate Cumulative Redeemable Perpetual Preferred Unit,$24.79,-0.025,-0.101%,,United States,,42096,,
+add,ET^D,Energy Transfer L.P. 7.625% Series D Fixed-to-Floating Rate Cumulative Redeemable Perpetual Preferred Unit,$25.02,0.06,0.24%,,United States,,19524,,
+add,ET^E,Energy Transfer L.P. 7.600% Series E Fixed-to-Floating Rate Cumulative Redeemable Perpetual Preferred Unit,$25.02,0.0201,0.08%,,United States,,43128,,
+add,ETB,Eaton Vance Tax-Managed Buy-Write Income Fund Eaton Vance Tax-Managed Buy-Write Income Fund Common Shares of Beneficial Interest,$16.68,-0.01,-0.06%,446416848.00,United States,2005,46833,,
+add,ETG,Eaton Vance Tax-Advantaged Global Dividend Income Fund Common Shares of Beneficial Interest,$21.325,0.135,0.637%,1627102064.00,United States,2004,93719,,
+add,ETH,Ethan Allen Interiors Inc. Common Stock,$30.24,-0.11,-0.362%,761950899.00,United States,1993,206775,Consumer Durables,Home Furnishings
+add,ETI^,Entergy Texas Inc 5.375% Series A Preferred Stock Cumulative No Par Value,$27.72,0.37,1.353%,,United States,,983,,
+add,ETJ,Eaton Vance Risk-Managed Diversified Equity Income Fund Common Shares of Beneficial Interest,$11.39,0.02,0.176%,727890832.00,United States,2007,156035,,
+add,ETN,Eaton Corporation PLC Ordinary Shares,$146.93,0.52,0.355%,58551605000.00,Ireland,,1273622,Capital Goods,Industrial Machinery/Components
+add,ETO,Eaton Vance Tax-Advantage Global Dividend Opp Common Stock,$29.5605,0.0605,0.205%,463544881.00,United States,2004,39685,,
+add,ETR,Entergy Corporation Common Stock,$108.74,1.12,1.041%,21819762746.00,United States,,484439,Public Utilities,Electric Utilities: Central
+add,ETRN,Equitrans Midstream Corporation Common Stock ,$9.53,0.11,1.168%,4121705940.00,,2018,2706589,Energy,Oilfield Services/Equipment
+add,ETV,Eaton Vance Corporation Eaton Vance Tax-Managed Buy-Write Opportunities Fund Common Shares of Beneficial Interest,$16.33,0.08,0.492%,1512307436.00,United States,2005,287205,,
+add,ETW,Eaton Vance Corporation Eaton Vance Tax-Managed Global Buy-Write Opportunites Fund Common Shares of Beneficial Interest,$11.32,0.08,0.712%,1216748584.00,United States,2005,223929,,
+add,ETWO,E2open Parent Holdings Inc.Class A Common Stock,$13.905,0.235,1.719%,2600946130.00,,2020,1236813,Technology,Computer Software: Prepackaged Software
+add,ETX           ,Eaton Vance Municipal Income 2028 Term Trust Common Shares of Beneficial Interest,$22.65,0.04,0.177%,245807313.00,,2013,26522,,
+add,ETY,Eaton Vance Tax-Managed Diversified Equity Income Fund Common Shares of Beneficial Interest,$14.15,0.03,0.212%,2146795776.00,United States,2006,202425,,
+add,EURN,Euronav NV Ordinary Shares,$9.66,0.07,0.73%,1948209296.00,,2015,1430501,Transportation,Marine Transportation
+add,EVA,Enviva Partners LP Common units representing limited partner interests,$48.50,-0.09,-0.185%,1941267451.00,United States,2015,47848,,
+add,EVC,Entravision Communications Corporation Common Stock,$5.15,0.36,7.516%,438515069.00,United States,2000,832862,Consumer Services,Broadcasting
+add,EVF,Eaton Vance Senior Income Trust Common Stock,$6.76,-0.02,-0.295%,255978263.00,United States,1998,44337,,
+add,EVG,Eaton Vance Short Diversified Income Fund Eaton Vance Short Duration Diversified Income Fund Common Shares of Beneficial Interest,$13.3812,0.0312,0.234%,239263831.00,United States,2005,128297,Finance,Investment Managers
+add,EVH,Evolent Health Inc Class A Common Stock,$19.28,0.13,0.679%,1676023568.00,United States,2015,203612,Health Care,Managed Health Care
+add,EVN,Eaton Vance Municipal Income Trust Common Stock,$14.005,-0.155,-1.095%,555538618.00,United States,1999,92602,,
+add,EVR,Evercore Inc. Class A Common Stock,$141.24,0.99,0.706%,5783773198.00,United States,2006,197513,Finance,Investment Managers
+add,EVRG,Evergy Inc. Common Stock,$64.12,0.76,1.199%,14700632228.00,,2018,417600,Public Utilities,Power Generation
+add,EVRI,Everi Holdings Inc. Common Stock,$21.78,-0.45,-2.024%,1919297813.00,United States,,430237,Consumer Services,Recreational Products/Toys
+add,EVT,Eaton Vance Tax Advantaged Dividend Income Fund Common Shares of Beneficial Interest,$28.29,0.03,0.106%,2079529268.00,United States,2003,73354,,
+add,EVTC,Evertec Inc. Common Stock,$43.65,0.11,0.253%,3149930533.00,Puerto Rico,2013,77299,Technology,EDP Services
+add,EW,Edwards Lifesciences Corporation Common Stock,$99.745,2.665,2.745%,62005160322.00,United States,,2282144,Health Care,Industrial Specialties
+add,EXD,Eaton Vance Tax-Managed Buy-Write Strategy Fund Common Shares of Beneficial Interest,$11.35,-0.09,-0.787%,110453501.00,United States,2010,21220,Finance,Trusts Except Educational Religious and Charitable
+add,EXG,Eaton Vance Tax-Managed Global Diversified Equity Income Fund Eaton Vance Tax-Managed Global Diversified Equity Income Fund Common Shares of Beneficial Interest,$10.265,0.065,0.637%,3108893355.00,United States,2007,615245,,
+add,EXK,Endeavour Silver Corporation Ordinary Shares (Canada),$7.47,0.35,4.916%,1254887661.00,Canada,,3045364,Basic Industries,Precious Metals
+add,EXP,Eagle Materials Inc Common Stock,$149.20,-3.25,-2.132%,6323142103.00,United States,,401441,Capital Goods,Building Materials
+add,EXPR,Express Inc. Common Stock,$5.085,-0.475,-8.543%,337134351.00,United States,2010,8362700,,
+add,EXR,Extra Space Storage Inc Common Stock,$158.86,0.29,0.183%,21244103156.00,United States,2004,286611,Consumer Services,Real Estate Investment Trusts
+add,EXTN,Exterran Corporation Common Stock,$4.92,-0.10,-1.992%,163766338.00,United States,2015,219808,Technology,Diversified Commercial Services
+add,F,Ford Motor Company Common Stock,$15.105,-0.375,-2.422%,60293789553.00,United States,,68842551,Capital Goods,Auto Manufacturing
+add,F^B,Ford Motor Company 6.20% Notes due June 1 2059,$27.05,0.01,0.037%,,United States,,51068,,
+add,F^C,Ford Motor Company 6% Notes due December 1 2059,$27.04,-0.01,-0.037%,,United States,,48504,,
+add,FACA,Figure Acquisition Corp. I Class A Common Stock,$10.08,0.01,0.099%,413999994.00,,2021,1501,,
+add,FACT,Freedom Acquisition I Corp. Class A Ordinary Shares,$9.69,-0.06,-0.615%,417881250.00,,2021,22040,Health Care,Major Pharmaceuticals
+add,FAF,First American Corporation (New) Common Stock,$65.48,0.32,0.491%,7185851353.00,United States,,467578,Finance,Specialty Insurers
+add,FAII,Fortress Value Acquisition Corp. II Class A Common Stock,$9.99,0.00,0.00%,430818750.00,,2020,1470257,,
+add,FAM,First Trust/Aberdeen Global Opportunity Income Fund First Trust/Aberdeen Global Opportunity Income Fund Common Shares of Beneficial Interest,$10.22,0.09,0.888%,103598392.00,United States,2006,123198,,
+add,FBC,Flagstar Bancorp Inc. Common Stock,$45.18,-0.92,-1.996%,2383362739.00,United States,,113162,Finance,Savings Institutions
+add,FBHS,Fortune Brands Home & Security Inc. Common Stock,$98.68,-1.56,-1.556%,13676883402.00,United States,,423934,Consumer Durables,Building Products
+add,FBK,FB Financial Corporation Common Stock,$39.70,-0.70,-1.733%,1880229715.00,United States,2016,209117,Finance,Major Banks
+add,FBP,First BanCorp. New Common Stock,$12.61,-0.22,-1.715%,2718898958.00,Puerto Rico,,1123877,Finance,Major Banks
+add,FC,Franklin Covey Company Common Stock,$30.90,-1.43,-4.423%,437099967.00,United States,,33634,Consumer Services,Professional Services
+add,FCAX,Fortress Capital Acquisition Corp. Class A Ordinary Shares,$9.89,0.00,0.00%,494500000.00,,2021,225510,Finance,Business Services
+add,FCF,First Commonwealth Financial Corporation Common Stock,$14.765,-0.285,-1.894%,1420533873.00,United States,,153823,Finance,Major Banks
+add,FCN,FTI Consulting Inc. Common Stock,$140.95,2.76,1.997%,4823488429.00,United States,,362640,Consumer Services,Professional Services
+add,FCPT,Four Corners Property Trust Inc. Common Stock,$28.97,-0.04,-0.138%,2206681431.00,United States,2015,87314,Consumer Services,Real Estate Investment Trusts
+add,FCRW,First Eagle Alternative Capital BDC Inc. 6.125% Notes Due 2023,$25.85,0.00,0.00%,0.00,United States,2018,76,,
+add,FCRX,First Eagle Alternative Capital BDC Inc. 5.000% Notes due 2026,$25.44,0.07,0.276%,0.00,United States,2021,3000,,
+add,FCRZ,First Eagle Alternative Capital BDC Inc. 6.75% Notes due 2022,$25.35,0.00,0.00%,0.00,United States,2015,1302,,
+add,FCT,First Trust Senior Floating Rate Income Fund II Common Shares of Beneficial Interest,$12.425,-0.0256,-0.206%,322578533.00,United States,2004,94383,Finance,Finance Companies
+add,FCX,Freeport-McMoRan Inc. Common Stock,$40.145,-0.555,-1.364%,58833574309.00,United States,,14164489,Basic Industries,Precious Metals
+add,FDEU,First Trust Dynamic Europe Equity Income Fund Common Shares of Beneficial Interest,$13.97,0.04,0.287%,240729755.00,,2015,19553,,
+add,FDP,Fresh Del Monte Produce Inc. Common Stock,$34.70,-0.17,-0.488%,1648602726.00,Cayman Islands,1997,72318,,
+add,FDX,FedEx Corporation Common Stock,$292.54,-0.57,-0.194%,77623170621.00,United States,,1461932,Transportation,Air Freight/Delivery Services
+add,FE,FirstEnergy Corp. Common Stock,$38.62,0.13,0.338%,21005434684.00,United States,,1623394,Public Utilities,Electric Utilities: Central
+add,FEDU,Four Seasons Education (Cayman) Inc. American Depositary Shares each two ADSs representing one ordinary share,$1.01,0.01,1.00%,46846214.00,,2017,42496,Consumer Services,Other Consumer Services
+add,FEI           ,First Trust MLP and Energy Income Fund Common Shares of Beneficial Interest,$8.0999,0.1199,1.503%,367758253.00,,2012,224106,Finance,Finance/Investors Services
+add,FENG,Phoenix New Media Limited American Depositary Shares each representing 8 Class A ordinary shares.,$1.63,-0.09,-5.233%,118648580.00,China,2011,382993,Consumer Services,Broadcasting
+add,FEO,First Trust/Aberdeen Emerging Opportunity Fund Common Shares of Beneficial Interest,$15.77,-0.065,-0.41%,78720718.00,United States,,2914,,
+add,FERG,Ferguson plc Ordinary Shares,$136.03,-1.75,-1.27%,30378775010.00,,2021,26971,Consumer Durables,Industrial Machinery/Components
+add,FET,Forum Energy Technologies Inc. Common Stock,$24.76,0.93,3.903%,138665087.00,United States,2012,39514,Energy,Metal Fabrications
+add,FF,FutureFuel Corp.  Common shares,$10.165,-0.265,-2.541%,444650065.00,United States,,243936,Basic Industries,Major Chemicals
+add,FFA,First Trust Enhanced Equity Income Fund,$20.15,-0.015,-0.074%,402654186.00,United States,2004,33175,,
+add,FFC,Flaherty & Crumrine Preferred and Income Securities Fund Incorporated,$22.63,0.06,0.266%,1011547015.00,,2003,84025,,
+add,FGB,First Trust Specialty Finance and Financial Opportunities Fund,$4.37,0.05,1.157%,62786373.00,United States,2007,27749,,
+add,FGNA,FG New America Acquisition Corp. Class A Common Stock,$10.225,-0.005,-0.049%,309818778.00,,2020,139159,,
+add,FHI,Federated Hermes Inc. Common Stock,$32.195,-0.115,-0.356%,3170789512.00,United States,,303506,Finance,Investment Managers
+add,FHN,First Horizon Corporation Common Stock,$18.265,-0.525,-2.794%,10089120042.00,United States,,2834061,Finance,Major Banks
+add,FHN^A,First Horizon Corporation Depositary Shares,$25.3633,-0.0067,-0.026%,,United States,,2370,,
+add,FHN^B,First Horizon Corporation Depositary Shares each representing a 1/400th interest in a share of Non-Cumulative Perpetual Preferred Stock Series B,$28.25,-0.0004,-0.001%,,United States,,911,,
+add,FHN^C,First Horizon Corporation Depositary Shares each representing a 1/400th interest in a share of Non-Cumulative Perpetual Preferred Stock Series C,$28.50,-0.14,-0.489%,,United States,,3473,,
+add,FHN^D,First Horizon Corporation Depositary Shares each representing a 1/400th interest in a share of Non-Cumulative Perpetual Preferred Stock Series D,$27.00,-0.06,-0.222%,,United States,,1195,,
+add,FHN^E,First Horizon Corporation Depositary Shares each representing a 1/4000th interest in a share of Non-Cumulative Perpetual Preferred Stock Series E,$28.05,0.01,0.036%,,United States,,17221,,
+add,FHN^F,First Horizon Corporation Depositary Shares each representing 1/4000th Interest in a Share of Non-Cumulative Perpetual Preferred Stock Series F,$25.73,0.41,1.619%,,United States,,38825,,
+add,FHS,First High-School Education Group Co. Ltd. American Depositary Shares,$7.35,0.33,4.701%,212754813.00,,2021,270899,Consumer Services,Other Consumer Services
+add,FI,Frank's International N.V. Common Stock,$3.275,0.175,5.645%,745758172.00,,2013,2056580,Energy,Oilfield Services/Equipment
+add,FICO,Fair Isaac Corproation Common Stock,$495.85,4.66,0.949%,14269009502.00,United States,,52002,Technology,Computer Software: Prepackaged Software
+add,FIF,First Trust Energy Infrastructure Fund Common Shares of Beneficial Interest,$13.98,0.12,0.866%,238574739.00,United States,2011,37219,,
+add,FIGS,FIGS Inc. Class A Common Stock,$34.00,0.87,2.626%,5445025540.00,,2021,709144,Consumer Non-Durables,Medical Specialities
+add,FINS,Angel Oak Financial Strategies Income Term Trust Common Shares of Beneficial Interest,$18.235,-0.11,-0.60%,277700779.00,,2019,24780,,
+add,FINV,FinVolution Group American Depositary Shares,$8.14,-0.46,-5.349%,2306683538.00,United States,2017,3342572,Finance,Finance: Consumer Services
+add,FIS,Fidelity National Information Services Inc. Common Stock,$145.13,0.00,0.00%,89998822233.00,United States,,1327666,Miscellaneous,Business Services
+add,FIV,First Trust Senior Floating Rate 2022 Target Term Fund Common Shares of Beneficial Interest,$9.484,0.004,0.042%,339826600.00,United States,2016,96298,,
+add,FIX,Comfort Systems USA Inc. Common Stock,$83.34,-2.05,-2.401%,3024023486.00,United States,1997,98423,Capital Goods,Engineering & Construction
+add,FL,Foot Locker Inc.,$61.26,-0.76,-1.225%,6326822593.00,United States,,688552,Consumer Services,Clothing/Shoe/Accessory Stores
+add,FLC,Flaherty & Crumrine Total Return Fund Inc Common Stock,$24.205,0.065,0.269%,243196736.00,United States,2003,12991,,
+add,FLME,Flame Acquisition Corp. Class A Common Stock,$9.65,-0.02,-0.207%,346796875.00,,2021,43720,Finance,Business Services
+add,FLNG,FLEX LNG Ltd. Ordinary Shares,$14.64,0.22,1.526%,780466950.00,,2019,33558,Consumer Services,Marine Transportation
+add,FLO,Flowers Foods Inc. Common Stock,$24.665,0.135,0.55%,5222038307.00,United States,,396783,Consumer Non-Durables,Farming/Seeds/Milling
+add,FLOW,SPX FLOW Inc. Common Stock,$64.76,-1.45,-2.19%,2733883616.00,United States,2015,81877,Capital Goods,Industrial Machinery/Components
+add,FLR,Fluor Corporation Common Stock,$19.36,-0.59,-2.957%,2736333552.00,United States,,1776291,Capital Goods,Oilfield Services/Equipment
+add,FLS,Flowserve Corporation Common Stock,$43.20,-0.17,-0.392%,5629616813.00,United States,,196105,Capital Goods,Fluid Controls
+add,FLT,FleetCor Technologies Inc. Common Stock,$271.555,0.325,0.12%,22633989766.00,United States,2010,184088,Technology,EDP Services
+add,FLY,Fly Leasing Limited,$16.88,-0.03,-0.177%,514520445.00,Ireland,2007,222568,Technology,Diversified Commercial Services
+add,FMAC,FirstMark Horizon Acquisition Corp. Class A Common Stock,$9.92,-0.03,-0.302%,513360000.00,United States,2020,73547,,
+add,FMC,FMC Corporation Common Stock,$118.61,0.30,0.254%,15286050798.00,United States,,378273,Basic Industries,Agricultural Chemicals
+add,FMN,Federated Hermes Premier Municipal Income Fund,$15.20,-0.12,-0.783%,174750995.00,United States,2002,20570,,
+add,FMO,Fiduciary/Claymore Energy Infrastructure Fund Common Shares of Beneficial Interest,$13.54,0.68,5.288%,95973605.00,United States,2004,36088,,
+add,FMS,Fresenius Medical Care AG Common Stock,$41.55,-0.04,-0.096%,24339004850.00,Germany,,61396,Health Care,Medical/Nursing Services
+add,FMX,Fomento Economico Mexicano S.A.B. de C.V. Common Stock,$86.32,0.60,0.70%,30887249163.00,Mexico,,288253,Consumer Non-Durables,Beverages (Production/Distribution)
+add,FMY,First Trust Motgage Income Fund Common Shares of Beneficial Interest,$13.60,-0.0309,-0.227%,57298364.00,United States,2005,5234,,
+add,FN,Fabrinet Ordinary Shares,$93.81,-0.53,-0.562%,3460047983.00,Cayman Islands,2010,84059,Public Utilities,Telecommunications Equipment
+add,FNB,F.N.B. Corporation Common Stock,$12.925,-0.235,-1.786%,4128055545.00,United States,,913742,Finance,Major Banks
+add,FNB^E,F.N.B. Corporation Depositary Shares each representing a 1/40th interest in a share of Fixed-to-Floating Rate Non-Cumulative Perpetual Preferred  Stock Series E,$31.1943,0.7043,2.31%,,United States,,2106,,
+add,FND,Floor & Decor Holdings Inc. Common Stock,$97.17,-1.43,-1.45%,10194280092.00,,2017,616991,Consumer Services,RETAIL: Building Materials
+add,FNF,FNF Group of Fidelity National Financial Inc. Common Stock,$47.0684,-0.2816,-0.595%,13605244951.00,United States,2014,775721,Finance,Specialty Insurers
+add,FNV,Franco-Nevada Corporation,$154.87,1.42,0.925%,29583793648.00,Canada,,427348,Basic Industries,Precious Metals
+add,FOA,Finance of America Companies Inc. Class A Common Stock,$8.44,-0.22,-2.54%,541343406.00,,2021,641231,Finance,Finance Companies
+add,FOE,Ferro Corporation Common Stock,$21.49,-0.03,-0.139%,1775649696.00,United States,,989460,Basic Industries,Paints/Coatings
+add,FOF,Cohen & Steers Closed-End Opportunity Fund Inc. Common Stock,$14.39,0.00,0.00%,392269702.00,United States,2006,75112,Finance,Finance/Investors Services
+add,FOR,Forestar Group Inc Common Stock ,$22.20,-0.76,-3.31%,1090570582.00,United States,2017,60941,Finance,Real Estate
+add,FOUR,Shift4 Payments Inc. Class A Common Stock,$95.46,0.90,0.952%,7725032628.00,United States,2020,767855,Technology,EDP Services
+add,FPAC,Far Peak Acquisition Corporation Class A Ordinary Shares,$9.80,0.01,0.102%,683550000.00,,2021,98132,Finance,Business Services
+add,FPF,First Trust Intermediate Duration Preferred & Income Fund Common Shares of Beneficial Interest,$24.805,-0.405,-1.607%,1507300556.00,,2013,326326,,
+add,FPH,Five Point Holdings LLC Class A Common Shares,$8.015,-0.215,-2.612%,1186345523.00,United States,2017,116194,Consumer Services,Real Estate
+add,FPI,Farmland Partners Inc. Common Stock,$13.0842,-0.0558,-0.425%,403515302.00,,2014,261983,Consumer Services,Real Estate Investment Trusts
+add,FPI^B,Farmland Partners Inc. Series B Participating Preferred Stock,$26.39,-0.0093,-0.035%,,,,3189,,
+add,FPL,First Trust New Opportunities MLP & Energy Fund Common Shares of Beneficial Interest,$6.10,0.07,1.161%,152775970.00,,2014,112472,Finance,Trusts Except Educational Religious and Charitable
+add,FR,First Industrial Realty Trust Inc. Common Stock,$53.68,0.54,1.016%,6931564737.00,United States,1994,334138,Consumer Services,Real Estate Investment Trusts
+add,FRA,Blackrock Floating Rate Income Strategies Fund Inc  Common Stock,$12.90,-0.10,-0.769%,455823254.00,United States,2003,380100,,
+add,FRC,FIRST REPUBLIC BANK Common Stock,$192.57,-2.08,-1.069%,33951431095.00,United States,,407797,Finance,Commercial Banks
+add,FRC^H,FIRST REPUBLIC BANK Depositary Shares each representing a 1/40th interest in a share of 5.125% Noncumulative Perpetual Series H Preferred Stock par value $0.01 per share,$26.3344,0.0844,0.322%,,United States,,6401,,
+add,FRC^I,FIRST REPUBLIC BANK Depositary Shares each representing a 1/40th interest in a share of 5.50% Noncumulative Perpetual Series I Preferred Stock par value $0.01 per share,$27.64,0.01,0.036%,,United States,,11867,,
+add,FRC^J,FIRST REPUBLIC BANK Depositary Shares Each Representing a 1/40th Interest in a Share of 4.70% Noncumulative Perpetual Series J Preferred Stock,$26.55,-0.045,-0.169%,,United States,,21211,,
+add,FRC^K,FIRST REPUBLIC BANK Depositary Shares Each Representing a 1/40th Interest in a Share of 4.125% Noncumulative Perpetual Series K Preferred Stock,$25.59,0.01,0.039%,,United States,,20951,,
+add,FRC^L,FIRST REPUBLIC BANK Depositary Shares Each Representing a 1/40th Interest in a Share of 4.250% Noncumulative Perpetual Series L Preferred Stock,$25.95,0.01,0.039%,,United States,,14313,,
+add,FRO,Frontline Ltd. Ordinary Shares,$8.785,0.245,2.869%,1736727040.00,Bermuda,,1171624,,
+add,FRT,Federal Realty Investment Trust Common Stock,$122.26,-0.20,-0.163%,9506936989.00,United States,,448331,Consumer Services,Real Estate Investment Trusts
+add,FRT^C,Federal Realty Investment Trust Depositary Shares each representing a 1/1000th interest in a 5.000% Series C Cumulative Redeemable Preferred Share,$26.25,0.00,0.00%,,United States,,3695,,
+add,FRX,Forest Road Acquisition Corp. Class A Common Stock,$10.325,0.005,0.048%,387187500.00,United States,2021,1386616,,
+add,FRXB,Forest Road Acquisition Corp. II Class A Common Stock,$9.76,-0.04,-0.408%,427000000.00,,2021,27799,,
+add,FSD,First Trust High Income Long Short Fund Common Shares of Beneficial Interest,$15.36,-0.01,-0.065%,514101396.00,,2010,78841,Finance,Investment Managers
+add,FSK,FS KKR Capital Corp. Common Stock,$22.345,-0.925,-3.975%,2765327038.00,,2014,643105,Finance,Investment Managers
+add,FSKR,FS KKR Capital Corp. II Common Stock,$21.41,-0.62,-2.814%,3637626784.00,,2020,347084,Finance,Investment Managers
+add,FSLF,First Eagle Senior Loan Fund ,$14.5484,-0.0216,-0.148%,107934434.00,,2013,37647,,
+add,FSLY,Fastly Inc. Class A Common Stock,$53.76,-0.93,-1.70%,6220032000.00,,2019,5292154,Technology,Computer Software: Prepackaged Software
+add,FSM,Fortuna Silver Mines Inc Ordinary Shares (Canada),$6.82,0.14,2.096%,1263861599.00,Canada,,3028040,Basic Industries,Precious Metals
+add,FSNB,Fusion Acquisition Corp. II Class A Common Stock,$9.68,-0.0184,-0.19%,605060500.00,,2021,7573,,
+add,FSR,Fisker Inc. Class A Common Stock,$17.71,-0.96,-5.142%,5228802870.00,,2018,13601391,Capital Goods,Auto Manufacturing
+add,FSS,Federal Signal Corporation Common Stock,$42.00,-0.77,-1.80%,2562311346.00,United States,,93488,Technology,Industrial Machinery/Components
+add,FST,FAST Acquisition Corp. Class A Common Stock,$12.92,-0.13,-0.996%,1542313514.00,United States,2020,43322,,
+add,FT,Franklin Universal Trust Common Stock,$8.16,0.06,0.741%,205076255.00,United States,,31899,,
+add,FTAI,Fortress Transportation and Infrastructure Investors LLC Common Shares,$30.98,0.97,3.232%,2652840728.00,United States,2015,153777,Technology,Diversified Commercial Services
+add,FTAI^A,Fortress Transportation and Infrastructure Investors LLC 8.25% Fixed to Floating Rate Series A Cumulative Perpetual Redeemable Preferred Shares,$26.335,0.155,0.592%,,United States,,3367,,
+add,FTAI^B,Fortress Transportation and Infrastructure Investors LLC 8.00% Fixed-to-Floating Rate Series B Cumulative Perpetual Redeemable Preferred Shares,$25.65,-0.10,-0.388%,,United States,,3667,,
+add,FTAI^C,Fortress Transportation and Infrastructure Investors LLC 8.25% Fixed - Rate Reset Series C Cumulative Perpetual Redeemable Preferred Shares,$27.19,0.03,0.11%,,United States,,11507,,
+add,FTCH,Farfetch Limited Class A Ordinary Shares,$46.58,1.03,2.261%,16525349211.00,,2018,1837852,Consumer Services,Catalog/Specialty Distribution
+add,FTEV,FinTech Evolution Acquisition Group Class A Ordinary Shares,$9.72,0.00,0.00%,0.00,,2021,7612,,
+add,FTHY,First Trust High Yield Opportunities 2027 Term Fund Common Stock,$19.92,0.10,0.505%,0.00,United States,2020,49468,,
+add,FTI,TechnipFMC plc Ordinary Share,$10.095,-0.385,-3.674%,4549496418.00,,,5267260,Energy,Metal Fabrications
+add,FTK,Flotek Industries Inc. Common Stock,$2.07,0.04,1.97%,150552868.00,United States,,113809,Energy,Oilfield Services/Equipment
+add,FTS,Fortis Inc. Common Shares,$46.63,0.40,0.865%,21888122000.00,,2016,267595,Public Utilities,Electric Utilities: Central
+add,FTV,Fortive Corporation Common Stock ,$70.505,-0.565,-0.795%,23867742845.00,,2016,2108791,Capital Goods,Industrial Machinery/Components
+add,FTV^A,Fortive Corporation 5.00% Mandatory Convertible Preferred Stock Series A,$1004.30,0.00,0.00%,,,,3021,,
+add,FUBO,fuboTV Inc. Common Stock,$27.84,-1.16,-4.00%,3910568679.00,,2020,8141115,Consumer Services,Broadcasting
+add,FUL,H. B. Fuller Company Common Stock,$69.00,-0.34,-0.49%,3605083020.00,United States,,298101,Basic Industries,Home Furnishings
+add,FUN,Cedar Fair L.P. Common Stock,$46.07,0.69,1.52%,2618123548.00,United States,1987,232995,Consumer Services,Movies/Entertainment
+add,FUSE,Fusion Acquisition Corp. Class A Common Stock,$9.94,-0.03,-0.301%,434875000.00,United States,2020,541798,,
+add,FVIV,Fortress Value Acquisition Corp. IV Class A Common Stock,$9.97,0.02,0.201%,648050000.00,,2021,40056,,
+add,FVRR,Fiverr International Ltd. Ordinary Shares no par value,$204.27,1.58,0.78%,7321645525.00,,2019,260993,Miscellaneous,Business Services
+add,FVT,Fortress Value Acquisition Corp. III Class A Common Stock,$9.98,-0.01,-0.10%,286925000.00,,2021,250,,
+add,FZT,FAST Acquisition Corp. II Class A Common Stock,$9.76,0.00,0.00%,244000000.00,,2021,107,,
+add,G,Genpact Limited Common Stock,$45.44,-0.15,-0.329%,8511654444.00,Bermuda,2007,735970,Consumer Services,Professional Services
+add,GAB,Gabelli Equity Trust Inc. (The) Common Stock,$7.2571,0.0371,0.514%,1899708012.00,United States,1986,677430,,
+add,GAB^G,Gabelli Equity Trust Inc. (The) Series G Cumulative Preferred Stock,$25.71,0.0282,0.11%,,United States,,3352,,
+add,GAB^H,Gabelli Equity Trust Inc. (The) Pfd Ser H,$25.71,0.01,0.039%,,United States,,661,,
+add,GAB^J,Gabelli Equity Trust Inc. (The) 5.45% Series J Cumulative Preferred Stock,$26.24,-0.12,-0.455%,,United States,,2948,,
+add,GAB^K,Gabelli Equity Trust Inc. (The) 5.00% Series K Cumulative Preferred Stock,$26.556,0.0358,0.135%,,United States,,6105,,
+add,GAM,General American Investors Inc. Common Stock,$43.75,0.18,0.413%,1076085588.00,United States,,5219,,
+add,GAM^B,General American Investors Company Inc. Cumulative Preferred Stock,$26.90,0.07,0.261%,,United States,,1629,,
+add,GAPA,G&P Acquisition Corp. Class A Common Stock,$9.72,0.02,0.206%,212625000.00,,2021,1860,,
+add,GATO,Gatos Silver Inc. Common Stock,$19.27,1.27,7.056%,1144812432.00,United States,2020,968568,Basic Industries,Precious Metals
+add,GATX,GATX Corporation Common Stock,$96.885,0.375,0.389%,3429729000.00,United States,,98365,Transportation,Rental/Leasing Companies
+add,GB,Global Blue Group Holding AG Ordinary Shares,$9.43,0.43,4.778%,1768454692.00,,2000,3447,Technology,EDP Services
+add,GBAB,Guggenheim Taxable Municipal Bond & Investment Grade Debt Trust Common Shares of Beneficial Interest,$24.46,0.00,0.00%,490749957.00,United States,2010,44219,,
+add,GBL,Gamco Investors Inc. Common Stock,$24.42,0.03,0.123%,667033961.00,United States,1999,18387,,
+add,GBX,Greenbrier Companies Inc. (The) Common Stock,$47.31,-0.78,-1.622%,1552956711.00,United States,1994,176376,Capital Goods,Railroads
+add,GCI,Gannett Co. Inc. Common Stock,$5.25,-0.11,-2.052%,748160700.00,,2014,600792,Consumer Services,Newspapers/Magazines
+add,GCO,Genesco Inc. Common Stock,$59.18,-2.67,-4.317%,885091582.00,United States,,83567,Consumer Services,Clothing/Shoe/Accessory Stores
+add,GCP,GCP Applied Technologies Inc. Common Stock,$23.12,-0.04,-0.173%,1695322020.00,,2016,97924,Consumer Durables,Industrial Specialties
+add,GCV,Gabelli Convertible and Income Securities Fund Inc. (The) Common Stock,$6.48,0.00,0.00%,121962575.00,United States,,40677,,
+add,GD,General Dynamics Corporation Common Stock,$191.45,-0.42,-0.219%,54103346130.00,United States,,536157,Capital Goods,Aerospace
+add,GDDY,GoDaddy Inc. Class A Common Stock,$81.505,0.365,0.45%,13705533426.00,United States,2015,334944,Technology,EDP Services
+add,GDL,GDL Fund The Common Shares of Beneficial Interest,$9.03,0.01,0.111%,125362813.00,United States,2007,17009,Finance,Investment Managers
+add,GDO,Western Asset Global Corporate Defined Opportunity Fund Inc. Western Asset Global Corporate Defined Opportunity Fund Inc.,$18.28,0.06,0.329%,273074427.00,United States,2009,43607,,
+add,GDOT,Green Dot Corporation Class A Common Stock $0.001 par value,$44.50,0.39,0.884%,2422130105.00,United States,2010,409230,Technology,Advertising
+add,GDV,Gabelli Dividend & Income Trust Common Shares of Beneficial Interest,$26.74,-0.01,-0.037%,2418160210.00,United States,2003,162145,,
+add,GDV^G,Gabelli Dividend 5.25% Series G Cumulative Preferred Shares par value $0.001 per share,$25.95,0.00,0.00%,,United States,,3658,,
+add,GDV^H,The Gabelli Dividend & Income Trust 5.375% Series H Cumulative Preferred Shares,$28.27,-0.08,-0.282%,,United States,,1904,,
+add,GE,General Electric Company Common Stock,$13.61,-0.12,-0.874%,119477304010.00,United States,,41445162,Consumer Durables,Metal Fabrications
+add,GEF,Greif Inc. Class A Common Stock,$61.99,2.03,3.386%,3690687782.00,United States,,231927,,
+add,GEL,Genesis Energy L.P. Common Units,$12.26,0.57,4.876%,1502821213.00,United States,1996,876415,Energy,Oil Refining/Marketing
+add,GENI,Genius Sports Limited Ordinary Shares,$19.315,-0.225,-1.151%,3447966175.00,,2021,7085669,,
+add,GEO,Geo Group Inc (The) REIT,$7.08,-1.72,-19.545%,866505192.00,United States,,20735836,Consumer Services,Real Estate Investment Trusts
+add,GER,Goldman Sachs MLP Energy Renaissance Fund,$12.23,0.25,2.087%,208213830.00,,1986,46892,,
+add,GES,Guess? Inc. Common Stock,$27.215,-0.495,-1.786%,1766900836.00,United States,1996,460356,,
+add,GF,New Germany Fund Inc. (The) Common Stock,$20.77,-0.02,-0.096%,325933807.00,United States,1990,5656,,
+add,GFF,Griffon Corporation Common Stock,$25.215,-0.665,-2.57%,1429274932.00,United States,,81270,Capital Goods,Diversified Manufacture
+add,GFI,Gold Fields Limited American Depositary Shares,$11.09,0.19,1.743%,9843085436.00,South Africa,,5982651,Basic Industries,Precious Metals
+add,GFL,GFL Environmental Inc. Subordinate voting shares no par value,$33.15,0.96,2.982%,10831272974.00,,2020,468122,,
+add,GFLU,GFL Environmental Inc. Tangible Equity Units,$76.59,1.64,2.188%,0.00,,2020,2109,,
+add,GFX,Golden Falcon Acquisition Corp. Class A Common Stock,$9.71,0.0316,0.327%,418743750.00,,2021,140627,,
+add,GGB,Gerdau S.A. Common Stock,$6.35,0.05,0.794%,10828895824.00,Brazil,,8770174,Basic Industries,Steel/Iron Ore
+add,GGG,Graco Inc. Common Stock,$73.38,-0.32,-0.434%,12433145290.00,United States,,221555,Capital Goods,Fluid Controls
+add,GGM,Guggenheim Credit Allocation Fund Common Shares of Beneficial Interest,$21.33,-0.14,-0.652%,209102853.00,,2013,46848,Finance,Trusts Except Educational Religious and Charitable
+add,GGT,Gabelli Multi-Media Trust Inc. (The) Common Stock,$10.865,0.105,0.976%,274494870.00,United States,,48931,,
+add,GGT^E,Gabelli Multi-Media Trust Inc. (The) 5.125% Series E Cumulative Preferred Stock,$25.95,-0.10,-0.384%,,United States,,400,,
+add,GGT^G,Gabelli Multi-Media Trust Inc. (The) 5.125% Series G Cumulative Preferred Shares,$26.395,-0.055,-0.208%,,United States,,3750,,
+add,GGZ,Gabelli Global Small and Mid Cap Value Trust (The) Common Shares of Beneficial Interest,$16.45,0.02,0.122%,148023400.00,,2014,10436,,
+add,GGZ^A,Gabelli Global Small and Mid Cap Value Trust (The) 5.450% Series A Cumulative Preferred Shares (Liquidation Preference $25.00 per share),$26.50,0.28,1.068%,,,,3765,,
+add,GHC,Graham Holdings Company Common Stock,$651.07,-9.69,-1.466%,3256423614.00,United States,,9823,Miscellaneous,Service to the Health Industry
+add,GHG,GreenTree Hospitality Group Ltd. American depositary shares each representing one Class A ordinary share,$14.97,0.44,3.028%,1542656449.00,,2018,160208,Consumer Services,Hotels/Resorts
+add,GHL,Greenhill & Co. Inc. Common Stock,$15.00,-0.03,-0.20%,292784850.00,United States,2004,53876,Finance,Investment Bankers/Brokers/Service
+add,GHLD,Guild Holdings Company Class A Common Stock,$15.40,0.00,0.00%,924000000.00,,2020,8308,Finance,Finance: Consumer Services
+add,GHM,Graham Corporation Common Stock,$14.19,0.02,0.141%,141189436.00,United States,,17673,Capital Goods,Industrial Machinery/Components
+add,GHY,PGIM Global High Yield Fund Inc.,$15.65,-0.04,-0.255%,640458706.00,United States,2012,110310,,
+add,GIB,CGI Inc. Common Stock,$90.69,0.96,1.07%,22484600931.00,Canada,,71668,,
+add,GIL,Gildan Activewear Inc. Class A Sub. Vot. Common Stock,$35.50,-0.41,-1.142%,7044258681.00,Canada,1998,145363,Consumer Durables,Building Products
+add,GIM,Templeton Global Income Fund Inc. Common Stock,$5.635,0.005,0.089%,755902330.00,United States,1988,212365,,
+add,GIS,General Mills Inc. Common Stock,$62.57,0.45,0.724%,38165902301.00,United States,,1648275,Consumer Services,Food Chains
+add,GJH,Synthetic Fixed-Income Securities Inc 6.375% (STRATS) Cl A-1,$10.7199,0.0399,0.374%,0.00,United States,,10601,,
+add,GJO,Synthetic Fixed-Income Securities Inc. Synthetic Fixed-Income Securities Inc. on behalf of STRATS(SM) Trust for Wal-Mart Stores Inc. Securities Series 2004-5,$24.00,0.07,0.293%,0.00,United States,,1536,,
+add,GJP,Synthetic Fixed-Income Securities Inc. Synthetic Fixed-Income Securities Inc. on behalf of STRATS (SM) Trust for Dominion Resources Inc. Securities Series 2005-6 Floating Rate Structured Repackaged Asset-Backed Trust Securities (STRATS) Certificates,$24.50,0.00,0.00%,0.00,United States,,13,,
+add,GJR,Synthetic Fixed-Income Securities Inc. STRATS Trust for Procter&Gamble Securities Series 2006-1,$22.88,-0.36,-1.549%,0.00,United States,,1000,,
+add,GJS,Goldman Sachs Group Securities STRATS Trust for Goldman Sachs Group Securities Series 2006-2,$21.00,-0.05,-0.238%,0.00,United States,,1225,Finance,Finance: Consumer Services
+add,GJT,Synthetic Fixed-Income Securities Inc. Synthetic Fixed-Income Securities Inc. Floating Rate Structured Repackaged Asset-Backed Trust Securities Certificates Series 2006-3,$20.36,-0.14,-0.683%,0.00,United States,,3200,,
+add,GKOS,Glaukos Corporation Common Stock,$78.44,-0.10,-0.127%,3630327606.00,United States,2015,109845,Health Care,Medical/Dental Instruments
+add,GL,Globe Life Inc. Common Stock,$103.74,-1.08,-1.03%,10690755151.00,United States,,162537,Finance,Life Insurance
+add,GL^C,Globe Life Inc. 6.125% Junior Subordinated Debentures due 2056,$25.22,-0.01,-0.04%,,United States,,12026,,
+add,GLEO,Galileo Acquisition Corp. Ordinary Shares,$10.01,0.00,0.00%,174174000.00,,2019,39153,Finance,Business Services
+add,GLOB,Globant S.A. Common Shares,$213.48,4.61,2.207%,8794078042.00,,2014,125318,Consumer Services,Electronics Distribution
+add,GLOG^A,GasLog LP. 8.75% Series A Cumulative Redeemable Perpetual Preference Shares,$25.50,0.0107,0.042%,,Monaco,,29847,,
+add,GLOP,GasLog Partners LP Common Units representing limited partnership interests,$3.10,0.00,0.00%,156903896.00,,2014,253085,Energy,Oil & Gas Production
+add,GLOP^A,GasLog Partners LP 8.625% Series A Cumulative Redeemable Perpetual Fixed to Floating Rate Preference Units,$24.43,0.09,0.37%,,,,8173,,
+add,GLOP^B,GasLog Partners LP 8.200% Series B Cumulative Redeemable Perpetual Fixed to Floating Rate Preference Units,$22.77,-0.05,-0.219%,,,,13290,,
+add,GLOP^C,GasLog Partners LP 8.500% Series C Cumulative Redeemable Perpetual Fixed to Floating Rate Preference Units,$23.80,-0.15,-0.626%,,,,21519,,
+add,GLP,Global Partners LP Global Partners LP Common Units representing Limited Partner Interests,$27.05,-0.15,-0.551%,919579979.00,United States,2005,73007,Energy,Oil Refining/Marketing
+add,GLP^A,Global Partners LP 9.75% Series A Fixed-to-Floating Rate Cumulative Redeemable Perpetual Preferred Units representing limited partner interests,$27.119,0.0813,0.301%,,United States,,1247,,
+add,GLP^B,Global Partners LP 9.50% Series B Fixed Rate Cumulative Redeemable Perpetual Preferred Units representing limited partner interests,$27.06,0.10,0.371%,,United States,,8242,,
+add,GLT,Glatfelter Corporation Common Stock,$14.12,-0.32,-2.216%,627657411.00,United States,,102971,Basic Industries,Paper
+add,GLW,Corning Incorporated Common Stock,$43.095,0.335,0.783%,36689222675.00,United States,,2565563,Capital Goods,Industrial Machinery/Components
+add,GM,General Motors Company Common Stock,$61.37,-1.40,-2.23%,89027671292.00,United States,2010,11394689,Capital Goods,Auto Manufacturing
+add,GME,GameStop Corporation Common Stock,$215.1778,-87.3822,-28.881%,15228515492.00,United States,2002,21392614,Consumer Services,Electronics Distribution
+add,GMED,Globus Medical Inc. Class A Common Stock,$72.2725,1.3425,1.893%,7253315872.00,United States,2012,158158,Health Care,Medical/Dental Instruments
+add,GMRE,Global Medical REIT Inc. Common Stock,$15.70,-0.07,-0.444%,954468406.00,,2016,233691,Consumer Services,Real Estate Investment Trusts
+add,GMRE^A,Global Medical REIT Inc. Series A Cumulative Redeemable Preferred Stock,$26.5405,-0.0595,-0.224%,,,,4169,,
+add,GMS,GMS Inc. Common Stock,$42.30,-1.28,-2.937%,1812410249.00,United States,2016,256847,,
+add,GNE,Genie Energy Ltd. Class B Common Stock Stock,$6.23,-0.01,-0.16%,163311152.00,United States,2011,34315,Public Utilities,Power Generation
+add,GNE^A,Genie Energy Ltd. Series 2012 - A Preferred Stock $0.01 par value,$8.92,-0.007,-0.078%,,United States,,6279,,
+add,GNK,Genco Shipping & Trading Limited Ordinary Shares New (Marshall Islands),$17.92,0.51,2.929%,751070781.00,United States,,972713,Transportation,Marine Transportation
+add,GNL,Global Net Lease Inc. Common Stock,$19.855,0.005,0.025%,1894033773.00,United States,2015,512622,Consumer Services,Real Estate Investment Trusts
+add,GNL^A,Global Net Lease Inc. 7.25% Series A Cumulative Redeemable Preferred Stock $0.01 par value per share,$26.835,0.01,0.037%,,United States,,3059,,
+add,GNL^B,Global Net Lease Inc. 6.875% Series B Cumulative Redeemable Perpetual Preferred Stock,$27.0507,-0.0743,-0.274%,,United States,,6928,,
+add,GNPK,Genesis Park Acquisition Corp. Class A Ordinary Shares,$10.1831,0.0531,0.524%,208468708.00,United States,2021,80740,Finance,Business Services
+add,GNRC,Generac Holdlings Inc. Common Stock,$344.335,0.625,0.182%,21677451187.00,United States,2010,320968,Consumer Durables,Metal Fabrications
+add,GNT,GAMCO Natural Resources Gold & Income Trust,$5.9601,0.0401,0.677%,124606809.00,United States,2011,42221,Finance,Finance/Investors Services
+add,GNT^A,GAMCO Natural Resources Gold & Income Tust  5.20% Series A Cumulative Preferred Shares (Liquidation Preference $25.00 per share),$26.10,-0.0166,-0.064%,,United States,,1266,,
+add,GNW,Genworth Financial Inc Common Stock,$4.07,-0.11,-2.632%,2062689354.00,United States,2004,1787406,Finance,Life Insurance
+add,GOAC,GO Acquisition Corp. Class A Common Stock,$9.84,-0.02,-0.203%,707250000.00,,2020,66889,,
+add,GOF,Guggenheim Strategic Opportunities Fund Common Shares of Beneficial Interest,$21.72,0.20,0.929%,1041501823.00,United States,,262677,,
+add,GOL,Gol Linhas Aereas Inteligentes S.A. Sponsored ADR representing 2 Pfd Shares,$10.36,-0.41,-3.807%,1959478683.00,Brazil,2004,1421746,Transportation,Air Freight/Delivery Services
+add,GOLD,Barrick Gold Corporation Common Stock (BC),$23.66,0.65,2.825%,42076265975.00,Canada,,11562044,Basic Industries,Precious Metals
+add,GOLF,Acushnet Holdings Corp. Common Stock,$50.53,-0.90,-1.75%,3742446391.00,United States,2016,162814,Consumer Non-Durables,Recreational Products/Toys
+add,GOOS,Canada Goose Holdings Inc. Subordinate Voting Shares,$39.77,-0.74,-1.827%,4392165194.00,,2017,423040,Consumer Non-Durables,Apparel
+add,GOTU,Gaotu Techedu Inc. American Depositary Shares,$16.165,0.665,4.29%,4131599693.00,,2019,10737666,Consumer Services,Other Consumer Services
+add,GPC,Genuine Parts Company Common Stock,$127.90,-0.49,-0.382%,18477996426.00,United States,,320714,Capital Goods,Automotive Aftermarket
+add,GPI,Group 1 Automotive Inc. Common Stock,$153.87,-2.81,-1.793%,2794814975.00,United States,1997,66701,Consumer Services,Other Specialty Stores
+add,GPJA,Georgia Power Company Series 2017A 5.00% Junior Subordinated Notes due October 1 2077,$27.14,0.00,0.00%,0.00,United States,2017,3784,,
+add,GPK,Graphic Packaging Holding Company,$17.605,0.065,0.371%,5404292041.00,United States,,2690612,Basic Industries,Paper
+add,GPM,Guggenheim Enhanced Equity Income Fund,$8.74,-0.03,-0.342%,422514219.00,,,70732,,
+add,GPMT,Granite Point Mortgage Trust Inc. Common Stock,$15.18,0.07,0.463%,836534233.00,,2017,244791,Consumer Services,Real Estate Investment Trusts
+add,GPN,Global Payments Inc. Common Stock,$192.00,0.05,0.026%,56681418624.00,United States,,906163,Miscellaneous,Business Services
+add,GPOR,Gulfport Energy Corporation Common Shares,$63.65,0.68,1.08%,1263183897.00,United States,2021,30275,Energy,Oil & Gas Production
+add,GPRK,Geopark Ltd Common Shares,$15.23,-0.02,-0.131%,929517786.00,Bermuda,2014,53220,Energy,Oil & Gas Production
+add,GPS,Gap Inc. (The) Common Stock,$31.33,-0.27,-0.854%,11830280122.00,United States,,3747370,Consumer Services,Clothing/Shoe/Accessory Stores
+add,GPX,GP Strategies Corporation Common Stock,$16.10,0.07,0.437%,280876672.00,United States,,38359,Miscellaneous,Service to the Health Industry
+add,GRA,W.R. Grace & Co. Common Stock,$68.62,-0.19,-0.276%,4546325120.00,United States,,350803,Basic Industries,Major Chemicals
+add,GRC,Gorman-Rupp Company (The) Common Stock,$35.90,-0.49,-1.347%,937569426.00,United States,,41849,Capital Goods,Fluid Controls
+add,GRUB,GrubHub Inc. Common Stock,$61.55,-0.73,-1.172%,5745567738.00,,2014,4031165,Miscellaneous,Business Services
+add,GRX,The Gabelli Healthcare & Wellness Trust Common Shares of Beneficial Interest,$13.54,0.05,0.371%,233966691.00,United States,,28385,,
+add,GS,Goldman Sachs Group Inc. (The) Common Stock,$374.075,-8.705,-2.274%,127096542721.00,United States,1999,2778885,Finance,Investment Bankers/Brokers/Service
+add,GS^A,Goldman Sachs Group Inc. (The) Depositary Shares each representing 1/1000th Interest in a Share of Floating Rate Non-Cumulative Preferred Stock Series A,$24.54,0.17,0.698%,,United States,,47690,,
+add,GS^C,Goldman Sachs Group Inc. (The) Depositary Share repstg 1/1000th Preferred Series C,$25.17,-0.03,-0.119%,,United States,,8031,,
+add,GS^D,Goldman Sachs Group Inc. (The) Dep Shs repstg 1/1000 Pfd Ser D Fltg,$24.97,0.15,0.604%,,United States,,69717,,
+add,GS^J,Goldman Sachs Group Inc Depositary Shs Repstg 1/1000th Pfd Ser J Fixed to Fltg Rate,$27.33,-0.02,-0.073%,,United States,,38371,,
+add,GS^K,Goldman Sachs Group Inc. (The) Dep Shs Repstg 1/1000 Int Sh Fxd/Fltg Non Cum Pfd Stk Ser K,$29.50,0.06,0.204%,,United States,,37181,,
+add,GSAH,GS Acquisition Holdings Corp II Class A Common Stock,$10.3599,0.0799,0.777%,971240625.00,United States,2020,518253,,
+add,GSBD,Goldman Sachs BDC Inc. Common Stock,$20.05,-0.15,-0.743%,2038425596.00,United States,2015,470682,Finance,Finance: Consumer Services
+add,GSK,GlaxoSmithKline PLC Common Stock,$40.145,0.595,1.504%,100994830318.00,United Kingdom,,2739414,Health Care,Major Pharmaceuticals
+add,GSL,Global Ship Lease Inc New Class A Common Shares,$19.28,0.44,2.335%,699545263.00,United Kingdom,,1115283,Transportation,Marine Transportation
+add,GSL^B,Global Ship Lease Inc. Depository Shares Representing 1/100th Perpetual Preferred Series B% (Marshall Island),$25.7974,0.0174,0.067%,,United Kingdom,,25149,,
+add,GSLD,Global Ship Lease Inc. 8.00% Senior Notes due 2024,$25.88,-0.015,-0.058%,0.00,United Kingdom,2019,3553,Transportation,Marine Transportation
+add,GSQD,G Squared Ascend I Inc. Class A Ordinary Shares,$9.91,0.06,0.609%,427368750.00,,2021,33826,Finance,Business Services
+add,GTES,Gates Industrial Corporation plc Ordinary Shares,$18.14,-0.02,-0.11%,5289877633.00,,2018,345128,Capital Goods,Industrial Machinery/Components
+add,GTLS,Chart Industries Inc. Common Stock,$143.41,-4.53,-3.062%,5212743261.00,United States,2006,158886,Technology,Electrical Products
+add,GTN,Gray Television Inc. Common Stock,$22.84,-0.53,-2.268%,2188152899.00,United States,,340718,Consumer Services,Broadcasting
+add,GTS,Triple-S Management Corporation Common Stock,$24.98,-0.08,-0.319%,591519805.00,United States,2007,60668,Finance,Accident &Health Insurance
+add,GTT,GTT Communications Inc. Common Stock,$2.62,-0.14,-5.072%,154107190.00,United States,,2230547,Public Utilities,Telecommunications Equipment
+add,GTY,Getty Realty Corporation Common Stock,$33.38,-0.34,-1.008%,1482218772.00,United States,,144941,Consumer Services,Real Estate Investment Trusts
+add,GUT,Gabelli Utility Trust (The) Common Stock,$7.6601,0.0751,0.99%,417273017.00,United States,,135312,,
+add,GUT^A,Gabelli Utility Trust (The) 5.625% Series A Cumulative Preferred Shares,$27.45,0.00,0.00%,,United States,,1,,
+add,GUT^C,Gabelli Utility Trust (The) 5.375% Series C Cumulative Preferred Shares,$26.222,-0.078,-0.297%,,United States,,2938,,
+add,GVA,Granite Construction Incorporated Common Stock,$38.94,-0.81,-2.038%,1783129265.00,United States,,151657,Capital Goods,Engineering & Construction
+add,GWB,Great Western Bancorp Inc. Common Stock,$33.895,-0.305,-0.892%,1868001005.00,United States,2014,273617,Finance,Major Banks
+add,GWRE,Guidewire Software Inc. Common Stock,$109.71,3.15,2.956%,9122904880.00,United States,2012,463739,Technology,Computer Software: Prepackaged Software
+add,GWW,W.W. Grainger Inc. Common Stock,$459.82,1.27,0.277%,23961286874.00,United States,,89860,Consumer Non-Durables,Telecommunications Equipment
+add,H,Hyatt Hotels Corporation Class A Common Stock,$80.98,-0.06,-0.074%,8241688807.00,United States,2009,461904,Consumer Services,Hotels/Resorts
+add,HAE,Haemonetics Corporation Common Stock,$58.39,0.06,0.103%,2975169668.00,United States,1991,486175,Health Care,Medical/Dental Instruments
+add,HAL,Halliburton Company Common Stock,$23.975,-0.285,-1.175%,21331010771.00,United States,,4329746,Energy,Oil & Gas Production
+add,HASI,Hannon Armstrong Sustainable Infrastructure Capital Inc. Common Stock,$52.01,-0.65,-1.234%,4091620199.00,United States,2013,602939,Consumer Services,Real Estate Investment Trusts
+add,HAYW,Hayward Holdings Inc. Common Stock,$23.79,-0.31,-1.286%,5497898904.00,,2021,467204,Technology,Electronic Components
+add,HBB,Hamilton Beach Brands Holding Company Class A Common Stock ,$23.10,-0.39,-1.66%,320498478.00,,2017,19655,Capital Goods,Office Equipment/Supplies/Services
+add,HBI,Hanesbrands Inc. Common Stock,$19.105,-0.195,-1.01%,6669850500.00,United States,,1855033,Consumer Non-Durables,Apparel
+add,HBM,Hudbay Minerals Inc. Ordinary Shares (Canada),$7.035,0.035,0.50%,1839091297.00,Canada,,938091,,
+add,HCA,HCA Healthcare Inc. Common Stock,$210.085,1.775,0.852%,69465760718.00,United States,2011,824057,Health Care,Hospital/Nursing Management
+add,HCC,Warrior Met Coal Inc. Common Stock,$18.22,-0.23,-1.247%,936671178.00,United States,2017,278210,,
+add,HCHC,HC2 Holdings Inc. Common Stock,$4.08,-0.16,-3.774%,316657127.00,United States,,263062,Public Utilities,Telecommunications Equipment
+add,HCI,HCI Group Inc. Common Stock,$86.97,-0.46,-0.526%,737798863.00,United States,,60180,Finance,Property-Casualty Insurers
+add,HCXY,Hercules Capital Inc. 6.25% Notes due 2033,$26.90,0.12,0.448%,0.00,United States,2018,960,Finance,Finance Companies
+add,HCXZ,Hercules Capital Inc. 5.25% Notes due 2025,$25.16,0.03,0.119%,0.00,United States,2018,3919,Finance,Finance Companies
+add,HD,Home Depot Inc. (The) Common Stock,$308.10,0.76,0.247%,327589923515.00,United States,,2530677,Consumer Services,RETAIL: Building Materials
+add,HDB,HDFC Bank Limited Common Stock,$77.26,0.01,0.013%,142108037992.00,India,2001,734987,Finance,Commercial Banks
+add,HE,Hawaiian Electric Industries Inc. Common Stock,$44.50,0.15,0.338%,4858576439.00,United States,,258862,,
+add,HEI,Heico Corporation Common Stock,$145.07,-0.16,-0.11%,19636073305.00,United States,,236630,Capital Goods,Military/Government/Technical
+add,HEI/A,Heico Corporation,$133.515,-0.625,-0.466%,,United States,,50778,,
+add,HEP,Holly Energy Partners L.P. Common Stock,$22.77,0.53,2.383%,2400873377.00,United States,2004,122470,,
+add,HEQ,John Hancock Hedged Equity & Income Fund Common Shares of Beneficial Interest,$13.01,-0.11,-0.838%,159031807.00,United States,2011,64985,,
+add,HES,Hess Corporation Common Stock,$89.13,0.25,0.281%,27489597421.00,United States,,822593,Energy,Oil & Gas Production
+add,HESM,Hess Midstream LP Class A Share,$25.90,-0.05,-0.193%,648495000.00,United States,2017,98780,Energy,Oilfield Services/Equipment
+add,HEXO,HEXO Corp. Common Shares,$6.58,-0.35,-5.051%,964317266.00,,,4518014,,
+add,HFC,HollyFrontier Corporation Common Stock,$34.975,-0.315,-0.893%,5681443470.00,United States,,1699855,Energy,Integrated oil Companies
+add,HFRO,Highland Income Fund,$11.97,-0.07,-0.581%,854063354.00,,2017,253061,,
+add,HFRO^A,Highland Income Fund 5.375% Series A Cumulative Preferred Shares,$26.28,0.09,0.344%,,,,12112,,
+add,HGH,Hartford Financial Services Group Inc. (The) 7.875% Fixed to Floating Rate Junior Subordinated Debentures due 2042,$26.72,-0.08,-0.299%,0.00,United States,,49529,Finance,Property-Casualty Insurers
+add,HGLB,Highland Global Allocation Fund Common Stock,$9.31,0.025,0.269%,204255609.00,,2019,182240,,
+add,HGV,Hilton Grand Vacations Inc. Common Stock ,$46.50,-0.04,-0.086%,3977711463.00,,2016,306953,Consumer Services,Hotels/Resorts
+add,HHC,Howard Hughes Corporation (The) Common Stock,$105.4799,-2.0001,-1.861%,5813018385.00,United States,,126674,Consumer Services,Real Estate Investment Trusts
+add,HHLA,HH&L Acquisition Co. Class A Ordinary Shares,$9.76,0.02,0.205%,505080000.00,,2021,33362,Finance,Business Services
+add,HI,Hillenbrand Inc Common Stock,$45.135,-0.485,-1.063%,3396335360.00,United States,,280200,Miscellaneous,Consumer Specialties
+add,HIE,Miller/Howard High Income Equity Fund Common Shares of Beneficial Interest,$10.70,0.06,0.564%,199990223.00,United States,2014,199808,,
+add,HIG,Hartford Financial Services Group Inc. (The) Common Stock,$65.19,-0.81,-1.227%,23285282203.00,United States,,1079213,Finance,Property-Casualty Insurers
+add,HIG^G,Hartford Financial Services Group Inc. (The) Depositary Shares each representing a 1/1000th interest in a share of 6.000% Non-Cumulative Preferred Stock Series G $0.01 par value,$27.89,0.11,0.396%,,United States,,16077,,
+add,HIGA,H.I.G. Acquisition Corp. Class A Ordinary Shares,$9.80,-0.03,-0.305%,445832625.00,United States,2020,7935,Finance,Business Services
+add,HII,Huntington Ingalls Industries Inc. Common Stock,$220.5001,-0.5299,-0.24%,8871234993.00,United States,,99291,Capital Goods,Metal Fabrications
+add,HIL,Hill International Inc. Common Stock,$2.59,0.01,0.388%,146661775.00,United States,2018,489563,Consumer Services,Military/Government/Technical
+add,HIMS,Hims & Hers Health Inc. Class A Common Stock,$12.68,-0.77,-5.725%,2432046545.00,,2019,2109285,Consumer Non-Durables,Package Goods/Cosmetics
+add,HIO,Western Asset High Income Opportunity Fund Inc. Common Stock,$5.24,0.01,0.191%,498319887.00,United States,,155759,,
+add,HIW,Highwoods Properties Inc. Common Stock,$48.52,0.33,0.685%,5048784311.00,United States,1994,308344,Consumer Services,Real Estate Investment Trusts
+add,HIX,Western Asset High Income Fund II Inc. Common Stock,$7.21,-0.01,-0.139%,607362267.00,United States,1998,159296,,
+add,HKIB,AMTD International Inc. American Depositary Shares each representing one Class A Ordinary Share,$6.75,-0.13,-1.89%,1657877483.00,,2019,1112,Finance,Finance: Consumer Services
+add,HL,Hecla Mining Company Common Stock,$9.255,0.365,4.106%,4956528448.00,United States,,5239840,Basic Industries,Precious Metals
+add,HL^B,Hecla Mining Company Preferred Stock,$58.67,0.00,0.00%,,United States,,122,,
+add,HLF,Herbalife Nutrition Ltd. Common Stock,$54.68,-0.31,-0.564%,5907237824.00,Cayman Islands,2004,608546,Health Care,Other Pharmaceuticals
+add,HLI,Houlihan Lokey Inc. Class A Common Stock,$78.88,1.98,2.575%,5379360823.00,United States,2015,394742,Finance,Investment Managers
+add,HLT,Hilton Worldwide Holdings Inc. Common Stock ,$126.76,0.31,0.245%,35306934601.00,,2016,1498949,Consumer Services,Hotels/Resorts
+add,HLX,Helix Energy Solutions Group Inc. Common Stock,$6.02,-0.06,-0.987%,907358408.00,United States,,908382,Energy,Oilfield Services/Equipment
+add,HMC,Honda Motor Company Ltd. Common Stock,$32.755,-0.075,-0.228%,56556593303.00,Japan,,522020,Capital Goods,Auto Manufacturing
+add,HMLP,Hoegh LNG Partners LP Common Units representing Limited Partner Interests,$17.12,0.03,0.176%,571141039.00,Bermuda,2014,61855,Transportation,Marine Transportation
+add,HMLP^A,Hoegh LNG Partners LP 8.75% Series A Cumulative Redeemable Preferred Units,$25.91,-0.18,-0.69%,,Bermuda,,9797,,
+add,HMN,Horace Mann Educators Corporation Common Stock,$38.24,-0.18,-0.469%,1586329881.00,United States,1991,93060,Finance,Property-Casualty Insurers
+add,HMY,Harmony Gold Mining Company Limited,$4.81,0.14,2.998%,2933607297.00,South Africa,,5149316,Basic Industries,Precious Metals
+add,HNGR,Hanger Inc. Common Stock,$25.94,-0.24,-0.917%,999762334.00,United States,2018,28353,Health Care,Medical Specialities
+add,HNI,HNI Corporation Common Stock,$45.67,-0.38,-0.825%,1989040757.00,United States,,54825,Consumer Durables,Office Equipment/Supplies/Services
+add,HNP,Huaneng Power Intl Common Stock,$15.10,0.14,0.936%,5926030228.00,China,1994,33384,Public Utilities,Electric Utilities: Central
+add,HOG,Harley-Davidson Inc. Common Stock,$46.58,-1.04,-2.184%,7157741133.00,United States,,967955,Consumer Non-Durables,Motor Vehicles
+add,HOME,At Home Group Inc. Common Stock,$36.44,-0.31,-0.844%,2389474035.00,United States,2016,1471959,Consumer Services,Other Specialty Stores
+add,HOV,Hovnanian Enterprises Inc. Class A Common Stock,$93.54,-3.83,-3.933%,579267497.00,United States,,228065,Capital Goods,Homebuilding
+add,HP,Helmerich & Payne Inc. Common Stock,$32.69,-0.19,-0.578%,3527054795.00,United States,,570285,Energy,Oil & Gas Production
+add,HPE,Hewlett Packard Enterprise Company Common Stock,$15.65,0.00,0.00%,20437766017.00,United States,2015,4717332,Technology,Electronic Components
+add,HPF,John Hancock Pfd Income Fund II Pfd Income Fund II,$21.45,-0.15,-0.694%,458445874.00,United States,2002,41358,,
+add,HPI,John Hancock Preferred Income Fund Common Shares of Beneficial Interest,$21.5398,-0.0602,-0.279%,564716648.00,United States,2002,42876,,
+add,HPP,Hudson Pacific Properties Inc. Common Stock,$29.90,0.28,0.945%,4513448505.00,United States,2010,710257,Consumer Services,Building operators
+add,HPQ,HP Inc. Common Stock,$30.01,-0.04,-0.133%,36049677495.00,United States,,5848708,Technology,Computer peripheral equipment
+add,HPS,John Hancock Preferred Income Fund III Preferred Income Fund III,$19.37,-0.14,-0.718%,613977088.00,United States,2003,62583,,
+add,HPX,HPX Corp. Class A Ordinary Shares,$9.7988,0.0288,0.295%,309691074.00,United States,2020,6940,Finance,Business Services
+add,HQH,Tekla Healthcare Investors Common Stock,$25.66,0.54,2.15%,1145822307.00,United States,1987,113979,,
+add,HQL,TeklaLife Sciences Investors Common Stock,$21.00,0.35,1.695%,509868198.00,United States,1992,64548,,
+add,HR,Healthcare Realty Trust Incorporated Common Stock,$32.31,0.22,0.686%,4577037088.00,United States,1993,636292,Consumer Services,Real Estate Investment Trusts
+add,HRB,H&R Block Inc. Common Stock,$25.75,-0.06,-0.232%,4671855254.00,United States,,791399,Miscellaneous,Other Consumer Services
+add,HRC,Hill-Rom Holdings Inc Common Stock,$113.98,2.93,2.638%,7575750456.00,United States,,286724,Health Care,Medical/Dental Instruments
+add,HRI,Herc Holdings Inc. Common Stock ,$103.31,-5.58,-5.124%,3058835643.00,,2016,262241,Technology,Diversified Commercial Services
+add,HRL,Hormel Foods Corporation Common Stock,$48.65,0.37,0.766%,26371944177.00,United States,,988023,Consumer Non-Durables,Meat/Poultry/Fish
+add,HRTG,Heritage Insurance Holdings Inc. Common Stock,$8.83,0.09,1.03%,246932628.00,,2014,77263,Finance,Property-Casualty Insurers
+add,HSBC,HSBC Holdings plc. Common Stock,$30.77,-0.09,-0.292%,125701839175.00,United Kingdom,,1465151,Finance,Savings Institutions
+add,HSC,Harsco Corporation Common Stock,$23.10,-0.19,-0.816%,1828726053.00,United States,,122253,Capital Goods,Office Equipment/Supplies/Services
+add,HSY,The Hershey Company Common Stock,$174.24,1.38,0.798%,36067061971.00,United States,,382642,Consumer Non-Durables,Specialty Foods
+add,HT,Hersha Hospitality Trust Class A Common Shares of Beneficial Interest,$11.83,-0.22,-1.826%,462935192.00,United States,1999,241976,Consumer Services,Real Estate Investment Trusts
+add,HT^C,Hersha Hospitality Trust 6.875% Series C Cumulative Redeemable Preferred Shares of Beneficial Interest,$25.00,0.00,0.00%,,United States,,3161,,
+add,HT^D,Hersha Hospitality Trust 6.50% Series D Cumulative Redeemable Preferred Shares of Beneficial Interest $0.01 par value per share,$23.84,0.04,0.168%,,United States,,11593,,
+add,HT^E,Hersha Hospitality Trust 6.50% Series E Cumulative Redeemable Preferred Shares of Beneficial Interest,$23.83,0.10,0.421%,,United States,,16358,,
+add,HTA,Healthcare Trust of America Inc. Class A Common Stock,$29.54,0.45,1.547%,6464133422.00,United States,,1331298,Consumer Services,Real Estate Investment Trusts
+add,HTD,John Hancock Tax Advantaged Dividend Income Fund Common Shares of Beneficial Interest,$25.42,-0.26,-1.012%,899888819.00,United States,2004,68484,,
+add,HTFB,Horizon Technology Finance Corporation 4.875% Notes due 2026,$25.7086,-0.0114,-0.044%,0.00,United States,,400,Finance,Finance Companies
+add,HTGC,Hercules Capital Inc. Common Stock,$17.275,-0.115,-0.661%,1999463607.00,United States,2012,370296,Finance,Finance Companies
+add,HTH,Hilltop Holdings Inc.,$37.35,-1.08,-2.81%,3077263661.00,United States,,315357,Finance,Major Banks
+add,HTPA,Highland Transcend Partners I Corp. Class A Ordinary Shares,$9.84,0.01,0.102%,369000000.00,,2021,573,Finance,Business Services
+add,HTY,John Hancock Tax-Advantaged Global Shareholder Yield Fund Common Shares of Beneficial Interest,$6.76,-0.14,-2.029%,73775280.00,United States,,69039,,
+add,HUBB,Hubbell Inc Common Stock,$184.855,-1.925,-1.031%,10040640746.00,United States,2015,96995,Capital Goods,Industrial Machinery/Components
+add,HUBS,HubSpot Inc. Common Stock,$502.62,5.27,1.06%,23485309533.00,United States,2014,226716,Technology,Computer Software: Prepackaged Software
+add,HUGS,USHG Acquisition Corp. Class A Common Stock,$9.79,0.0132,0.135%,349351255.00,,2021,19282,,
+add,HUM,Humana Inc. Common Stock,$420.68,-2.07,-0.49%,54273789150.00,United States,,378123,Health Care,Medical Specialities
+add,HUN,Huntsman Corporation Common Stock,$27.01,-0.22,-0.808%,5987760414.00,United States,2005,1497936,Basic Industries,Major Chemicals
+add,HUYA,HUYA Inc. American depositary shares each  representing one Class A ordinary share,$15.84,-0.18,-1.124%,3742086427.00,United States,2018,3159929,Consumer Services,Broadcasting
+add,HVT,Haverty Furniture Companies Inc. Common Stock,$49.12,-0.59,-1.187%,896247941.00,United States,,100630,Consumer Services,Other Specialty Stores
+add,HVT/A,Haverty Furniture Companies Inc.,$50.04,0.00,0.00%,,United States,,3,,
+add,HWM,Howmet Aerospace Inc. Common Stock,$35.16,0.13,0.371%,15098584125.00,United States,,2534337,Capital Goods,Industrial Machinery/Components
+add,HXL,Hexcel Corporation Common Stock,$61.03,-0.22,-0.359%,5112642022.00,United States,,408520,Capital Goods,Industrial Machinery/Components
+add,HY,Hyster-Yale Materials Handling Inc. Class A Common Stock,$72.80,-0.33,-0.451%,1224226858.00,United States,,24353,Capital Goods,Construction/Ag Equipment/Trucks
+add,HYB,New America High Income Fund Inc. (The) Common Stock,$9.225,0.005,0.054%,215578269.00,United States,1988,42796,,
+add,HYI,Western Asset High Yield Defined Opportunity Fund Inc. Common Stock,$15.50,0.01,0.065%,351097382.00,,2010,62358,,
+add,HYLN,Hyliion Holdings Corp. Class A Common Stock,$12.00,-0.46,-3.692%,2067860496.00,,2019,2753630,Capital Goods,Auto Parts:O.E.M.
+add,HYT,Blackrock Corporate High Yield Fund Inc. Common Stock,$12.37,0.08,0.651%,1507953173.00,United States,2003,420628,,
+add,HZAC,Horizon Acquisition Corporation Class A Ordinary Shares,$10.09,0.04,0.398%,686100234.00,United States,2020,197096,Finance,Business Services
+add,HZN,Horizon Global Corporation Common Shares,$9.90,-0.02,-0.202%,267371914.00,United States,2015,42328,Capital Goods,Auto Parts:O.E.M.
+add,HZO,MarineMax Inc.  (FL) Common Stock,$47.22,0.19,0.404%,1046131712.00,United States,1998,425988,Consumer Services,Other Specialty Stores
+add,HZON,Horizon Acquisition Corporation II Class A Ordinary Shares,$9.77,-0.03,-0.306%,641156250.00,United States,2020,689090,Finance,Business Services
+add,IAA,IAA Inc. Common Stock ,$53.605,-2.435,-4.345%,7223562413.00,,2019,3482117,Miscellaneous,Business Services
+add,IACA,ION Acquisition Corp 1 Ltd. Class A Ordinary Shares,$10.438,0.238,2.333%,337604063.00,Israel,2020,349787,Finance,Business Services
+add,IACB,ION Acquisition Corp 2 Ltd. Class A Ordinary Shares,$9.87,-0.032,-0.323%,312138750.00,,2021,16982,Finance,Business Services
+add,IACC,ION Acquisition Corp 3 Ltd. Class A Ordinary Shares,$9.875,0.025,0.254%,319762375.00,,2021,2166,,
+add,IAE,Voya Asia Pacific High Dividend Equity Income Fund ING Asia Pacific High Dividend Equity Income Fund Common Shares of Beneficial Interest,$9.615,0.035,0.365%,114407481.00,United States,2007,39830,,
+add,IAG,Iamgold Corporation Ordinary Shares,$3.765,0.085,2.31%,1794022500.00,Canada,,3502772,,
+add,IBA,Industrias Bachoco S.A.B. de C.V. Common Stock,$46.56,-1.04,-2.185%,2328000000.00,Mexico,1997,4758,Consumer Non-Durables,Meat/Poultry/Fish
+add,IBER,Ibere Pharmaceuticals Class A Ordinary Shares,$9.75,0.00,0.00%,0.00,,2021,6,,
+add,IBM,International Business Machines Corporation Common Stock,$150.68,0.01,0.007%,134636019723.00,United States,,3489332,Technology,EDP Services
+add,IBN,ICICI Bank Limited Common Stock,$17.59,0.16,0.918%,60892349376.00,India,,4638988,Finance,Commercial Banks
+add,IBP,Installed Building Products Inc. Common Stock,$115.13,-4.07,-3.414%,3418996268.00,,2014,124512,Capital Goods,Homebuilding
+add,ICD,Independence Contract Drilling Inc. Common Stock,$4.37,-0.18,-3.956%,28484447.00,,2014,283310,Energy,Oil & Gas Production
+add,ICE,Intercontinental Exchange Inc. Common Stock,$111.69,0.84,0.758%,62855307176.00,United States,2005,1902015,,
+add,ICL,ICL Group Ltd. Ordinary Shares,$7.31,-0.04,-0.544%,9387144885.00,Israel,2014,113779,Basic Industries,Agricultural Chemicals
+add,IDA,IDACORP Inc. Common Stock,$100.25,0.67,0.673%,5064176670.00,United States,,94534,Public Utilities,Electric Utilities: Central
+add,IDE,Voya Infrastructure Industrials and Materials Fund Common Shares of Beneficial Interest,$12.65,0.10,0.797%,240847006.00,United States,2010,73880,,
+add,IDT,IDT Corporation Class B Common Stock,$34.64,-6.36,-15.512%,891125882.00,United States,,546841,Public Utilities,Telecommunications Equipment
+add,IEX,IDEX Corporation Common Stock,$220.27,-0.74,-0.335%,16725328419.00,United States,1989,239479,Capital Goods,Fluid Controls
+add,IFF,Internationa Flavors & Fragrances Inc. Common Stock,$147.72,0.63,0.428%,36770444378.00,United States,,1214525,Basic Industries,Major Chemicals
+add,IFFT,International Flavors & Fragrances Inc. 6.00% Tangible Equity Units,$51.37,0.31,0.607%,0.00,United States,2018,10686,Basic Industries,Major Chemicals
+add,IFN,India Fund Inc. (The) Common Stock,$22.35,0.23,1.04%,601317251.00,United States,,45071,,
+add,IFS,Intercorp Financial Services Inc. Common Shares,$25.72,0.29,1.14%,2968676499.00,,2019,101417,Finance,Commercial Banks
+add,IGA,Voya Global Advantage and Premium Opportunity Fund Common Shares of Beneficial Interest,$9.97,0.01,0.10%,181446542.00,United States,2005,113641,,
+add,IGD,Voya Global Equity Dividend and Premium Opportunity Fund,$6.07,0.00,0.00%,576509564.00,United States,2005,258469,,
+add,IGI,Western Asset Investment Grade Defined Opportunity Trust Inc. Common Stock,$21.53,0.04,0.186%,233439456.00,United States,2009,23718,,
+add,IGR,CBRE Clarion Global Real Estate Income Fund Common Stock,$9.0488,-0.0112,-0.124%,1055004062.00,United States,2004,441474,,
+add,IGT,International Game Technology Ordinary Shares,$24.705,-0.835,-3.269%,5060992185.00,United States,2015,1049170,Consumer Services,Movies/Entertainment
+add,IH,iHuman Inc. American depositary shares each representing five Class A ordinary shares,$10.05,-1.22,-10.825%,535910984.00,United States,2020,76675,Consumer Services,Other Consumer Services
+add,IHC,Independence Holding Company Common Stock,$46.91,0.57,1.23%,686736553.00,United States,,7621,Finance,Life Insurance
+add,IHD,Voya Emerging Markets High Income Dividend Equity Fund Common Shares,$8.65,0.02,0.232%,160261292.00,United States,2011,44893,,
+add,IHG,Intercontinental Hotels Group American Depositary Shares (Each representing one Ordinary Share),$72.28,-0.91,-1.243%,13242875031.00,United Kingdom,,49194,Consumer Services,Hotels/Resorts
+add,IHIT,Invesco High Income 2023 Target Term Fund Common Shares of Beneficial Interest,$9.81,0.11,1.134%,236007528.00,United States,2016,42484,,
+add,IHTA,Invesco High Income 2024 Target Term Fund Common Shares of Beneficial Interest No par value per share,$9.8027,0.0627,0.644%,86077185.00,,2017,13118,Finance,Finance/Investors Services
+add,IIAC,Investindustrial Acquisition Corp. Class A Ordinary Shares,$9.77,0.00,0.00%,491553125.00,United Kingdom,2021,10269,Finance,Business Services
+add,IIF,Morgan Stanley India Investment Fund Inc. Common Stock,$25.12,0.08,0.319%,283208030.00,United States,1994,9994,,
+add,IIIN,Insteel Industries Inc. Common Stock,$32.56,-0.99,-2.951%,629731369.00,United States,,45349,,
+add,IIM,Invesco Value Municipal Income Trust Common Stock,$16.38,0.04,0.245%,770785765.00,United States,,75652,,
+add,IIPR,Innovative Industrial Properties Inc. Common Stock,$191.27,2.29,1.212%,4576386653.00,United States,2016,84469,Consumer Services,Real Estate Investment Trusts
+add,IIPR^A,Innovative Industrial Properties Inc. 9.00% Series A Cumulative Redeemable Preferred Stock,$35.50,0.00,0.00%,,United States,,172,,
+add,IMAX,Imax Corporation Common Stock,$22.52,-0.71,-3.056%,1336757451.00,Canada,,636313,,
+add,IMPX,AEA-Bridges Impact Corp. Class A Ordinary Shares,$9.74,-0.02,-0.205%,487000000.00,,2020,32401,Finance,Business Services
+add,INFO,IHS Markit Ltd. Common Shares,$107.22,0.48,0.45%,45433856662.00,Bermuda,1996,956240,Technology,EDP Services
+add,INFY,Infosys Limited American Depositary Shares,$19.90,0.24,1.221%,84487822219.00,India,,4833329,Technology,EDP Services
+add,ING,ING Group N.V. Common Stock,$13.39,-0.02,-0.149%,52265569271.00,Netherlands,1997,2764768,Finance,Commercial Banks
+add,INGR,Ingredion Incorporated Common Stock,$95.00,-0.52,-0.544%,6362667560.00,United States,,144295,Consumer Non-Durables,Farming/Seeds/Milling
+add,INN,Summit Hotel Properties Inc. Common Stock,$10.04,-0.12,-1.181%,1065456989.00,United States,2011,233829,Consumer Services,Real Estate Investment Trusts
+add,INN^D,Summit Hotel Properties Inc. 6.45% Series D Cumulative Redeemable Preferred Stock,$25.08,-0.112,-0.445%,,United States,,1300,,
+add,INN^E,Summit Hotel Properties Inc. 6.250% Series E Cumulative Redeemable Preferred Stock,$26.315,0.00,0.00%,,United States,,125,,
+add,INS,Intelligent Systems Corporation Common Stock,$33.27,-0.50,-1.481%,295515785.00,United States,1992,30943,Technology,Computer Software: Prepackaged Software
+add,INSI,Insight Select Income Fund,$20.91,-0.07,-0.334%,223946832.00,United States,,10890,,
+add,INSP,Inspire Medical Systems Inc. Common Stock,$173.06,5.81,3.474%,4709573156.00,United States,1998,189084,Health Care,Biotechnology: Electromedical & Electrotherapeutic Apparatus
+add,INSW,International Seaways Inc. Common Stock ,$20.00,-0.30,-1.478%,561740220.00,,2016,116240,Transportation,Marine Transportation
+add,INSW^A,International Seaways Inc. 8.50% Senior Notes due June 30 2023,$25.90,0.00,0.00%,,,,402,,
+add,INT,World Fuel Services Corporation Common Stock,$34.55,0.13,0.378%,2184770287.00,United States,,331549,Energy,Oil Refining/Marketing
+add,INVH,Invitation Homes Inc. Common Stock,$37.92,0.47,1.255%,21525304457.00,United States,2017,1832248,Consumer Services,Real Estate Investment Trusts
+add,IO,Ion Geophysical Corporation Common Stock,$2.18,-0.04,-1.802%,62808431.00,United States,,154219,Energy,Oilfield Services/Equipment
+add,IP,International Paper Company Common Stock,$62.92,-0.36,-0.569%,24648235749.00,United States,,1183333,Basic Industries,Containers/Packaging
+add,IPG,Interpublic Group of Companies Inc. (The) Common Stock,$33.515,-0.005,-0.015%,13183984843.00,United States,,3259021,Technology,Advertising
+add,IPI,Intrepid Potash Inc Common Stock,$27.74,-1.74,-5.902%,372986575.00,United States,2008,75815,Basic Industries,Major Chemicals
+add,IPOD,Social Capital Hedosophia Holdings Corp. IV Class A Ordinary Shares,$10.66,0.02,0.188%,612950000.00,United States,2020,363639,Finance,Business Services
+add,IPOF,Social Capital Hedosophia Holdings Corp. VI Class A Ordinary Shares,$10.2858,0.0058,0.056%,1478583750.00,United States,2020,797076,Finance,Business Services
+add,IPVA,InterPrivate II Acquisition Corp. Class A Common Stock,$9.71,0.01,0.103%,314057813.00,,2021,1875,,
+add,IPVF,InterPrivate III Financial Partners Inc. Class A Common Stock,$9.75,0.00,0.00%,315351563.00,,2021,841,,
+add,IQI,Invesco Quality Municipal Income Trust Common Stock,$13.42,-0.04,-0.297%,709700556.00,United States,,55826,,
+add,IQV,IQVIA Holdings Inc. Common Stock,$242.905,3.525,1.473%,46555457470.00,United States,2013,567382,Health Care,Managed Health Care
+add,IR,Ingersoll Rand Inc. Common Stock,$47.43,-0.24,-0.503%,19894646351.00,United States,2017,938395,Capital Goods,Industrial Machinery/Components
+add,IRL,New Ireland Fund Inc (The) Common Stock,$12.5104,0.0004,0.003%,60715498.00,United States,1990,9844,,
+add,IRM,Iron Mountain Incorporated (Delaware)Common Stock REIT,$46.385,-0.635,-1.35%,13392791656.00,United States,,1759102,Consumer Services,Real Estate Investment Trusts
+add,IRR,Voya Natural Resources Equity Income Fund Common Shares of Beneficial Interest,$3.713,-0.017,-0.456%,78347040.00,United States,,200437,,
+add,IRS,IRSA Inversiones Y Representaciones S.A. Common Stock,$3.9917,-0.1383,-3.349%,231014305.00,Argentina,,212497,Consumer Services,Homebuilding
+add,IRT,Independence Realty Trust Inc. Common Stock,$18.53,0.20,1.091%,1892793397.00,United States,2013,297897,Consumer Services,Real Estate Investment Trusts
+add,ISD,PGIM High Yield Bond Fund Inc.,$16.375,-0.105,-0.637%,544578872.00,United States,2012,81909,,
+add,ISOS,Isos Acquisition Corporation Class A Ordinary Shares,$9.66,0.00,0.00%,307716644.00,,2021,8,,
+add,IT,Gartner Inc. Common Stock,$231.27,0.98,0.426%,19906918862.00,United States,1993,650633,Finance,Diversified Commercial Services
+add,ITCB,Itau CorpBanca American Depositary Shares (each representing 1500 shares of Common Stock no par value),$4.63,-0.22,-4.536%,1581628863.00,Chile,,42717,Finance,Commercial Banks
+add,ITGR,Integer Holdings Corporation Common Stock,$88.32,-0.05,-0.057%,2912359507.00,United States,,69820,Health Care,Medical/Dental Instruments
+add,ITT,ITT Inc. Common Stock ,$92.34,-0.62,-0.667%,7950474000.00,United States,2011,189448,Capital Goods,Fluid Controls
+add,ITUB,Itau Unibanco Banco Holding SA American Depositary Shares (Each repstg 500 Preferred shares),$6.5099,-0.0201,-0.308%,63823940702.00,Brazil,,47763635,Finance,Commercial Banks
+add,ITW,Illinois Tool Works Inc. Common Stock,$232.635,0.315,0.136%,73485379359.00,United States,,471693,Capital Goods,Industrial Machinery/Components
+add,IVAN,Ivanhoe Capital Acquisition Corp. Class A Ordinary Shares,$10.07,0.01,0.099%,347415000.00,,2021,26948,Finance,Business Services
+add,IVC,Invacare Corporation Common Stock,$8.27,0.07,0.854%,289079405.00,United States,,128137,Health Care,Industrial Specialties
+add,IVH,Ivy High Income Opportunities Fund Common Shares of Beneficial Interest,$13.89,0.04,0.289%,230160564.00,,2013,30165,,
+add,IVR,INVESCO MORTGAGE CAPITAL INC Common Stock,$4.2808,0.1208,2.904%,1215309317.00,United States,2009,80440305,Consumer Services,Real Estate Investment Trusts
+add,IVR^A,Invesco Mortgage Capital Inc. Pfd Ser A,$25.2599,-0.0101,-0.04%,,United States,,13150,,
+add,IVR^B,Invesco Mortgage Capital Inc. Preferred Series B Cum Fxd to Fltg,$24.95,0.00,0.00%,,United States,,37630,,
+add,IVR^C,INVESCO MORTGAGE CAPITAL INC 7.5% Fixed-to-Floating Series C Cumulative Redeemable Preferred Stock Liquation Preference $25.00 per Share,$24.8334,-0.0666,-0.267%,,United States,,23497,,
+add,IVZ,Invesco Ltd Common Stock,$28.875,0.175,0.61%,13324400195.00,United States,,2853020,Finance,Investment Managers
+add,IX,Orix Corp Ads Common Stock,$90.18,-0.67,-0.737%,20723576915.00,Japan,,12342,Finance,Diversified Financial Services
+add,J,Jacobs Engineering Group Inc. Common Stock,$141.23,-0.29,-0.205%,18390319953.00,United States,,341492,Capital Goods,Oilfield Services/Equipment
+add,JAX,J. Alexander's Holdings Inc. Common Stock,$11.79,-0.07,-0.59%,177912008.00,,2015,8429,Consumer Services,Restaurants
+add,JBGS,JBG SMITH Properties Common Shares ,$34.79,0.09,0.259%,4574855394.00,United States,2017,250973,Consumer Services,Real Estate Investment Trusts
+add,JBI,Janus International Group Inc. Common Stock,$14.31,0.18,1.274%,0.00,,2021,274313,,
+add,JBK,Lehman ABS 3.50 3.50% Adjustable Corp Backed Tr Certs GS Cap I,$29.6136,-1.0564,-3.444%,0.00,United States,,468,Finance,Trusts Except Educational Religious and Charitable
+add,JBL,Jabil Inc. Common Stock,$57.40,0.10,0.175%,8541003076.00,United States,1993,362698,Technology,Electrical Products
+add,JBT,John Bean Technologies Corporation Common Stock,$139.68,-3.69,-2.574%,4434886793.00,United States,,114595,Capital Goods,Diversified Manufacture
+add,JCE,Nuveen Core Equity Alpha Fund Nuveen Core Equity Alpha Fund Common Shares of Beneficial Interest,$16.52,0.04,0.243%,264803722.00,United States,2007,41177,,
+add,JCI,Johnson Controls International plc Ordinary Share,$67.00,0.14,0.209%,48019911097.00,Switzerland,,3104738,Capital Goods,Auto Parts:O.E.M.
+add,JCO,Nuveen Credit Opportunities 2022 Target Term Fund Common Shares of Beneficial Interest,$8.51,-0.01,-0.117%,236156687.00,United States,2017,51488,,
+add,JDD,Nuveen Diversified Dividend and Income Fund Shares of Beneficial Interest,$10.86,0.05,0.463%,213600095.00,United States,2003,37990,,
+add,JEF,Jefferies Financial Group Inc. Common Stock,$31.6199,-0.3501,-1.095%,7809242369.00,United States,,945679,Finance,Finance/Investors Services
+add,JELD,JELD-WEN Holding Inc. Common Stock,$27.22,-0.45,-1.626%,2699254396.00,United States,2017,399742,,
+add,JEMD,Nuveen Emerging Markets Debt 2022 Target Term Fund Common Shares of Beneficial Interest $0.01 par value per share,$8.2503,-0.0097,-0.117%,117541958.00,,2017,10490,,
+add,JEQ,Aberdeen Japan Equity Fund Inc.  Common Stock,$8.99,0.03,0.335%,120542730.00,United States,1992,77315,,
+add,JFR,Nuveen Floating Rate Income Fund Common Stock,$9.79,0.02,0.205%,557231802.00,United States,2004,173978,,
+add,JGH,Nuveen Global High Income Fund Common Shares of Beneficial Interest,$16.0058,-0.0742,-0.461%,370972717.00,United States,2014,87733,,
+add,JHAA,Nuveen Corporate Income 2023 Target Term Fund,$9.98,0.03,0.302%,78098081.00,,2018,48833,,
+add,JHB,Nuveen Corporate Income November 2021 Target Term Fund,$9.41,-0.01,-0.106%,526019461.00,,2016,85649,,
+add,JHG,Janus Henderson Group plc Ordinary Shares,$38.855,0.155,0.401%,6696658823.00,,2017,792202,Finance,Investment Managers
+add,JHI,John Hancock Investors Trust Common Stock,$18.67,-0.30,-1.581%,162560157.00,United States,,32765,,
+add,JHS,John Hancock Income Securities Trust Common Stock,$15.89,-0.14,-0.873%,185064220.00,United States,,13129,,
+add,JHX,James Hardie Industries plc American Depositary Shares (Ireland),$34.46,0.89,2.651%,15310194598.00,Ireland,,13461,Capital Goods,Building Materials
+add,JILL,J. Jill Inc. Common Stock,$21.42,-0.02,-0.093%,213759176.00,,2017,218376,Consumer Services,Clothing/Shoe/Accessory Stores
+add,JKS,JinkoSolar Holding Company Limited American Depositary Shares (each representing 4 Common Shares),$41.66,1.41,3.503%,1986304140.00,China,2010,2960201,Technology,Semiconductors
+add,JLL,Jones Lang LaSalle Incorporated Common Stock,$208.71,-1.50,-0.714%,10708319451.00,United States,,172716,Finance,Real Estate
+add,JLS,Nuveen Mortgage and Income Fund,$21.0867,-0.0483,-0.229%,115712001.00,United States,2009,6812,,
+add,JMIA,Jumia Technologies AG American Depositary Shares each representing two Ordinary Shares,$29.64,-1.41,-4.541%,2922284190.00,,2019,4045765,Consumer Services,Catalog/Specialty Distribution
+add,JMM,Nuveen Multi-Market Income Fund (MA),$7.35,0.0038,0.052%,69548280.00,United States,,14232,,
+add,JMP,JMP Group LLC Common Shares,$5.665,-0.045,-0.788%,112464373.00,United States,2007,8522,Finance,Investment Bankers/Brokers/Service
+add,JNJ,Johnson & Johnson Common Stock,$166.99,1.40,0.845%,439750798541.00,United States,,5055881,Health Care,Major Pharmaceuticals
+add,JNPR,Juniper Networks Inc. Common Stock,$28.93,0.45,1.58%,9481521672.00,United States,1999,2485463,Technology,Computer peripheral equipment
+add,JOE,St. Joe Company (The) Common Stock,$47.5501,-0.7499,-1.553%,2799871093.00,United States,,95160,Consumer Services,Homebuilding
+add,JOF,Japan Smaller Capitalization Fund Inc Common Stock,$9.29,-0.01,-0.108%,263221866.00,United States,1990,27370,,
+add,JP,Jupai Holdings Limited American Depositary Shares each representing six ordinary shares,$1.5899,-0.0701,-4.223%,52824704.00,,2015,128798,Consumer Services,Other Consumer Services
+add,JPC,Nuveen Preferred & Income Opportunities Fund,$9.925,-0.025,-0.251%,1025799854.00,United States,2003,239150,,
+add,JPI,Nuveen Preferred and Income Term Fund Common Shares of Beneficial Interest,$25.7168,-0.0632,-0.245%,585350140.00,,2012,12299,Finance,Finance Companies
+add,JPM,JP Morgan Chase & Co. Common Stock,$160.73,-2.21,-1.356%,486550301442.00,United States,,9359924,Finance,Major Banks
+add,JPM^C,J P Morgan Chase & Co Depositary Shares each representing a 1/400th interest in a share of 6.00% Non-Cumulative  Preferred Stock Series EE,$28.25,-0.11,-0.388%,,United States,,146436,,
+add,JPM^D,J P Morgan Chase & Co Depositary Shares each representing a 1/400th  interest in a share of 5.75% Non-Cumulative  Preferred Stock Series DD,$27.74,-0.04,-0.144%,,United States,,70691,,
+add,JPM^J,J P Morgan Chase & Co Depositary Shares each representing a 1/400th interest in a share of JPMorgan Chase & Co. 4.75% Non-Cumulative Preferred Stock Series GG,$26.685,0.075,0.282%,,United States,,116756,,
+add,JPM^K,J P Morgan Chase & Co Depositary Shares each representing a 1/400th interest in a share of 4.55% Non-Cumulative Preferred Stock Series JJ,$26.19,0.08,0.306%,,United States,,158420,,
+add,JPM^L,J P Morgan Chase & Co Depositary Shares each representing a 1/400th interest in a share of 4.625% Non-Cumulative Preferred Stock Series LL,$26.29,0.02,0.076%,,United States,,378227,,
+add,JPS,Nuveen Preferred & Income Securities Fund,$9.91,-0.01,-0.101%,2019560357.00,United States,2002,260713,,
+add,JPT,Nuveen Preferred and Income 2022 Term Fund Common Shares of Beneficial Interest,$24.8936,-0.0684,-0.274%,170298910.00,United States,2017,4609,,
+add,JQC,Nuveen Credit Strategies Income Fund Shares of Beneficial Interest,$6.57,-0.02,-0.303%,890953035.00,United States,2003,814154,,
+add,JRI,Nuveen Real Asset Income and Growth Fund Common Shares of Beneficial Interest,$16.50,0.16,0.979%,452985720.00,United States,2012,113834,,
+add,JRO,Nuveen Floating Rate Income Opportuntiy Fund Shares of Beneficial Interest,$9.54,-0.04,-0.418%,386763220.00,United States,2004,407673,,
+add,JRS,Nuveen Real Estate Income Fund Common Shares of Beneficial Interest,$11.375,0.075,0.664%,328651858.00,United States,2001,94535,,
+add,JSD,Nuveen Short Duration Credit Opportunities Fund Common Shares of Beneficial Interest,$14.67,0.00,0.00%,147956456.00,United States,2011,29928,Finance,Finance Companies
+add,JT,Jianpu Technology Inc. American depositary shares,$2.8781,0.0181,0.633%,60962113.00,,2017,155046,Technology,EDP Services
+add,JTA,Nuveen Tax-Advantaged Total Return Strategy Fund Common Share of Beneficial Interest,$11.9267,-0.1233,-1.023%,165195493.00,United States,2004,46740,,
+add,JTD,Nuveen Tax-Advantaged Dividend Growth Fund Common Shares of Beneficial Interest,$16.6301,0.0601,0.363%,240876023.00,United States,,62807,,
+add,JW/A,John Wiley & Sons Inc.,$61.47,-3.08,-4.771%,,United States,,594549,,
+add,JW/B,John Wiley & Sons Inc.,$64.12,0.00,0.00%,,United States,,5,,
+add,JWN,Nordstrom Inc. Common Stock,$34.32,-0.69,-1.971%,5453402560.00,United States,,1613232,Consumer Services,Clothing/Shoe/Accessory Stores
+add,JWSM,Jaws Mustang Acquisition Corp. Class A Ordinary Shares,$9.87,0.02,0.203%,1276931250.00,,2021,93336,Finance,Business Services
+add,K,Kellogg Company Common Stock,$65.285,0.485,0.748%,22229303296.00,United States,,1118571,Consumer Non-Durables,Packaged Foods
+add,KAHC,KKR Acquisition Holdings I Corp. Class A Common Stock,$9.76,-0.05,-0.51%,1683600000.00,,2021,1263220,,
+add,KAI,Kadant Inc Common Stock,$171.24,0.14,0.082%,1982579047.00,United States,,29972,Technology,Industrial Machinery/Components
+add,KAMN,Kaman Corporation Common Stock,$54.76,-0.52,-0.941%,1522878667.00,United States,,58409,Capital Goods,Military/Government/Technical
+add,KAR,KAR Auction Services Inc Common Stock,$17.78,-0.25,-1.387%,2218252358.00,United States,2009,1642269,,
+add,KB,KB Financial Group Inc,$51.62,0.72,1.415%,20112924373.00,South Korea,,174906,Finance,Commercial Banks
+add,KBH,KB Home Common Stock,$43.48,-0.88,-1.984%,4295099710.00,United States,1986,2254792,,
+add,KBR,KBR Inc. Common Stock,$39.24,-0.27,-0.683%,5546424849.00,United States,2006,1366880,Capital Goods,Oilfield Services/Equipment
+add,KCAC,Kensington Capital Acquisition Corp. II Class A Common Stock,$9.95,-0.05,-0.50%,286062500.00,,2021,572312,Finance,Business Services
+add,KEN,Kenon Holdings Ltd. Ordinary Shares,$35.3915,0.8715,2.525%,1906862769.00,Singapore,2015,4653,Public Utilities,Electric Utilities: Central
+add,KEP,Korea Electric Power Corporation Common Stock,$11.625,-0.075,-0.641%,14925664790.00,South Korea,1994,113905,Public Utilities,Electric Utilities: Central
+add,KEX,Kirby Corporation Common Stock,$66.105,-1.405,-2.081%,3973241025.00,United States,,148548,Transportation,Marine Transportation
+add,KEY,KeyCorp Common Stock,$21.825,-0.435,-1.954%,21181586734.00,United States,,3632108,Finance,Major Banks
+add,KEY^I,KeyCorp Depositary Shares Each Representing a 1/40th Ownership Interest in a Share of Fixed-to-Floating Rate Perpetual Non-Cumulative Preferred Stock Series E,$31.03,-0.05,-0.161%,,United States,,52786,,
+add,KEY^J,KeyCorp Depositary Shares each representing a 1/40th ownership interest in a share of Fixed Rate Perpetual Non-Cumulative Preferred Stock Series F,$27.48,0.22,0.807%,,United States,,28148,,
+add,KEY^K,KeyCorp Depositary Shares each representing a 1/40th ownership interest in a share of Fixed Rate Perpetual Non-Cumulative Preferred Stock Series G,$28.12,0.08,0.285%,,United States,,24425,,
+add,KEYS,Keysight Technologies Inc. Common Stock,$148.72,1.75,1.191%,27398088638.00,United States,2014,274729,Capital Goods,Industrial Machinery/Components
+add,KF,Korea Fund Inc. (The) New Common Stock,$46.29,0.305,0.663%,232374689.00,United States,,4785,,
+add,KFS,Kingsway Financial Services Inc. Common Stock (DE),$5.12,0.27,5.567%,121372831.00,Canada,,367328,,
+add,KFY,Korn Ferry Common Stock,$65.94,-0.60,-0.902%,3561206348.00,United States,1999,102557,Technology,Diversified Commercial Services
+add,KGC,Kinross Gold Corporation Common Stock,$7.95,0.18,2.317%,10026540000.00,Canada,,8412274,Basic Industries,Precious Metals
+add,KIM,Kimco Realty Corporation Common Stock,$22.025,-0.135,-0.609%,9546938924.00,United States,,2002465,Consumer Services,Real Estate Investment Trusts
+add,KIM^L,Kimco Realty Corporation Class L Depositary Shares each of which represents a one-one thousandth fractional interest in a share of 5.125% Class L Cumulative Redeemable Preferred Stock liquidation preference $25000.00 per share,$26.05,0.00,0.00%,,United States,,4650,,
+add,KIM^M,Kimco Realty Corporation Class M Depositary Shares each of which represents a one-one thousandth fractional interest in a share of 5.25% Class M Cumulative Redeemable Preferred Stock liquidation preference $25000.00 per share,$26.26,0.00,0.00%,,United States,,7891,,
+add,KIO,KKR Income Opportunities Fund Common Shares,$16.46,-0.05,-0.303%,334801585.00,,2013,45635,,
+add,KKR,KKR & Co. Inc. Common Stock,$56.135,0.855,1.547%,32658149851.00,United States,,2298644,Finance,Investment Managers
+add,KKR^A,KKR & Co. Inc. 6.75% Series A Preferred Stock,$24.99,-0.03,-0.12%,,United States,,8681,,
+add,KKR^B,KKR & Co. Inc. 6.50% Series B Preferred Stock,$25.386,0.036,0.142%,,United States,,6328,,
+add,KKR^C,KKR & Co. Inc. 6.00% Series C Mandatory Convertible Preferred Stock,$74.9327,0.8427,1.137%,,United States,,8609,,
+add,KKRS,KKR Group Finance Co. IX LLC 4.625% Subordinated Notes due 2061,$25.95,-0.04,-0.154%,0.00,,2021,26878,,
+add,KL,Kirkland Lake Gold Ltd. Common Shares,$43.765,0.935,2.183%,11688881981.00,,,858697,,
+add,KMB,Kimberly-Clark Corporation Common Stock,$129.475,0.175,0.135%,43688954856.00,United States,,1093194,Basic Industries,Paper
+add,KMF,Kayne Anderson NextGen Energy & Infrastructure Inc.,$7.60,0.13,1.74%,358700711.00,,2010,143562,,
+add,KMI,Kinder Morgan Inc. Common Stock,$19.02,0.19,1.009%,43072360729.00,United States,2011,13793657,Public Utilities,Natural Gas Distribution
+add,KMPR,Kemper Corporation,$72.13,0.75,1.051%,4657182078.00,United States,,127023,Finance,Life Insurance
+add,KMT,Kennametal Inc. Common Stock,$36.56,-0.53,-1.429%,3056366607.00,United States,,336607,Capital Goods,Industrial Machinery/Components
+add,KMX,CarMax Inc,$115.15,0.15,0.13%,18786853310.00,United States,,711517,Consumer Services,Other Specialty Stores
+add,KN,Knowles Corporation Common Stock,$20.005,-0.035,-0.175%,1856332967.00,,2014,387782,Consumer Non-Durables,Consumer Electronics/Appliances
+add,KNL,Knoll Inc. Common Stock,$26.955,-0.115,-0.425%,1369655789.00,United States,2004,342961,,
+add,KNOP,KNOT Offshore Partners LP Common Units representing Limited Partner Interests,$19.02,0.03,0.158%,621841668.00,United Kingdom,2013,171111,Transportation,Marine Transportation
+add,KNX,Knight-Swift Transportation Holdings Inc.,$46.23,-1.26,-2.653%,7651557719.00,United States,2017,1100755,Transportation,Trucking Freight/Courier Services
+add,KO,Coca-Cola Company (The) Common Stock,$55.955,0.475,0.856%,241229218942.00,United States,,6836465,Consumer Non-Durables,Beverages (Production/Distribution)
+add,KODK,Eastman Kodak Company Common New,$9.15,-0.62,-6.346%,718306805.00,United States,,6362901,Miscellaneous,Business Services
+add,KOF,Coca Cola Femsa S.A.B. de C.V.  American Depositary Shares each representing 10 Units (each Unit consists of 3 Series B Shares and 5 Series L Shares),$51.41,0.25,0.489%,10800378649.00,Mexico,1993,196756,Consumer Non-Durables,Beverages (Production/Distribution)
+add,KOP,Koppers Holdings Inc. Koppers Holdings Inc. Common Stock,$33.33,-0.25,-0.744%,707957897.00,United States,2006,52770,Basic Industries,Industrial Specialties
+add,KOS,Kosmos Energy Ltd. Common Shares (DE),$3.305,0.025,0.762%,1348599681.00,Bermuda,2011,3810805,Energy,Oil & Gas Production
+add,KR,Kroger Company (The) Common Stock,$38.825,0.545,1.424%,29394441200.00,United States,,5194358,Consumer Services,Food Chains
+add,KRA,Kraton Corporation Common Stock,$33.89,-0.81,-2.334%,1089361753.00,United States,2009,110203,Basic Industries,Major Chemicals
+add,KRC,Kilroy Realty Corporation Common Stock,$73.23,0.62,0.854%,8527660595.00,United States,1997,506832,Consumer Services,Real Estate Investment Trusts
+add,KREF,KKR Real Estate Finance Trust Inc. Common Stock,$22.31,-0.33,-1.458%,1241272179.00,United States,2017,334156,Consumer Services,Real Estate Investment Trusts
+add,KREF^A,KKR Real Estate Finance Trust Inc. 6.50% Series A Cumulative Redeemable Preferred Stock,$26.0799,0.0999,0.385%,,United States,,33182,,
+add,KRG,Kite Realty Group Trust Common Stock,$22.965,-0.055,-0.239%,1940209048.00,United States,2004,288003,Consumer Services,Real Estate Investment Trusts
+add,KRO,Kronos Worldwide Inc Common Stock,$15.335,-0.195,-1.256%,1771847565.00,United States,,77948,Basic Industries,Major Chemicals
+add,KRP,Kimbell Royalty Partners Common Units Representing Limited Partner Interests,$12.96,0.05,0.387%,778664768.00,United States,2017,163181,Energy,Oil & Gas Production
+add,KSM,DWS Strategic Municipal Income Trust,$12.38,0.0272,0.22%,138704790.00,United States,1989,20880,,
+add,KSS,Kohl's Corporation Common Stock,$54.00,-0.44,-0.808%,8436584646.00,United States,1992,2147743,Consumer Services,Department/Specialty Retail Stores
+add,KSU,Kansas City Southern Common Stock,$294.875,-1.195,-0.404%,26814190379.00,United States,,373171,Transportation,Railroads
+add,KSU^,Kansas City Southern Preferred Stock,$37.2924,0.0924,0.248%,,United States,,46,,
+add,KT,KT Corporation Common Stock,$14.75,-0.16,-1.073%,7015057048.00,South Korea,,312623,Public Utilities,Telecommunications Equipment
+add,KTB,Kontoor Brands Inc. Common Stock ,$61.78,-0.79,-1.263%,3560473761.00,,2019,287026,,
+add,KTF,DWS Municipal Income Trust,$12.1951,0.0251,0.206%,481717889.00,United States,1988,28516,,
+add,KTH,Structures Products Cp 8% CorTS Issued by Peco Energy Cap Tr II Preferred Stock,$33.2356,0.00,0.00%,0.00,United States,,26,Finance,Investment Managers
+add,KTN,Structured Products Corp 8.205% CorTS 8.205% Corporate Backed Trust Securities (CorTS),$33.4779,0.0718,0.215%,0.00,United States,,1279,,
+add,KUKE,Kuke Music Holding Limited American Depositary Shares each representing one Ordinary Share,$5.77,-0.132,-2.237%,170599992.00,,2021,45908,Consumer Services,Other Consumer Services
+add,KW,Kennedy-Wilson Holdings Inc. Common Stock,$20.55,0.03,0.146%,2892820664.00,United States,,183446,Consumer Services,Real Estate
+add,KWAC,Kingswood Acquisition Corp. Class A Common Stock,$10.01,0.00,0.00%,144934790.00,,2021,62641,,
+add,KWR,Quaker Chemical Corporation Common Stock,$240.40,0.25,0.104%,4296748772.00,United States,,23895,Basic Industries,Automotive Aftermarket
+add,KYN,Kayne Anderson Energy Infrastructure Fund Inc.,$9.0157,0.1657,1.872%,1140013213.00,United States,2004,483688,,
+add,L,Loews Corporation Common Stock,$55.95,-0.50,-0.886%,14724674316.00,United States,,401253,Finance,Property-Casualty Insurers
+add,LAC,Lithium Americas Corp. Common Shares,$15.15,-0.26,-1.687%,1815938994.00,Canada,,1441058,,
+add,LAD,Lithia Motors Inc. Common Stock,$327.93,-0.36,-0.11%,9976538638.00,United States,,318886,Consumer Services,Other Specialty Stores
+add,LADR,Ladder Capital Corp Class A Common Stock,$12.245,-0.375,-2.971%,1547058941.00,,2014,871940,Consumer Services,Real Estate Investment Trusts
+add,LAIX,LAIX Inc. American Depositary Shares each  representing one Class A Ordinary Share,$1.8299,0.0099,0.544%,91091212.00,,2018,413161,Miscellaneous,Service to the Health Industry
+add,LAZ,Lazard LTD. Lazard LTD. Class A Common Stock,$46.21,-0.76,-1.618%,4868685369.00,Bermuda,2005,541197,Finance,Investment Managers
+add,LB,L Brands Inc.,$65.70,0.24,0.367%,18187159804.00,United States,,2579277,Consumer Services,Clothing/Shoe/Accessory Stores
+add,LBRT,Liberty Oilfield Services Inc. Class A Common Stock,$15.335,0.205,1.355%,2762921089.00,United States,2018,1922283,Energy,Oilfield Services/Equipment
+add,LC,LendingClub Corporation Common Stock,$16.12,-0.22,-1.346%,1567317391.00,United States,2014,1102697,Finance,Finance Companies
+add,LCI,Lannett Co Inc Common Stock,$5.12,-0.12,-2.29%,212203587.00,United States,,1343350,Health Care,Major Pharmaceuticals
+add,LCII,LCI Industries,$138.50,-3.72,-2.616%,3497740633.00,United States,,126814,Capital Goods,Auto Parts:O.E.M.
+add,LDI,loanDepot Inc. Class A Common Stock,$13.8263,-1.2437,-8.253%,4256466026.00,,2021,879812,Finance,Finance: Consumer Services
+add,LDL,Lydall Inc. Common Stock,$35.87,-0.79,-2.155%,646341351.00,United States,,44594,Technology,Industrial Machinery/Components
+add,LDOS,Leidos Holdings Inc. Common Stock,$106.63,1.70,1.62%,15079631554.00,United States,,241804,Technology,EDP Services
+add,LDP,Cohen & Steers Limited Duration Preferred and Income Fund Inc.,$26.60,-0.25,-0.931%,769375501.00,United States,2012,49576,,
+add,LEA,Lear Corporation Common Stock,$189.73,-4.71,-2.422%,11409706873.00,United States,,164162,Capital Goods,Auto Parts:O.E.M.
+add,LEAF,Leaf Group Ltd. Common Stock,$8.485,0.065,0.772%,305732326.00,United States,,3515985,Technology,EDP Services
+add,LEAP,Ribbit LEAP Ltd. Class A Ordinary Shares,$10.47,-0.05,-0.475%,612547350.00,United States,2020,22193,Finance,Business Services
+add,LEG,Leggett & Platt Incorporated Common Stock,$53.44,-0.56,-1.037%,7119955274.00,United States,,253073,Consumer Durables,Home Furnishings
+add,LEJU,Leju Holdings Limited American Depositary Shares each representing one Ordinary share,$2.05,-0.12,-5.53%,279645838.00,,2014,289617,Finance,Real Estate
+add,LEN,Lennar Corporation Class A Common Stock,$91.145,-2.755,-2.934%,28563167117.00,United States,,2899792,Consumer Services,Building operators
+add,LEO,BNY Mellon Strategic Municipals Inc. Common Stock,$8.91,-0.04,-0.447%,554288979.00,United States,1987,80570,,
+add,LEV,The Lion Electric Company Common Shares,$20.7401,-0.5699,-2.674%,3909883230.00,,2021,1138961,Finance,Business Services
+add,LEVI,Levi Strauss & Co Class A Common Stock,$26.65,-0.11,-0.411%,10669712060.00,United States,2019,662755,Basic Industries,Industrial Specialties
+add,LFC,China Life Insurance Company Limited American Depositary Shares,$10.225,-0.085,-0.824%,57801321725.00,China,2003,379378,Finance,Life Insurance
+add,LFT,Lument Finance Trust Inc. Common Stock,$4.00,0.15,3.896%,99773532.00,United States,2013,134501,Consumer Services,Real Estate Investment Trusts
+add,LFT^A,Lument Finance Trust Inc. 7.875% Series A Cumulative Redeemable Preferred Stock,$25.33,0.00,0.00%,,United States,,864,,
+add,LGI,Lazard Global Total Return and Income Fund Common Stock,$20.925,0.125,0.601%,272227156.00,United States,2004,21747,,
+add,LGV,Longview Acquisition Corp. II Class A Common Stock,$9.84,0.00,0.00%,848700000.00,,2021,58984,,
+add,LH,Laboratory Corporation of America Holdings Common Stock,$260.36,1.17,0.451%,25437172000.00,United States,,583562,Health Care,Medical Specialities
+add,LHC,Leo Holdings Corp. II Class A Ordinary Shares,$9.76,-0.01,-0.102%,457500000.00,,2021,5825,Finance,Business Services
+add,LHX,L3Harris Technologies Inc. Common Stock,$219.78,2.27,1.044%,45051344399.00,United States,,1243023,Capital Goods,Industrial Machinery/Components
+add,LII,Lennox International Inc. Common Stock,$338.82,0.59,0.174%,12799485569.00,United States,1999,96834,Capital Goods,Industrial Machinery/Components
+add,LIII,Leo Holdings III Corp. Class A Ordinary Shares,$9.7259,0.0158,0.163%,0.00,,2021,200,,
+add,LIN,Linde plc Ordinary Share,$290.495,0.015,0.005%,151066029154.00,,2018,955854,Basic Industries,Major Chemicals
+add,LINX,Linx S.A. American Depositary Shares each representing one common share,$7.30,0.00,0.00%,1285291911.00,,2019,8943,Technology,Computer Software: Prepackaged Software
+add,LITB,LightInTheBox Holding Co. Ltd. American Depositary Shares each representing 2 ordinary shares,$2.285,-0.065,-2.766%,255407191.00,China,2013,536407,Consumer Services,Catalog/Specialty Distribution
+add,LL,Lumber Liquidators Holdings Inc Common Stock,$22.69,-0.17,-0.744%,658591726.00,United States,2007,245125,Consumer Services,RETAIL: Building Materials
+add,LLY,Eli Lilly and Company Common Stock,$233.43,7.43,3.288%,223865309860.00,United States,,4702450,Health Care,Major Pharmaceuticals
+add,LMND,Lemonade Inc. Common Stock,$101.48,-3.67,-3.49%,6231829565.00,United States,2020,1792836,Finance,Property-Casualty Insurers
+add,LMT,Lockheed Martin Corporation Common Stock,$387.60,0.80,0.207%,107727212586.00,United States,,583829,Capital Goods,Aerospace
+add,LNC,Lincoln National Corporation Common Stock,$67.105,-1.175,-1.721%,12774993318.00,United States,,900004,Finance,Life Insurance
+add,LND,Brasilagro Brazilian Agric Real Estate Co Sponsored ADR (Brazil),$6.40,0.04,0.629%,506770720.00,Brazil,,3912,Consumer Non-Durables,Farming/Seeds/Milling
+add,LNFA,L&amp;F Acquisition Corp. Class A Ordinary Shares,$9.96,0.022,0.221%,214762500.00,United States,2021,56172,Finance,Business Services
+add,LNN,Lindsay Corporation Common Stock,$163.49,-3.49,-2.09%,1783118399.00,United States,,15622,Capital Goods,Industrial Machinery/Components
+add,LOKB,Live Oak Acquisition Corp. II Class A Common Stock,$9.9716,0.0016,0.016%,315351850.00,,2021,115983,,
+add,LOKM,Live Oak Mobility Acquisition Corp. Class A Common Stock,$9.85,0.00,0.00%,311506250.00,,2021,76,,
+add,LOMA,Loma Negra Compania Industrial Argentina Sociedad Anonima ADS,$7.29,0.11,1.532%,868968000.00,Argentina,2017,175558,Capital Goods,Building Materials
+add,LOW,Lowe's Companies Inc. Common Stock,$188.88,-1.72,-0.902%,133517409077.00,United States,,3381780,Consumer Services,RETAIL: Building Materials
+add,LPG,Dorian LPG Ltd. Common Stock,$14.35,0.04,0.28%,589585090.00,,2014,114874,Transportation,Marine Transportation
+add,LPI,Laredo Petroleum Inc. Common Stock,$62.99,-3.53,-5.307%,812496861.00,United States,2011,481532,Energy,Oil & Gas Production
+add,LPL,LG Display Co Ltd AMERICAN DEPOSITORY SHARES,$10.25,0.01,0.098%,7335221850.00,South Korea,2004,299989,Capital Goods,Industrial Machinery/Components
+add,LPX,Louisiana-Pacific Corporation Common Stock,$59.95,-3.56,-5.605%,6130086234.00,United States,,2116161,,
+add,LRN,Stride Inc. Common Stock,$30.20,0.50,1.684%,1254567856.00,United States,,159267,Miscellaneous,Other Consumer Services
+add,LSI,Life Storage Inc. Common Stock,$107.2617,0.8017,0.753%,8243642682.00,United States,,159761,Consumer Services,Real Estate Investment Trusts
+add,LSPD,Lightspeed POS Inc. Subordinate Voting Shares,$70.99,0.23,0.325%,9319456669.00,,,654553,,
+add,LTC,LTC Properties Inc. Common Stock,$39.365,-0.055,-0.14%,1549588345.00,United States,,126203,Consumer Services,Real Estate Investment Trusts
+add,LTHM,Livent Corporation Common Stock,$18.91,-1.58,-7.711%,2771557160.00,United States,2018,7099942,Basic Industries,Industrial Specialties
+add,LU,Lufax Holding Ltd American Depositary Shares two of which representing one Ordinary Share,$12.045,-0.115,-0.946%,29658416990.00,China,2020,4030165,Finance,Finance: Consumer Services
+add,LUB,Luby's Inc. Common Stock,$3.7185,-0.0015,-0.04%,114524126.00,United States,,13598,Consumer Services,Restaurants
+add,LUMN,Lumen Technologies Inc. Common Stock,$15.11,-0.17,-1.113%,16701272449.00,United States,,4052060,Public Utilities,Telecommunications Equipment
+add,LUV,Southwest Airlines Company Common Stock,$57.655,-0.765,-1.309%,34095816489.00,United States,,3525367,Transportation,Air Freight/Delivery Services
+add,LVS,Las Vegas Sands Corp. Common Stock,$55.42,0.33,0.599%,42338920792.00,United States,2004,5993059,Consumer Services,Hotels/Resorts
+add,LW,Lamb Weston Holdings Inc. Common Stock ,$82.11,-0.39,-0.473%,12011251066.00,,2016,836686,Consumer Non-Durables,Specialty Foods
+add,LXP,Lexington Realty Trust Common Stock,$13.02,0.09,0.696%,3823041416.00,United States,,754160,,
+add,LXP^C,Lexington Realty Trust  Preferred Conv. Series C,$60.00,-0.29,-0.481%,,United States,,2856,,
+add,LXU,LSB Industries Inc. Common Stock,$6.91,-0.29,-4.028%,207560846.00,United States,,119462,Basic Industries,Industrial Specialties
+add,LYB,LyondellBasell Industries NV Ordinary Shares Class A (Netherlands),$110.45,-1.60,-1.428%,36929395103.00,Netherlands,,602145,Basic Industries,Industrial Specialties
+add,LYG,Lloyds Banking Group Plc American Depositary Shares,$2.69,-0.01,-0.37%,47722189002.00,United Kingdom,,3056347,Finance,Commercial Banks
+add,LYV,Live Nation Entertainment Inc. Common Stock,$87.04,-1.13,-1.282%,19034188600.00,United States,,1674143,Consumer Services,Movies/Entertainment
+add,LZB,La-Z-Boy Incorporated Common Stock,$42.46,0.30,0.712%,1965757585.00,United States,,169121,Consumer Durables,Home Furnishings
+add,M,Macy's Inc Common Stock,$18.985,-0.615,-3.138%,5920822125.00,United States,,10762969,Consumer Services,Department/Specialty Retail Stores
+add,MA,Mastercard Incorporated Common Stock,$363.95,0.62,0.171%,360691732530.00,United States,2006,2005329,Miscellaneous,Business Services
+add,MAA,Mid-America Apartment Communities Inc. Common Stock,$171.56,2.87,1.701%,19641352663.00,United States,1994,298435,Consumer Services,Real Estate Investment Trusts
+add,MAA^I,Mid-America Apartment Communities Inc. 8.50% Series I Cumulative Redeemable Preferred Stock,$68.00,0.00,0.00%,,United States,,2,,
+add,MAC,Macerich Company (The) Common Stock,$17.37,-0.64,-3.554%,3587221759.00,United States,1994,3560639,Consumer Services,Real Estate Investment Trusts
+add,MACC,Mission Advancement Corp. Class A Common Stock,$9.78,0.01,0.102%,421762500.00,,2021,52496,,
+add,MAIN,Main Street Capital Corporation Common Stock,$41.63,-0.17,-0.407%,2840278895.00,United States,2007,169789,Finance,Finance/Investors Services
+add,MAN,ManpowerGroup Common Stock,$123.28,0.12,0.097%,6721931008.00,United States,,181523,Technology,Professional Services
+add,MANU,Manchester United Ltd. Class A Ordinary Shares,$15.67,0.02,0.128%,2553257154.00,United Kingdom,2012,155250,Consumer Services,Movies/Entertainment
+add,MAS,Masco Corporation Common Stock,$58.515,0.105,0.18%,14850279130.00,United States,,1944413,Capital Goods,Building Products
+add,MATX,Matson Inc. Common Stock,$63.00,0.08,0.127%,2736443241.00,United States,,133691,Transportation,Marine Transportation
+add,MAV,Pioneer Municipal High Income Advantage Fund Inc.,$12.20,0.07,0.577%,291568044.00,United States,,78877,,
+add,MAX,MediaAlpha Inc. Class A Common Stock,$42.23,-0.50,-1.17%,2521223948.00,,2020,77593,Capital Goods,Industrial Machinery/Components
+add,MAXR,Maxar Technologies Inc.,$35.94,0.47,1.325%,2582727827.00,,,1093601,Capital Goods,Telecommunications Equipment
+add,MBAC,M3-Brigade Acquisition II Corp. Class A Common Stock,$9.80,0.04,0.41%,504700000.00,,2021,125,,
+add,MBI,MBIA Inc. Common Stock,$9.99,-0.21,-2.059%,542948138.00,United States,1987,247637,Finance,Property-Casualty Insurers
+add,MBT,Mobile TeleSystems PJSC,$9.50,0.11,1.171%,8203045646.00,Russia,,1946866,Public Utilities,Telecommunications Equipment
+add,MC,Moelis & Company Class A Common Stock,$54.13,0.42,0.782%,3319697523.00,,2014,255247,,
+add,MCA,Blackrock MuniYield California Quality Fund Inc. Common Stock,$15.5594,0.0494,0.319%,535332313.00,United States,1992,34997,,
+add,MCB,Metropolitan Bank Holding Corp. Common Stock,$64.25,-0.74,-1.139%,536085038.00,,2017,20207,Finance,Major Banks
+add,MCD,McDonald's Corporation Common Stock,$234.45,2.98,1.287%,174940560884.00,United States,,1711756,Consumer Services,Restaurants
+add,MCI,Barings Corporate Investors Common Stock,$15.0015,0.0015,0.01%,303956178.00,United States,,10183,,
+add,MCK,McKesson Corporation Common Stock,$195.74,5.19,2.724%,30963381860.00,United States,,888385,Health Care,Other Pharmaceuticals
+add,MCN,Madison Covered Call & Equity Strategy Fund Common Stock,$8.37,0.03,0.36%,175325754.00,United States,2004,74289,,
+add,MCO,Moody's Corporation Common Stock,$339.90,1.12,0.331%,63629280000.00,United States,,453185,Technology,Advertising
+add,MCR,MFS Charter Income Trust Common Stock,$8.7399,0.0399,0.459%,387308424.00,United States,1989,45233,,
+add,MCS,Marcus Corporation (The) Common Stock,$22.11,-0.46,-2.038%,694052755.00,United States,,133751,Consumer Services,Movies/Entertainment
+add,MCY,Mercury General Corporation Common Stock,$60.17,0.12,0.20%,3331660314.00,United States,,117678,Finance,Property-Casualty Insurers
+add,MD,Mednax Inc. Common Stock,$32.33,-0.82,-2.474%,2789379088.00,United States,,301142,Health Care,Medical Specialities
+add,MDC,M.D.C. Holdings Inc. Common Stock,$52.93,-1.44,-2.649%,3719249512.00,United States,,462116,Capital Goods,Homebuilding
+add,MDH,MDH Acquisition Corp. Class A Common Stock,$9.69,-0.06,-0.615%,334305000.00,,2021,5355,,
+add,MDLA,Medallia Inc. Common Stock,$28.27,0.43,1.545%,4483348601.00,United States,2019,824805,Technology,EDP Services
+add,MDLQ,Medley LLC 7.25% Notes due 2024,$2.33,0.17,7.87%,0.00,,2017,272817,,
+add,MDLX,Medley LLC 6.875% Senior Notes due 2026,$2.305,0.135,6.221%,0.00,,2016,179578,,
+add,MDLY,Medley Management Inc. Class A Common Stock,$7.95,2.11,36.13%,24341859.00,United States,2014,29873548,Finance,Finance/Investors Services
+add,MDP,Meredith Corporation Common Stock,$42.47,0.67,1.603%,1939108383.00,United States,,234064,Consumer Services,Newspapers/Magazines
+add,MDT,Medtronic plc. Ordinary Shares,$124.75,1.64,1.332%,167838733707.00,United States,,2760932,Health Care,Biotechnology: Electromedical & Electrotherapeutic Apparatus
+add,MDU,MDU Resources Group Inc. Common Stock (Holding Company),$33.16,-0.21,-0.629%,6671610847.00,United States,,458788,Capital Goods,Building Materials
+add,MEC,Mayville Engineering Company Inc. Common Stock,$19.12,0.81,4.424%,389923146.00,,2019,45521,Capital Goods,Metal Fabrications
+add,MED,MEDIFAST INC Common Stock,$289.335,-4.025,-1.372%,3402899026.00,United States,,84030,Health Care,Major Pharmaceuticals
+add,MEG,Montrose Environmental Group Inc. Common Stock,$49.28,-1.67,-3.278%,1284026227.00,United States,2020,48812,,
+add,MEI,Methode Electronics Inc. Common Stock,$48.45,-0.47,-0.961%,1862744456.00,United States,,66651,Capital Goods,Electrical Products
+add,MER^K,Bank of America Corporation Income Capital Obligation Notes initially due December 15 2066,$27.417,0.097,0.355%,,United States,,20041,,
+add,MET,MetLife Inc. Common Stock,$64.085,-0.595,-0.92%,56100967519.00,United States,2000,2574107,Finance,Life Insurance
+add,MET^A,MetLife Inc. Preferred Series A Floating Rate,$26.0276,-0.0024,-0.009%,,United States,,14899,,
+add,MET^E,MetLife Inc. Depositary shares each representing a 1/1000th interest in a share of the Issuera??s 5.625% Non-Cumulative Preferred Stock Series E.,$27.60,0.06,0.218%,,United States,,40574,,
+add,MET^F,MetLife Inc. Depositary Shares each representing a 1/1000th interest in a share of 4.75% Non-Cumulative Preferred Stock Series F,$26.69,-0.04,-0.15%,,United States,,110761,,
+add,MFA,MFA Financial Inc.,$4.71,-0.09,-1.875%,2078436383.00,United States,,3320163,Consumer Services,Real Estate Investment Trusts
+add,MFA^B,MFA Financial Inc. Preferred Series B,$25.07,0.0596,0.238%,,United States,,7846,,
+add,MFA^C,MFA Financial Inc. 6.50% Series C Fixed-to-Floating Rate Cumulative Redeemable Preferred Stock,$23.15,0.00,0.00%,,United States,,12530,,
+add,MFC,Manulife Financial Corporation Common Stock,$20.43,-0.20,-0.969%,39674765216.00,Canada,,3379218,Technology,Advertising
+add,MFD,Macquarie First Trust Global Common Stock,$10.04,0.02,0.20%,85816318.00,United States,2004,27559,,
+add,MFG,Mizuho Financial Group Inc. Sponosred ADR (Japan),$3.05,-0.04,-1.294%,38664241708.00,Japan,,244881,Finance,Major Banks
+add,MFGP,Micro Focus Intl PLC ADS each representing One Ord Sh,$7.035,-0.025,-0.354%,2360582839.00,,2017,332082,Technology,Computer Software: Prepackaged Software
+add,MFL,Blackrock MuniHoldings Investment Quality Fund Common Shares of Beneficial Interest,$14.61,0.00,0.00%,553663599.00,United States,1997,27454,,
+add,MFM,MFS Municipal Income Trust Common Stock,$7.1151,0.0051,0.072%,293054113.00,United States,1986,29936,,
+add,MFV,MFS Special Value Trust Common Stock,$6.7727,0.1227,1.845%,48946845.00,United States,,8864,,
+add,MG,Mistras Group Inc Common Stock,$11.05,-0.46,-3.997%,325222639.00,United States,2009,39128,Miscellaneous,Diversified Manufacture
+add,MGA,Magna International Inc. Common Stock,$98.41,-0.22,-0.223%,29671933202.00,Canada,,763123,Capital Goods,Auto Parts:O.E.M.
+add,MGF,MFS Government Markets Income Trust Common Stock,$4.42,0.00,0.00%,144031402.00,United States,1987,81298,,
+add,MGM,MGM Resorts International Common Stock,$42.795,-0.745,-1.711%,20992475538.00,United States,,4098509,Consumer Services,Hotels/Resorts
+add,MGP,MGM Growth Properties LLC Class A common shares representing limited liability company interests,$37.27,-0.21,-0.56%,9868581972.00,United States,2016,615886,Consumer Services,Real Estate Investment Trusts
+add,MGR,Affiliated Managers Group Inc. 5.875% Junior Subordinated Notes due 2059,$27.83,0.23,0.833%,0.00,United States,2019,15566,Finance,Investment Managers
+add,MGRB,Affiliated Managers Group Inc. 4.750% Junior Subordinated Notes due 2060,$26.24,0.00,0.00%,0.00,United States,2020,13609,Finance,Investment Managers
+add,MGU,Macquarie Global Infrastructure Total Return Fund Inc. Common Stock,$24.71,0.22,0.898%,307473770.00,United States,2005,25608,,
+add,MGY,Magnolia Oil & Gas Corporation Class A Common Stock,$14.765,0.175,1.199%,3575331698.00,United States,2017,718758,Energy,Oil & Gas Production
+add,MH^A,Maiden Holdings Ltd. Pref Shs Ser A (Bermuda),$13.91,-0.0517,-0.37%,,Bermuda,,1442,,
+add,MH^C,Maiden Holdings North America Ltd. 7.125% Non-Cumulative Preference Shares Series C,$13.50,0.07,0.521%,,Bermuda,,1400,,
+add,MH^D,Maiden Holdings Ltd. 6.700% Non-Cumulative Preference Shares Series D,$13.39,-0.10,-0.741%,,Bermuda,,7410,,
+add,MHD,Blackrock MuniHoldings Fund Inc. Common Stock,$16.70,-0.01,-0.06%,237302357.00,United States,1997,55190,,
+add,MHF,Western Asset Municipal High Income Fund Inc. Common Stock,$8.18,0.05,0.615%,176957400.00,United States,1988,23196,,
+add,MHI,Pioneer Municipal High Income Fund Inc.,$12.67,-0.03,-0.236%,288512992.00,United States,2003,36563,,
+add,MHK,Mohawk Industries Inc. Common Stock,$190.99,-7.41,-3.735%,13313532066.00,United States,,806716,Consumer Durables,Home Furnishings
+add,MHLA,Maiden Holdings Ltd. 6.625% Notes due 2046,$21.949,0.099,0.453%,0.00,Bermuda,2016,3908,Finance,Property-Casualty Insurers
+add,MHN,Blackrock MuniHoldings New York Quality Fund Inc. Common Stock,$14.765,0.005,0.034%,459664320.00,United States,1997,42170,,
+add,MHNC,Maiden Holdings North America Ltd. 7.75% Notes due 2043,$23.9507,0.1207,0.507%,0.00,Bermuda,2013,1182,Finance,Property-Casualty Insurers
+add,MHO,M/I Homes Inc. Common Stock,$63.72,-2.41,-3.644%,1859708344.00,United States,1993,498329,Capital Goods,Homebuilding
+add,MIC,Macquarie Infrastructure Corporation Common Stock,$38.575,0.075,0.195%,3378924354.00,United States,2004,1187402,Transportation,Aerospace
+add,MIE,Cohen & Steers MLP Income and Energy Opportunity Fund Inc. Common Stock,$4.2301,0.1201,2.922%,110371972.00,,2013,287612,,
+add,MIN,MFS Intermediate Income Trust Common Stock,$3.71,0.01,0.27%,430102259.00,United States,1988,404276,,
+add,MIT,Mason Industrial Technology Inc. Class A Common Stock,$9.66,-0.09,-0.923%,603750000.00,,2021,105643,,
+add,MITT,AG Mortgage Investment Trust Inc. Common Stock,$4.70,0.00,0.00%,218656967.00,United States,2011,2220782,,
+add,MITT^A,AG Mortgage Investment Trust Inc. 8.25% Preferred Series A,$25.3604,0.0506,0.20%,,United States,,734,,
+add,MITT^B,AG Mortgage Investment Trust Inc. Preferred Series B,$24.951,0.151,0.609%,,United States,,990,,
+add,MITT^C,AG Mortgage Investment Trust Inc. 8.00% Series C Fixed-to-Floating Rate Cumulative Redeemable Preferred Stock $0.01 par value per share,$23.9031,0.1031,0.433%,,United States,,3613,,
+add,MIXT,MiX Telematics Limited American Depositary Shares each representing 25 Ordinary Shares,$16.43,0.23,1.42%,362631952.00,South Africa,2013,56087,Technology,Computer Software: Prepackaged Software
+add,MIY,Blackrock MuniYield Michigan Quality Fund Inc. Common Stock,$15.41,0.03,0.195%,454741934.00,United States,1992,13272,,
+add,MKC,McCormick & Company Incorporated Common Stock,$88.63,0.50,0.567%,23667326408.00,United States,,562831,Consumer Non-Durables,Farming/Seeds/Milling
+add,MKL,Markel Corporation Common Stock,$1206.38,9.12,0.762%,16597563029.00,United States,1986,21693,Finance,Property-Casualty Insurers
+add,MLI,Mueller Industries Inc. Common Stock,$46.47,-0.30,-0.641%,2654715204.00,United States,,160275,Basic Industries,Metal Fabrications
+add,MLM,Martin Marietta Materials Inc. Common Stock,$351.25,-7.85,-2.186%,21907077179.00,United States,1994,227420,Capital Goods,Building Materials
+add,MLP,Maui Land & Pineapple Company Inc. Common Stock,$10.87,-0.17,-1.54%,211230166.00,United States,,28935,Finance,Real Estate
+add,MLR,Miller Industries Inc. Common Stock,$41.35,-0.25,-0.601%,471833603.00,United States,,8192,Capital Goods,Construction/Ag Equipment/Trucks
+add,MMC,Marsh & McLennan Companies Inc. Common Stock,$138.73,1.31,0.953%,70548634094.00,United States,,847179,Finance,Specialty Insurers
+add,MMD,MainStay MacKay DefinedTerm Municipal Opportunities Fund,$22.5506,0.0906,0.403%,625314450.00,United States,2012,21908,,
+add,MMI,Marcus & Millichap Inc. Common Stock,$38.72,-0.17,-0.437%,1530636835.00,,2013,48481,Finance,Real Estate
+add,MMM,3M Company Common Stock,$203.325,0.585,0.289%,117862419782.00,United States,,1289243,Health Care,Medical/Dental Instruments
+add,MMP,Magellan Midstream Partners L.P. Limited Partnership,$53.41,1.36,2.613%,11925535309.00,United States,,1036608,Energy,Oil & Gas Production
+add,MMS,Maximus Inc. Common Stock,$92.02,0.96,1.054%,5656633472.00,United States,1997,167609,Miscellaneous,Business Services
+add,MMT,MFS Multimarket Income Trust Common Stock,$6.35,0.04,0.634%,382228712.00,United States,1987,93978,,
+add,MMU,Western Asset Managed Municipals Fund Inc. Common Stock,$13.534,-0.026,-0.192%,586940495.00,United States,1992,30055,,
+add,MN,Manning & Napier Inc. Class A Common Stock,$8.00,-0.30,-3.614%,135932552.00,United States,2011,25521,Finance,Investment Managers
+add,MNP,Western Asset Municipal Partners Fund Inc. Common Stock,$15.91,0.00,0.00%,154630292.00,United States,1993,15021,,
+add,MNR,Monmouth Real Estate Investment Corporation Class A Common Stock,$19.52,0.17,0.879%,1918852307.00,United States,,139131,Consumer Services,Real Estate Investment Trusts
+add,MNR^C,Monmouth Real Estate Investment Corporation 6.125% Series C Cumulative Redeemable Preferred Stock,$25.1699,0.0121,0.048%,,United States,,16434,,
+add,MNRL,Brigham Minerals Inc. Class A Common Stock,$20.325,0.115,0.569%,1152873939.00,,2019,196000,Energy,Oil & Gas Production
+add,MNSO,MINISO Group Holding Limited American Depositary Shares each representing four Class A Ordinary Shares,$23.22,-0.15,-0.642%,7058308811.00,China,2020,554833,Consumer Services,Department/Specialty Retail Stores
+add,MO,Altria Group Inc.,$50.135,0.235,0.471%,92781734826.00,United States,,4672112,Consumer Non-Durables,Farming/Seeds/Milling
+add,MOD,Modine Manufacturing Company Common Stock,$17.08,-0.29,-1.67%,881782772.00,United States,,118476,Capital Goods,Auto Parts:O.E.M.
+add,MODN,Model N Inc. Common Stock,$34.46,0.72,2.134%,1225643024.00,United States,2013,105563,Technology,EDP Services
+add,MOGU,MOGU Inc. American Depositary Shares (each  representing 25 Class A Ordinary Shares),$1.70,-0.05,-2.857%,184394796.00,,2018,59377,Miscellaneous,Business Services
+add,MOH,Molina Healthcare Inc Common Stock,$250.465,2.115,0.852%,14627156000.00,United States,2003,215557,Health Care,Medical Specialities
+add,MOS,Mosaic Company (The) Common Stock,$34.54,-0.41,-1.173%,13117794106.00,United States,,3025156,Basic Industries,Agricultural Chemicals
+add,MOTV,Motive Capital Corp Class A Ordinary Shares,$9.77,0.04,0.411%,505597500.00,,2021,55227,Finance,Business Services
+add,MOV,Movado Group Inc. Common Stock,$30.10,-0.30,-0.987%,703726803.00,United States,,138927,Consumer Non-Durables,Consumer Specialties
+add,MP,MP Materials Corp. Common Stock,$32.88,-0.80,-2.375%,5614122331.00,,2020,2377979,,
+add,MPA,Blackrock MuniYield Pennsylvania Quality Fund Common Stock,$15.60,-0.10,-0.637%,207586829.00,United States,1992,22888,,
+add,MPC,Marathon Petroleum Corporation Common Stock,$63.67,0.06,0.094%,41554212448.00,United States,,4634690,Energy,Integrated oil Companies
+add,MPLN,MultiPlan Corporation Class A Common Stock,$8.875,0.055,0.624%,5928172805.00,,2020,1019937,Health Care,Medical Specialities
+add,MPLX,MPLX LP Common Units Representing Limited Partner Interests,$30.19,0.56,1.89%,31081421700.00,United States,2012,1367153,Energy,Oil & Gas Production
+add,MPV,Barings Participation Investors Common Stock,$13.50,0.06,0.446%,143122950.00,United States,1988,5151,Finance,Finance Companies
+add,MPW,Medical Properties Trust Inc. common stock,$21.82,0.18,0.832%,12834524000.00,United States,2005,2200160,Consumer Services,Real Estate Investment Trusts
+add,MPX,Marine Products Corporation Common Stock,$15.58,-0.28,-1.765%,529624728.00,United States,,4930,Consumer Non-Durables,Recreational Products/Toys
+add,MQT,Blackrock MuniYield Quality Fund II Inc. Common Stock,$14.53,-0.01,-0.069%,327767871.00,United States,1992,16107,,
+add,MQY,Blackrock MuniYield Quality Fund Inc. Common Stock,$16.53,-0.08,-0.482%,507897276.00,United States,1992,58673,,
+add,MRC,MRC Global Inc. Common Stock,$10.89,0.06,0.554%,898488717.00,United States,2012,196166,Capital Goods,Fluid Controls
+add,MRK,Merck & Company Inc. Common Stock (new),$76.25,2.21,2.985%,193069450255.00,United States,,12370518,Health Care,Major Pharmaceuticals
+add,MRO,Marathon Oil Corporation Common Stock,$13.515,0.155,1.16%,10651888227.00,United States,,16599850,Energy,Oil & Gas Production
+add,MS,Morgan Stanley Common Stock,$91.79,-0.88,-0.95%,170783456508.00,United States,,5043330,Finance,Investment Bankers/Brokers/Service
+add,MS^A,Morgan Stanley Dep Shs repstg 1/1000 Pfd Ser A,$25.21,-0.03,-0.119%,,United States,,60130,,
+add,MS^E,Morgan Stanley DEPOSITARY SHARES REP 1/1000TH SHARES FIXED/FLTG PREFERRED STOCK SERIES E,$29.01,0.01,0.034%,,United States,,47060,,
+add,MS^F,Morgan Stanley Dep Shs Rpstg 1/1000th Int Prd Ser F Fxd to Flag,$28.91,0.03,0.104%,,United States,,41296,,
+add,MS^I,Morgan Stanley Depository Shares Representing 1/1000th Preferred Series 1 Fixed to Floating Non (Cum),$29.38,0.19,0.651%,,United States,,49694,,
+add,MS^K,Morgan Stanley Depositary Shares each representing 1/1000th of a share of Fixed-to-Floating Rate Non-Cumulative Preferred Stock  Series K,$29.93,0.10,0.335%,,United States,,44620,,
+add,MS^L,Morgan Stanley Depositary Shares each representing 1/1000th of a share of 4.875% Non-Cumulative Preferred Stock Series L,$27.35,0.02,0.073%,,United States,,17799,,
+add,MSA,MSA Safety Incorporated Common Stock,$166.50,-0.52,-0.311%,6521357948.00,United States,,44021,Miscellaneous,Diversified Manufacture
+add,MSB,Mesabi Trust Common Stock,$37.51,0.19,0.509%,492131575.00,United States,,27487,Basic Industries,Steel/Iron Ore
+add,MSC,Studio City International Holdings Limited American depositary shares each representing four  Class A ordinary shares,$11.25,0.15,1.351%,1245556294.00,,2018,342,Consumer Services,Hotels/Resorts
+add,MSCI,MSCI Inc Common Stock,$476.93,11.10,2.383%,39309833034.00,United States,,320142,Technology,Advertising
+add,MSD,Morgan Stanley Emerging Markets Debt Fund Inc. Common Stock,$9.41,-0.02,-0.212%,191839035.00,United States,1993,26339,,
+add,MSGE,Madison Square Garden Entertainment Corp. Class A Common Stock ,$89.31,-0.46,-0.512%,2156643680.00,,2020,139716,Consumer Services,Services-Misc. Amusement & Recreation
+add,MSGN,MSG Networks Inc. Common Stock,$15.43,-0.13,-0.835%,880257352.00,United States,,130587,Consumer Services,Television Services
+add,MSGS,Madison Square Garden Sports Corp. Class A Common Stock (New),$177.51,0.80,0.453%,4280942991.00,United States,2015,83845,Consumer Services,Hotels/Resorts
+add,MSI,Motorola Solutions Inc. Common Stock,$212.43,3.31,1.583%,36042506325.00,United States,,280145,Technology,Radio And Television Broadcasting And Communications Equipment
+add,MSM,MSC Industrial Direct Company Inc. Common Stock,$91.67,0.13,0.142%,5129022303.00,United States,1995,90111,Capital Goods,Industrial Machinery/Components
+add,MSP,Datto Holding Corp. Common Stock,$26.74,-0.14,-0.521%,4312512833.00,United States,2020,527447,Technology,Computer Software: Prepackaged Software
+add,MT,Arcelor Mittal NY Registry Shares NEW,$32.635,0.235,0.725%,34499050956.00,Luxembourg,,5108390,Basic Industries,Steel/Iron Ore
+add,MTB,M&T Bank Corporation Common Stock,$154.34,-3.32,-2.106%,19856412367.00,United States,,841936,Finance,Major Banks
+add,MTCN,ArcelorMittal 5.50% Mandatorily Convertible Subordinated Notes due 2023,$77.03,1.08,1.422%,0.00,Luxembourg,2020,416281,Basic Industries,Steel/Iron Ore
+add,MTD,Mettler-Toledo International Inc. Common Stock,$1297.44,28.35,2.234%,30190677582.00,Switzerland,1997,94404,Health Care,Medical Specialities
+add,MTDR,Matador Resources Company Common Stock,$33.14,-0.33,-0.986%,3870154917.00,United States,2012,973042,Energy,Oil & Gas Production
+add,MTG,MGIC Investment Corporation Common Stock,$14.3966,-0.2434,-1.663%,4884991356.00,United States,1991,1075582,Finance,Property-Casualty Insurers
+add,MTH,Meritage Homes Corporation Common Stock,$97.30,-4.12,-4.062%,3682499089.00,United States,,489828,Capital Goods,Homebuilding
+add,MTL,Mechel PAO American Depositary Shares (Each rep. 1 common shares),$2.355,0.145,6.561%,640010155.00,Russia,2004,995770,Basic Industries,Steel/Iron Ore
+add,MTL^,Mechel PAO American Depositary Shares (each representing one-half of a Preferred Share),$0.7677,0.0077,1.013%,,Russia,,227492,,
+add,MTN,Vail Resorts Inc. Common Stock,$320.03,0.09,0.028%,12897931308.00,United States,1997,178201,Consumer Services,Movies/Entertainment
+add,MTOR,Meritor Inc. Common Stock,$25.98,-0.72,-2.697%,1885681841.00,United States,,169400,Capital Goods,Auto Parts:O.E.M.
+add,MTR,Mesa Royalty Trust Common Stock,$5.98,0.03,0.504%,11144268.00,United States,,4234,Energy,Oil & Gas Production
+add,MTRN,Materion Corporation,$77.745,0.005,0.006%,1587063495.00,United States,,52588,,
+add,MTW,Manitowoc Company Inc. (The) Common Stock,$24.75,-1.37,-5.245%,859690557.00,United States,,205497,Capital Goods,Construction/Ag Equipment/Trucks
+add,MTX,Minerals Technologies Inc. Common Stock,$82.72,-1.12,-1.336%,2790138403.00,United States,1992,53262,Basic Industries,Major Chemicals
+add,MTZ,MasTec Inc. Common Stock,$117.765,-2.905,-2.407%,8751275191.00,United States,,546177,Basic Industries,Water Supply
+add,MUA,Blackrock MuniAssets Fund Inc Common Stock,$16.68,-0.12,-0.714%,610105411.00,United States,1993,32767,,
+add,MUC,Blackrock MuniHoldings California Quality Fund Inc.  Common Stock,$15.82,-0.01,-0.063%,648659281.00,United States,1998,45437,,
+add,MUE,Blackrock MuniHoldings Quality Fund II Inc. Common Stock,$13.79,0.02,0.145%,310561267.00,United States,,44466,,
+add,MUFG,Mitsubishi UFJ Financial Group Inc. Common Stock,$5.70,-0.02,-0.35%,73378780129.00,Japan,,788479,Finance,Commercial Banks
+add,MUI,Blackrock Muni Intermediate Duration Fund Inc Common Stock,$15.66,0.01,0.064%,599719526.00,United States,2003,43942,,
+add,MUJ,Blackrock MuniHoldings New Jersey Quality Fund Inc. Common Stock,$15.98,0.10,0.63%,480792961.00,United States,1998,35476,,
+add,MUR,Murphy Oil Corporation Common Stock,$23.685,0.215,0.916%,3656959547.00,United States,,1580313,Energy,Oil & Gas Production
+add,MUSA,Murphy USA Inc. Common Stock,$135.28,-1.31,-0.959%,3642314434.00,United States,2013,85550,Public Utilities,Natural Gas Distribution
+add,MUX,McEwen Mining Inc. Common Stock,$1.625,0.145,9.797%,746179510.00,Canada,,10316413,Basic Industries,Precious Metals
+add,MVF,Blackrock MuniVest Fund Inc. Common Stock,$9.66,0.01,0.104%,626319344.00,United States,,80554,,
+add,MVO,MV Oil Trust Units of Beneficial Interests,$6.8241,-0.0359,-0.523%,78477150.00,United States,2007,27882,Energy,Oil & Gas Production
+add,MVT,Blackrock MuniVest Fund II Inc.  Common Stock,$15.79,0.045,0.286%,336956626.00,United States,1993,5745,,
+add,MWA,MUELLER WATER PRODUCTS Common Stock,$14.40,-0.09,-0.621%,2282771174.00,United States,2006,227068,Capital Goods,Office Equipment/Supplies/Services
+add,MX,Magnachip Semiconductor Corporation Common Stock,$23.045,0.035,0.152%,1063082581.00,Luxembourg,2011,110722,Technology,Semiconductors
+add,MXE,Mexico Equity and Income Fund Inc. (The) Common Stock,$12.11,-0.14,-1.143%,21634067.00,United States,,920,,
+add,MXF,Mexico Fund Inc. (The) Common Stock,$15.624,0.014,0.09%,234441620.00,United States,,10231,,
+add,MXL,MaxLinear Inc. Common Stock,$38.44,0.70,1.855%,2897530781.00,United States,2010,175682,Technology,Semiconductors
+add,MYC,Blackrock MuniYield California Fund Inc. Common Stock,$15.51,0.15,0.977%,332216352.00,United States,1992,25035,,
+add,MYD,Blackrock MuniYield Fund Inc.  Common Stock,$15.07,-0.02,-0.133%,707079804.00,United States,1991,33723,,
+add,MYE,Myers Industries Inc. Common Stock,$21.23,0.03,0.142%,766113741.00,United States,,56364,Capital Goods,Auto Parts:O.E.M.
+add,MYI,Blackrock MuniYield Quality Fund III Inc Common Stock,$14.84,0.04,0.27%,1011356106.00,United States,,112596,,
+add,MYJ,Blackrock MuniYield New Jersey Fund Inc Common Stock,$16.20,-0.01,-0.062%,390815555.00,United States,1992,19313,,
+add,MYN,Blackrock MuniYield New York Quality Fund Inc.Common Stock,$14.06,0.08,0.572%,556587371.00,United States,1992,62729,,
+add,MYOV,Myovant Sciences Ltd. Common Shares,$23.93,0.17,0.715%,2189123053.00,United States,2016,537784,Health Care,Major Pharmaceuticals
+add,MYTE,MYT Netherlands Parent B.V. American Depositary Shares each representing one Ordinary Share,$30.605,-0.405,-1.306%,2625396458.00,,2021,119105,Consumer Services,Catalog/Specialty Distribution
+add,NAC,Nuveen California Quality Municipal Income Fund,$15.66,-0.07,-0.445%,2266551024.00,United States,1999,134600,,
+add,NAD,Nuveen Quality Municipal Income Fund Common Stock,$15.9277,0.0177,0.111%,3371082462.00,United States,1999,294387,,
+add,NAN,Nuveen New York Quality Municipal Income Fund Common Stock,$14.99,-0.09,-0.597%,462461467.00,United States,1999,20992,,
+add,NAPA,The Duckhorn Portfolio Inc. Common Stock,$22.50,1.15,5.386%,2573581590.00,,2021,496189,Consumer Non-Durables,Beverages (Production/Distribution)
+add,NAT,Nordic American Tankers Limited Common Stock,$3.545,0.085,2.457%,547475198.00,Bermuda,,1509588,Transportation,Marine Transportation
+add,NAV,Navistar International Corporation Common Stock,$44.41,0.00,0.00%,4429665991.00,United States,,261438,Capital Goods,Auto Manufacturing
+add,NAV^D,Navistar International Corporation Preferred Stock,$13.1279,0.00,0.00%,,United States,,2,,
+add,NAZ,Nuveen Arizona Quality Municipal Income Fund Common Stock,$16.03,0.008,0.05%,185539443.00,United States,1992,9926,,
+add,NBB,Nuveen Taxable Municipal Income Fund Common Shares of Beneficial Interest,$23.03,0.01,0.043%,638550323.00,United States,2010,44059,,
+add,NBHC,National Bank Holdings Corporation Common Stock,$39.64,-0.16,-0.402%,1220507196.00,United States,2012,151461,Finance,Major Banks
+add,NBR,Nabors Industries Ltd.,$110.94,-0.85,-0.76%,822346633.00,Bermuda,,52139,Energy,Oil & Gas Production
+add,NBXG,Neuberger Berman Next Generation Connectivity Fund Inc. Common Stock,$20.06,0.04,0.20%,0.00,,2021,79041,,
+add,NC,NACCO Industries Inc. Common Stock,$27.41,0.14,0.513%,195974428.00,United States,,7720,,
+add,NCA,Nuveen California Municipal Value Fund,$10.52,-0.01,-0.095%,295577105.00,United States,,22586,,
+add,NCLH,Norwegian Cruise Line Holdings Ltd. Ordinary Shares,$32.5299,-0.1301,-0.398%,12033884635.00,United States,,14500808,Transportation,Marine Transportation
+add,NCR,NCR Corporation Common Stock,$47.33,-0.68,-1.416%,6195497000.00,United States,,821450,Miscellaneous,Office Equipment/Supplies/Services
+add,NCV,Virtus AllianzGI Convertible & Income Fund Common Shares of Beneficial Interest,$5.90,0.04,0.683%,533204057.00,United States,2003,352567,,
+add,NCV^A,Virtus AllianzGI Convertible & Income Fund 5.625% Series A Cumulative Preferred Shares,$26.36,-0.21,-0.79%,,United States,,8492,,
+add,NCZ,Virtus AllianzGI Convertible & Income Fund II Common Shares of Beneficial Interest,$5.155,0.005,0.097%,392376686.00,United States,2003,566337,,
+add,NCZ^A,Virtus AllianzGI Convertible & Income Fund II 5.50% Series A Cumulative Preferred Shares,$26.10,-0.2667,-1.012%,,United States,,1735,,
+add,NDMO,Nuveen Dynamic Municipal Opportunities Fund Common Shares of Beneficial Interest,$16.59,-0.02,-0.12%,0.00,,2020,87792,,
+add,NDP,Tortoise Energy Independence Fund Inc. Common Stock,$20.95,-0.29,-1.365%,38673637.00,United States,2012,66485,,
+add,NE,Noble Corporation plc Ordinary Shares,$24.895,0.145,0.586%,6250735508.00,,2021,143538,,
+add,NEA,Nuveen AMT-Free Quality Municipal Income Fund Common Shares of Beneficial Interest Par Value $.01,$15.55,0.02,0.129%,4650031446.00,United States,2002,263627,,
+add,NEE,NextEra Energy Inc. Common Stock,$73.43,0.98,1.353%,144028910756.00,United States,,4854047,Public Utilities,Electric Utilities: Central
+add,NEE^K,NextEra Energy Inc. Series K Junior Subordinated Debentures due June 1 2076,$25.18,0.04,0.159%,,United States,,38753,,
+add,NEE^N,NextEra Energy Inc. Series N Junior Subordinated Debentures due March 1 2079,$28.155,0.065,0.231%,,United States,,34008,,
+add,NEE^O,NextEra Energy Inc. 4.872% Corporate Units,$56.01,0.54,0.973%,,United States,,106234,,
+add,NEE^P,NextEra Energy Inc. 5.279% Corporate Units,$48.595,0.405,0.84%,,United States,,54270,,
+add,NEE^Q,NextEra Energy Inc. 6.219% Corporate Units,$48.95,0.32,0.658%,,United States,,70285,,
+add,NEM,Newmont Corporation,$71.07,1.08,1.543%,56938579218.00,United States,,3469745,Basic Industries,Precious Metals
+add,NEP,NextEra Energy Partners LP Common Units representing limited partner interests,$74.09,1.85,2.561%,5622891032.00,United States,2014,248414,Public Utilities,Electric Utilities: Central
+add,NET,Cloudflare Inc. Class A Common Stock,$93.47,3.34,3.706%,29034212968.00,United States,2019,2963766,Technology,EDP Services
+add,NETI,Eneti Inc. Common Stock,$20.57,0.47,2.338%,231075234.00,Monaco,2013,27422,Transportation,Marine Transportation
+add,NEU,NewMarket Corp Common Stock,$336.055,-0.945,-0.28%,3672460792.00,United States,,29894,Basic Industries,Major Chemicals
+add,NEV,Nuveen Enhanced Municipal Value Fund Common Shares of Beneficial Interest,$16.39,-0.07,-0.425%,408931615.00,United States,2009,17624,,
+add,NEW,Puxin Limited American Depositary Shares each representing two Ordinary Shares,$2.17,0.02,0.93%,189795561.00,,2018,4838613,Miscellaneous,Service to the Health Industry
+add,NEWR,New Relic Inc. Common Stock,$67.25,1.33,2.018%,4290160757.00,United States,2014,183617,Technology,Computer Software: Prepackaged Software
+add,NEX,NexTier Oilfield Solutions Inc. Common Stock,$4.94,0.25,5.33%,1064705203.00,United States,2017,2052013,Energy,Oilfield Services/Equipment
+add,NEXA,Nexa Resources S.A. Common Shares,$10.52,0.04,0.382%,1393254188.00,,2017,79663,Basic Industries,Precious Metals
+add,NFG,National Fuel Gas Company Common Stock,$54.855,0.305,0.559%,5001278513.00,United States,,148006,Energy,Oil & Gas Production
+add,NFH,New Frontier Health Corporation Ordinary Shares,$11.40,0.04,0.352%,1503063712.00,,2018,187938,Health Care,Hospital/Nursing Management
+add,NFJ,Virtus Dividend Interest & Premium Strategy Fund Common Shares of Beneficial Interest,$15.02,0.16,1.077%,1423919747.00,United States,2005,236667,Finance,Finance: Consumer Services
+add,NGAB,Northern Genesis Acquisition Corp. II Common Stock,$10.08,0.07,0.699%,521640000.00,,2021,24100,,
+add,NGC,Northern Genesis Acquisition Corp. III Common Stock,$9.80,0.00,0.00%,231770000.00,,2021,3,,
+add,NGG,National Grid Transco PLC National Grid PLC (NEW) American Depositary Shares,$65.19,0.25,0.385%,46354796457.00,United Kingdom,,305073,Public Utilities,Natural Gas Distribution
+add,NGL,NGL ENERGY PARTNERS LP Common Units representing Limited Partner Interests,$2.305,0.025,1.096%,298714029.00,United States,2011,1277403,,
+add,NGL^B,NGL ENERGY PARTNERS LP 9.00% Class B Fixed-to-Floating Rate Cumulative Redeemable Perpetual Preferred Units representing limited partnership interests,$14.49,-0.15,-1.025%,,United States,,5786,,
+add,NGL^C,NGL ENERGY PARTNERS LP 9.625% Class C Fixed-to-Floating Rate Cumulative  Redeemable Perpetual Preferred Units representing  limited partner interests,$14.7907,0.0507,0.344%,,United States,,5676,,
+add,NGS,Natural Gas Services Group Inc. Common Stock,$10.78,-0.22,-2.00%,146726505.00,United States,2002,17319,Energy,Metal Fabrications
+add,NGVC,Natural Grocers by Vitamin Cottage Inc. Common Stock,$11.29,0.22,1.987%,255229304.00,United States,2012,62277,Consumer Services,Food Chains
+add,NGVT,Ingevity Corporation Common Stock ,$83.12,0.27,0.326%,3327198926.00,,2016,110679,Basic Industries,Industrial Specialties
+add,NHF,NexPoint Strategic Opportunities Fund,$13.91,0.10,0.724%,514116452.00,,,108472,,
+add,NHF^A,NexPoint Strategic Opportunities Fund 5.50% Series A Cumulative Preferred Shares,$22.40,-0.13,-0.577%,,,,7912,,
+add,NHI,National Health Investors Inc. Common Stock,$67.415,0.275,0.41%,3091018132.00,United States,,119632,Consumer Services,Real Estate Investment Trusts
+add,NI,NiSource Inc Common Stock,$25.75,0.13,0.507%,10099588935.00,United States,,2133948,Public Utilities,Power Generation
+add,NI^B,NiSource Inc Depositary Shares representing 1/1000th ownership interest in a share of 6.50% Series B Preferred Stock and 1/1000th ownership interest in a share of Series B-1 Preferred Stock,$28.10,0.00,0.00%,,United States,,11406,,
+add,NID,Nuveen Intermediate Duration Municipal Term Fund Common Shares of Beneficial Interest,$14.60,0.07,0.482%,684881036.00,United States,2012,30711,,
+add,NIE,Virtus AllianzGI Equity & Convertible Income Fund Common Shares of Beneficial Interest,$29.56,0.11,0.374%,819077005.00,United States,2007,58179,,
+add,NIM,Nuveen Select Maturities Municipal Fund Common Stock,$10.87,0.11,1.022%,135281096.00,United States,1992,34535,,
+add,NIMC,NiSource Inc Series A Corporate Units,$106.67,0.35,0.329%,0.00,United States,2021,14004,Public Utilities,Power Generation
+add,NINE,Nine Energy Service Inc. Common Stock,$2.29,-0.09,-3.782%,71810958.00,United States,2018,68884,Energy,Oilfield Services/Equipment
+add,NIO,NIO Inc. American depositary shares each  representing one Class A ordinary share,$42.74,0.00,0.00%,70030263979.00,,2018,33118711,Finance,Finance Companies
+add,NIQ,Nuveenn Intermediate Duration Quality Municipal Term Fund Common Shares of Beneficial Interest,$14.82,-0.06,-0.403%,194099674.00,,2013,10378,,
+add,NJR,NewJersey Resources Corporation Common Stock,$43.68,-0.10,-0.228%,4208124604.00,United States,,163770,Public Utilities,Oil/Gas Transmission
+add,NKE,Nike Inc. Common Stock,$131.01,-0.83,-0.63%,206991486365.00,United States,,5286931,Consumer Non-Durables,Shoe Manufacturing
+add,NKG,Nuveen Georgia Quality Municipal Income Fund ,$13.87,0.05,0.362%,144245392.00,United States,2002,19354,,
+add,NKX,Nuveen California AMT-Free Quality Municipal Income Fund,$16.06,-0.05,-0.31%,763176564.00,United States,2002,40558,,
+add,NL,NL Industries Inc. Common Stock,$7.365,-0.145,-1.931%,359330867.00,United States,,16595,Consumer Services,Diversified Commercial Services
+add,NLS,Nautilus Inc. Common Stock,$16.585,-0.805,-4.629%,509343195.00,United States,,667222,Consumer Non-Durables,Recreational Products/Toys
+add,NLSN,Nielsen N.V. Ordinary Shares,$25.58,-1.26,-4.694%,9170356611.00,Netherlands,2011,2183404,Miscellaneous,Business Services
+add,NLY,Annaly Capital Management Inc Common Stock,$9.535,-0.005,-0.052%,13334738911.00,United States,,12742025,Consumer Services,Real Estate Investment Trusts
+add,NLY^F,Annaly Capital Management Inc 6.95% Series F,$25.91,0.07,0.271%,,United States,,48691,,
+add,NLY^G,Annaly Capital Management Inc 6.50% Series G Fixed-to-Floating Rate Cumulative Redeemable Preferred Stock,$25.45,0.06,0.236%,,United States,,17147,,
+add,NLY^I,Annaly Capital Management Inc 6.750% Series I Fixed-to-Floating Rate Cumulative Redeemable Preferred Stock,$25.93,0.08,0.309%,,United States,,31572,,
+add,NM,Navios Maritime Holdings Inc. Common Stock,$8.35,-0.44,-5.006%,132740952.00,Monaco,,278384,Transportation,Marine Transportation
+add,NM^G,Navios Maritime Holdings Inc. Sponsored ADR Representing 1/100th Perpetual Preferred Series G (Marshall Islands),$11.50,0.705,6.531%,,Monaco,,505,,
+add,NM^H,Navios Maritime Holdings Inc. Sponsored ADR Representing 1/100th Perp. Preferred Series H%,$11.10,0.19,1.742%,,Monaco,,11229,,
+add,NMCO,Nuveen Municipal Credit Opportunities Fund Common Shares,$15.24,0.09,0.594%,811927459.00,,2019,220304,,
+add,NMG,Nouveau Monde Graphite Inc. Common Shares,$11.60,0.125,1.089%,429848382.00,,,26453,,
+add,NMI,Nuveen Municipal Income Fund Inc. Common Stock,$11.75,0.02,0.171%,108076982.00,United States,1988,23637,,
+add,NMK^B,Niagara Mohawk Holdings Inc. Preferred Stock,$100.70,0.50,0.499%,,United States,,1193,,
+add,NMK^C,Niagara Mohawk Holdings Inc. Preferred Stock,$105.36,-0.64,-0.604%,,United States,,516,,
+add,NMM,Navios Maritime Partners LP Common Units Representing Limited Partner Interests,$28.0901,1.2101,4.502%,641735526.00,Greece,2007,572940,Transportation,Marine Transportation
+add,NMR,Nomura Holdings Inc ADR American Depositary Shares,$5.44,0.03,0.555%,16663565561.00,Japan,,116660,Finance,Investment Bankers/Brokers/Service
+add,NMS,Nuveen Minnesota Quality Municipal Income Fund ,$16.1793,-0.0749,-0.461%,93554958.00,United States,2014,2699,,
+add,NMT,Nuveen Massachusetts Quality Municipal Income Fund Common Stock,$15.03,-0.02,-0.133%,140120948.00,United States,,1882,,
+add,NMZ,Nuveen Municipal High Income Opportunity Fund Common Stock $0.01 par value per share,$15.12,0.00,0.00%,1275619802.00,United States,2003,236150,,
+add,NNA,Navios Maritime Acquisition Corporation Common stock,$3.8402,-0.0798,-2.036%,63591719.00,Greece,,65912,Transportation,Marine Transportation
+add,NNI,Nelnet Inc. Common Stock,$74.36,-0.53,-0.708%,2864716620.00,United States,2003,26782,Finance,Finance: Consumer Services
+add,NNN,National Retail Properties Common Stock,$49.9959,0.3659,0.737%,8778303270.00,United States,,556953,Consumer Services,Real Estate Investment Trusts
+add,NNN^F,National Retail Properties Depositary Shares each representing a 1/100th interest in a share of 5.20% Series F Cumulative Redeemable Preferred Stock,$25.64,0.00,0.00%,,United States,,9814,,
+add,NNY,Nuveen New York Municipal Value Fund Common Stock,$10.01,0.03,0.301%,152504022.00,United States,1988,25738,,
+add,NOA,North American Construction Group Ltd. Common Shares (no par),$14.155,0.015,0.106%,397737127.00,Canada,2006,43646,,
+add,NOAH,Noah Holdings Limited,$43.865,-0.505,-1.138%,2679654948.00,China,2010,43435,Finance,Investment Managers
+add,NOC,Northrop Grumman Corporation Common Stock,$372.5665,-0.0335,-0.009%,59968753900.00,United States,,506502,Miscellaneous,Diversified Manufacture
+add,NOK,Nokia Corporation Sponsored American Depositary Shares,$5.4381,-0.0519,-0.945%,30612864911.00,Finland,1994,25364568,Technology,Radio And Television Broadcasting And Communications Equipment
+add,NOM,Nuveen Missouri Quality Municipal Income Fund ,$15.45,0.45,3.00%,36253997.00,United States,1993,717,,
+add,NOMD,Nomad Foods Limited Ordinary Shares,$31.225,0.155,0.499%,5515110910.00,,2016,495555,Consumer Non-Durables,Specialty Foods
+add,NOV,NOV Inc. Common Stock,$16.90,-0.29,-1.687%,6601870553.00,United States,,2672530,Energy,Metal Fabrications
+add,NOVA,Sunnova Energy International Inc. Common Stock,$31.71,1.54,5.104%,3550572822.00,United States,2019,1382142,Public Utilities,Electric Utilities: Central
+add,NOW,ServiceNow Inc. Common Stock,$488.475,23.765,5.114%,96448405450.00,United States,2012,2376793,Technology,Computer Software: Prepackaged Software
+add,NP,Neenah Inc. Common Stock,$52.08,-0.87,-1.643%,877177867.00,United States,,32689,Basic Industries,Paper
+add,NPCT,Nuveen Core Plus Impact Fund Common Shares of Beneficial Interest,$19.64,-0.07,-0.355%,0.00,,2021,58277,,
+add,NPK,National Presto Industries Inc. Common Stock,$100.95,0.91,0.91%,710283594.00,United States,,14772,Consumer Non-Durables,Military/Government/Technical
+add,NPO,EnPro Industries Inc,$97.53,-0.07,-0.072%,2008981946.00,United States,,82350,,
+add,NPTN,NeoPhotonics Corporation Common Stock,$10.675,0.065,0.613%,547944857.00,United States,2011,277666,Technology,Semiconductors
+add,NPV,Nuveen Virginia Quality Municipal Income Fund Common Stock,$16.17,0.01,0.062%,289261912.00,United States,1993,11119,,
+add,NQP,Nuveen Pennsylvania Quality Municipal Income Fund Common Stock,$14.9958,-0.0442,-0.294%,560593105.00,United States,1991,32936,,
+add,NR,Newpark Resources Inc. Common Stock,$3.75,-0.18,-4.58%,341101178.00,United States,,250663,Energy,Metal Fabrications
+add,NREF,NexPoint Real Estate Finance Inc. Common Stock,$21.52,-0.05,-0.232%,113674300.00,,2020,31653,Consumer Services,Real Estate Investment Trusts
+add,NREF^A,NexPoint Real Estate Finance Inc. 8.50% Series A Cumulative Redeemable Preferred Stock,$26.345,0.085,0.324%,,,,550,,
+add,NRG,NRG Energy Inc. Common Stock,$36.36,-0.31,-0.845%,8899254095.00,United States,,1532448,Public Utilities,Electric Utilities: Central
+add,NRGX,PIMCO Energy and Tactical Credit Opportunities Fund Common Shares of Beneficial Interest,$12.9575,0.1275,0.994%,579290356.00,,2019,91770,Finance,Finance/Investors Services
+add,NRK,Nuveen New York AMT-Free Quality Municipal Income Fund ,$14.07,0.04,0.285%,1227400727.00,United States,2002,84665,,
+add,NRP,Natural Resource Partners LP Limited Partnership,$20.36,-0.14,-0.683%,251472590.00,United States,2002,20832,Energy,Coal Mining
+add,NRT,North European Oil Royality Trust Common Stock,$6.15,0.09,1.485%,56522129.00,United States,,28692,Energy,Oil & Gas Production
+add,NRUC,National Rural Utilities Cooperative Finance Corporation 5.500% Subordinated Notes due 2064 (Subordinated Deferrable Interest Notes),$26.9399,0.0199,0.074%,0.00,,2019,65824,,
+add,NRZ,New Residential Investment Corp. Common Stock,$11.125,0.015,0.135%,5191450801.00,United States,,2147904,Consumer Services,Real Estate Investment Trusts
+add,NRZ^A,New Residential Investment Corp. 7.50% Series A Fixed-to-Floating Rate Cumulative Redeemable Preferred Stock,$25.4034,0.0484,0.191%,,United States,,13254,,
+add,NRZ^B,New Residential Investment Corp. 7.125% Series B Fixed-to-Floating Rate Cumulative Redeemable Preferred Stock,$25.09,0.01,0.04%,,United States,,11959,,
+add,NRZ^C,New Residential Investment Corp. 6.375% Series C Fixed-to-Floating Rate Cumulative Redeemable Preferred Stock,$23.99,0.09,0.377%,,United States,,49497,,
+add,NS,Nustar Energy L.P.  Common Units,$20.53,0.64,3.218%,2248575350.00,United States,,313909,,
+add,NS^A,Nustar Energy L.P. 8.50% Series A Fixed-to-Floating Rate Cumulative Redeemable Perpetual Preferred Units,$23.74,0.16,0.679%,,United States,,18896,,
+add,NS^B,Nustar Energy L.P. 7.625% Series B Fixed-to-Floating Rate Cumulative Redeemable Perpetual Preferred Units representing limited partner interests,$21.75,0.01,0.046%,,United States,,17584,,
+add,NS^C,Nustar Energy L.P. 9.00% Series C Fixed-to-Floating Rate Cumulative Redeemable Perpetual Preferred Units,$25.00,0.025,0.10%,,United States,,11124,,
+add,NSA,National Storage Affiliates Trust Common Shares of Beneficial Interest,$49.36,0.64,1.314%,3781283019.00,,2015,290591,Consumer Services,Real Estate Investment Trusts
+add,NSA^A,National Storage Affiliates Trust 6.000% Series A Cumulative Redeemable Preferred Shares of Beneficial Interest (Liquidation Preference $25.00 per share),$26.7768,-0.0007,-0.003%,,,,4892,,
+add,NSC,Norfolk Southern Corporation Common Stock,$270.41,-3.35,-1.224%,67667671244.00,United States,,850540,Transportation,Railroads
+add,NSH,NavSight Holdings Inc. Class A Common Stock,$9.96,0.02,0.201%,286350000.00,,2020,203468,,
+add,NSL,Nuveen Senior Income Fund Common Stock,$5.72,-0.04,-0.694%,220857620.00,United States,1999,194088,,
+add,NSP,Insperity Inc. Common Stock,$90.27,-0.89,-0.976%,3491191438.00,United States,,231669,Technology,Professional Services
+add,NSS,NuStar Logistics L.P. 7.625% Fixed-to-Floating Rate Subordinated Notes due 2043,$25.332,-0.008,-0.032%,0.00,United States,,27520,,
+add,NSTB,Northern Star Investment Corp. II Class A Common stock,$10.03,-0.02,-0.199%,501500000.00,,2021,381247,,
+add,NSTC,Northern Star Investment Corp. III Class A Common Stock,$9.83,0.00,0.00%,492114375.00,,2021,715,,
+add,NSTD,Northern Star Investment Corp. IV Class A Common Stock,$9.80,-0.04,-0.407%,490000000.00,,2021,17856,,
+add,NTB,Bank of N.T. Butterfield & Son Limited (The) Voting Ordinary Shares,$36.01,-0.52,-1.423%,1812087010.00,Bermuda,2016,39612,Finance,Commercial Banks
+add,NTCO,Natura &Co Holding S.A. American Depositary Shares ,$22.30,-0.03,-0.134%,15356308086.00,,2020,267882,Consumer Non-Durables,Package Goods/Cosmetics
+add,NTG,Tortoise Midstream Energy Fund Inc. Common Stock,$31.2911,0.4611,1.496%,176575396.00,,2010,14099,,
+add,NTP,Nam Tai Property Inc. Common Stock,$35.235,1.315,3.877%,1381141530.00,China,,410580,Capital Goods,Industrial Machinery/Components
+add,NTR,Nutrien Ltd. Common Shares,$64.62,-0.42,-0.646%,36846847874.00,,2004,1335998,Miscellaneous,Agricultural Chemicals
+add,NTST,NetSTREIT Corp. Common Stock,$23.67,-0.06,-0.253%,932726055.00,United States,2020,218953,Consumer Services,Real Estate Investment Trusts
+add,NTZ,Natuzzi S.p.A.,$20.15,0.17,0.851%,221057771.00,Italy,1993,8607,Consumer Durables,Home Furnishings
+add,NUE,Nucor Corporation Common Stock,$106.55,-1.03,-0.957%,31884230199.00,United States,,1780813,Basic Industries,Steel/Iron Ore
+add,NUO,Nuveen Ohio Quality Municipal Income Fund Common Stock,$16.36,-0.06,-0.365%,299665384.00,United States,1991,12035,,
+add,NUS,Nu Skin Enterprises Inc. Common Stock,$60.90,-1.54,-2.466%,3047578323.00,United States,1996,230869,Health Care,Other Pharmaceuticals
+add,NUV,Nuveen Municipal Value Fund Inc. Common Stock,$11.47,-0.01,-0.087%,2375150411.00,United States,1987,206624,,
+add,NUVB,Nuvation Bio Inc. Class A Common Stock,$13.22,0.28,2.164%,2877333727.00,United States,2020,735527,Health Care,Major Pharmaceuticals
+add,NUW,Nuveen AMT-Free Municipal Value Fund,$16.92,0.015,0.089%,262532107.00,United States,2009,24751,,
+add,NVG,Nuveen AMT-Free Municipal Credit Income Fund ,$17.68,-0.05,-0.282%,3772391218.00,United States,2002,175769,,
+add,NVGS,Navigator Holdings Ltd. Ordinary Shares (Marshall Islands),$10.745,0.095,0.892%,600576925.00,Isle of Man,2013,69164,Transportation,Marine Transportation
+add,NVO,Novo Nordisk A/S Common Stock,$84.83,1.34,1.605%,194886729113.00,Denmark,,1031203,Health Care,Biotechnology: Biological Products (No Diagnostic Substances)
+add,NVR,NVR Inc. Common Stock,$4615.40,-177.55,-3.704%,16786699032.00,United States,,32068,Capital Goods,Homebuilding
+add,NVRO,Nevro Corp. Common Stock,$156.275,2.775,1.808%,5434572518.00,United States,2014,164648,Health Care,Biotechnology: Electromedical & Electrotherapeutic Apparatus
+add,NVS,Novartis AG Common Stock,$93.39,1.16,1.258%,209668843873.00,Switzerland,,1816492,Health Care,Major Pharmaceuticals
+add,NVST,Envista Holdings Corporation Common Stock,$43.51,0.36,0.834%,6995402397.00,,2019,949017,Health Care,Medical/Dental Instruments
+add,NVT,nVent Electric plc Ordinary Shares ,$31.86,-0.61,-1.879%,5342215186.00,,2018,300467,Capital Goods,Electrical Products
+add,NVTA,Invitae Corporation Common Stock,$31.31,0.79,2.588%,6256904579.00,United States,2015,3012636,Health Care,Medical Specialities
+add,NWG,NatWest Group plc American Depositary Shares,$5.78,0.00,0.00%,32880762782.00,United Kingdom,,646955,Finance,Commercial Banks
+add,NWHM,New Home Company Inc. (The) Common Stock,$5.92,-0.01,-0.169%,106818698.00,,2014,77383,,
+add,NWN,Northwest Natural Holding Company Common Stock,$54.81,-0.09,-0.164%,1680255689.00,United States,,47141,Public Utilities,Oil/Gas Transmission
+add,NX,Quanex Building Products Corporation Common Stock,$26.28,-0.69,-2.558%,882904063.00,United States,,67190,,
+add,NXC,Nuveen California Select Tax-Free Income Portfolio Common Stock,$16.15,-0.08,-0.493%,102651080.00,United States,1992,7604,,
+add,NXJ,Nuveen New Jersey Qualified Municipal Fund ,$15.425,0.005,0.032%,639874288.00,United States,2001,44349,,
+add,NXN,Nuveen New York Select Tax-Free Income Portfolio Common Stock,$14.2159,0.0409,0.289%,55795915.00,United States,1992,1195,,
+add,NXP,Nuveen Select Tax Free Income Portfolio Common Stock,$18.0204,-0.2646,-1.447%,298952687.00,United States,1992,10567,,
+add,NXQ,Nuveen Select Tax Free Income Portfolio II Common Stock,$16.512,0.072,0.438%,292533643.00,United States,1992,29361,,
+add,NXR,Nuveen Select Tax Free Income Portfolio III Common Stock,$18.40,0.07,0.382%,240060550.00,United States,1992,29570,,
+add,NXRT,NexPoint Residential Trust Inc. Common Stock,$56.72,0.33,0.585%,1425211438.00,United States,2015,45826,Consumer Services,Real Estate Investment Trusts
+add,NXU,Novus Capital Corporation II Class A Common Stock,$9.79,0.0683,0.703%,351828125.00,,2021,48180,,
+add,NYC,New York City REIT Inc. Class A Common Stock,$11.76,0.03,0.256%,150251028.00,,2020,18646,Consumer Services,Real Estate Investment Trusts
+add,NYCB,New York Community Bancorp Inc. Common Stock,$11.705,-0.225,-1.886%,5443572364.00,United States,,3280037,Finance,Banks
+add,NYCB^A,New York Community Bancorp Inc. Depositary shares each representing a 1/40th interest in a share of Fixed-to-Floating Rate Series A Noncumulative Perpetual Preferred Stock,$28.72,0.02,0.07%,,United States,,13601,,
+add,NYCB^U,New York Community Bancorp Inc. New York Community Capital Tr V (BONUSES),$50.40,-0.183,-0.362%,,United States,,3304,,
+add,NYT,New York Times Company (The) Common Stock,$41.97,0.07,0.167%,7045124281.00,United States,,458409,Consumer Services,Newspapers/Magazines
+add,NZF,Nuveen Municipal Credit Income Fund ,$17.0699,0.0399,0.234%,2426075003.00,United States,2007,144168,,
+add,O,Realty Income Corporation Common Stock,$71.07,0.11,0.155%,26549557501.00,United States,,2498644,Consumer Services,Real Estate Investment Trusts
+add,OACB,Oaktree Acquisition Corp. II Class A Ordinary Shares,$9.9171,-0.0129,-0.13%,309909375.00,United States,2020,7386,Finance,Business Services
+add,OAK^A,Oaktree Capital Group LLC 6.625% Series A Preferred units,$27.25,0.07,0.258%,,United States,,10142,,
+add,OAK^B,Oaktree Capital Group LLC 6.550% Series B Preferred Units,$27.51,0.00,0.00%,,United States,,3670,,
+add,OC,Owens Corning Inc Common Stock New,$99.11,-3.14,-3.071%,10353236055.00,United States,,1079007,,
+add,OCA,Omnichannel Acquisition Corp. Class A Common Stock,$9.82,0.01,0.102%,253478750.00,,2021,11236,,
+add,OCFT,OneConnect Financial Technology Co. Ltd. American Depositary Shares each representing three ordinary shares,$12.61,-0.08,-0.63%,4917818703.00,China,2019,1821348,Technology,Computer Software: Programming Data Processing
+add,OCN,Ocwen Financial Corporation NEW Common Stock,$33.66,-0.54,-1.579%,293120402.00,United States,,60299,Finance,Finance: Consumer Services
+add,ODC,Oil-Dri Corporation Of America Common Stock,$35.42,-0.66,-1.829%,263164720.00,United States,,20870,Basic Industries,Industrial Specialties
+add,OEC,Orion Engineered Carbons S.A Common Shares,$19.53,-0.20,-1.014%,1181313395.00,Luxembourg,2014,118578,Basic Industries,Specialty Chemicals
+add,OFC,Corporate Office Properties Trust Common Stock,$30.17,0.39,1.31%,3388877049.00,United States,,488403,Consumer Services,Real Estate Investment Trusts
+add,OFG,OFG Bancorp Common Stock,$24.175,-0.265,-1.084%,1248378627.00,Puerto Rico,,158008,Finance,Major Banks
+add,OFG^D,OFG Bancorp 7.125% Non-Cumulative Perpetual Preferred Stock. Series D,$25.4099,0.0097,0.038%,,Puerto Rico,,1441,,
+add,OG,Onion Global Limited American Depositary Shares (each ten (10) ADSs representing one (1) Class A Ordinary Share),$5.27,-0.20,-3.656%,470341229.00,,2021,36976,Consumer Services,Catalog/Specialty Distribution
+add,OGE,OGE Energy Corp Common Stock,$34.925,0.445,1.291%,6991076286.00,United States,,891279,Public Utilities,Electric Utilities: Central
+add,OGN,Organon & Co. Common Stock ,$30.6474,2.1974,7.724%,7757787855.00,,2021,9996326,,
+add,OGS,ONE Gas Inc. Common Stock,$77.53,0.87,1.135%,4128096014.00,,2014,156989,Public Utilities,Oil/Gas Transmission
+add,OHI,Omega Healthcare Investors Inc. Common Stock,$37.65,0.28,0.749%,8861292780.00,United States,1992,946718,Consumer Services,Real Estate Investment Trusts
+add,OI,O-I Glass Inc. Common Stock,$18.79,-0.36,-1.88%,2967168378.00,United States,,656753,Consumer Durables,Containers/Packaging
+add,OIA,Invesco Municipal Income Opportunities Trust Common Stock,$8.1798,-0.0102,-0.125%,389081029.00,United States,,26981,,
+add,OII,Oceaneering International Inc. Common Stock,$16.69,-0.20,-1.184%,1664869909.00,United States,,333459,Energy,Oilfield Services/Equipment
+add,OIS,Oil States International Inc. Common Stock,$7.365,0.075,1.029%,451335265.00,United States,2001,442286,Energy,Metal Fabrications
+add,OKE,ONEOK Inc. Common Stock,$55.005,0.165,0.301%,24506739143.00,United States,,2205896,Public Utilities,Oil & Gas Production
+add,OLN,Olin Corporation Common Stock,$48.24,-0.05,-0.104%,7691496263.00,United States,,647231,Basic Industries,Specialty Chemicals
+add,OLO,Olo Inc. Class A Common Stock,$41.53,1.42,3.54%,6126232872.00,,2021,437326,Technology,Computer Software: Prepackaged Software
+add,OLP,One Liberty Properties Inc. Common Stock,$28.67,0.07,0.245%,594390827.00,United States,,42989,Consumer Services,Real Estate Investment Trusts
+add,OMC,Omnicom Group Inc. Common Stock,$83.015,-0.515,-0.617%,17854930205.00,United States,,792418,Technology,Advertising
+add,OMF,OneMain Holdings Inc. Common Stock,$58.975,-0.915,-1.528%,7930786737.00,,2013,779563,Finance,Finance: Consumer Services
+add,OMI,Owens & Minor Inc. Common Stock,$47.05,0.69,1.488%,3535705260.00,United States,,463608,Health Care,Medical Specialities
+add,ONE,OneSmart International Education Group Limited ADS,$1.48,0.02,1.37%,239078617.00,,2018,1060979,Miscellaneous,Service to the Health Industry
+add,ONTF,ON24 Inc. Common Stock,$35.42,0.82,2.37%,1642345032.00,,2021,623720,Technology,Computer Software: Prepackaged Software
+add,ONTO,Onto Innovation Inc. Common Stock,$73.50,0.87,1.198%,3604414496.00,United States,,133100,Technology,Semiconductors
+add,OOMA,Ooma Inc. Common Stock,$22.49,1.40,6.638%,522008935.00,,2015,839018,Consumer Services,Telecommunications Equipment
+add,OPA,Magnum Opus Acquisition Limited Class A Ordinary Shares,$9.72,0.00,0.00%,243000000.00,,2021,7,,
+add,OPP,RiverNorth/DoubleLine Strategic Opportunity Fund Inc. Common Stock,$15.71,-0.10,-0.633%,217707028.00,United States,2016,172277,,
+add,OPP^A,RiverNorth/DoubleLine Strategic Opportunity Fund Inc. 4.375% Series A Cumulative Preferred Stock,$24.62,0.0301,0.122%,,United States,,16237,,
+add,OPY,Oppenheimer Holdings Inc. Class A Common Stock (DE),$49.54,0.99,2.039%,628449974.00,United States,,65938,Finance,Investment Bankers/Brokers/Service
+add,OR,Osisko Gold Royalties Ltd Common Shares,$14.70,0.14,0.962%,2461650196.00,,2016,388691,Basic Industries,Precious Metals
+add,ORA,Ormat Technologies Inc. Common Stock,$70.955,0.705,1.004%,3972372534.00,United States,2004,159631,Public Utilities,Electric Utilities: Central
+add,ORAN,Orange,$12.87,-0.05,-0.387%,34226139313.00,France,,1081924,Public Utilities,Telecommunications Equipment
+add,ORC,Orchid Island Capital Inc. Common Stock,$5.78,0.13,2.301%,550618741.00,United States,2013,3335171,Consumer Services,Real Estate Investment Trusts
+add,ORCC,Owl Rock Capital Corporation Common Stock,$14.68,-0.06,-0.407%,5745778233.00,,2019,1136150,Finance,Diversified Financial Services
+add,ORCL,Oracle Corporation Common Stock,$82.29,-2.23,-2.638%,237286095150.00,United States,1986,13692407,Technology,Computer Software: Prepackaged Software
+add,ORI,Old Republic International Corporation Common Stock,$26.155,-0.055,-0.21%,7970732065.00,United States,,913505,Finance,Specialty Insurers
+add,ORN,Orion Group Holdings Inc. Common,$5.85,-0.01,-0.171%,178140374.00,United States,,173326,Capital Goods,Oilfield Services/Equipment
+add,OSCR,Oscar Health Inc. Class A Common Stock,$26.21,-2.18,-7.679%,5435477607.00,,2021,487231,Finance,Accident &Health Insurance
+add,OSG,Overseas Shipholding Group Inc. Class A Common Stock,$2.20,0.01,0.457%,191100032.00,United States,2015,231583,Energy,Oil & Gas Production
+add,OSH,Oak Street Health Inc. Common Stock,$57.50,-0.41,-0.708%,13844984263.00,United States,2020,720908,Health Care,Assisted Living Services
+add,OSK,Oshkosh Corporation (Holding Company)Common Stock,$128.30,-1.05,-0.812%,8803550066.00,United States,,332183,Capital Goods,Auto Manufacturing
+add,OTIS,Otis Worldwide Corporation Common Stock ,$80.3884,-0.3616,-0.448%,34498153226.00,,2020,1296577,,
+add,OUST,Ouster Inc. Common Stock,$12.9666,0.1866,1.46%,2093447262.00,United States,2020,1150317,Capital Goods,Industrial Machinery/Components
+add,OUT,OUTFRONT Media Inc. Common Stock,$24.13,-0.70,-2.819%,3511878487.00,,2014,1240341,Consumer Services,Real Estate Investment Trusts
+add,OVV,Ovintiv Inc. (DE),$30.69,-0.26,-0.84%,8011434007.00,Canada,,1491933,Energy,Oil & Gas Production
+add,OWL,Blue Owl Capital Inc. Class A Common Stock,$16.13,0.43,2.739%,554468750.00,United States,2020,1389518,Finance,Investment Managers
+add,OXM,Oxford Industries Inc. Common Stock,$107.23,9.13,9.307%,1811962031.00,United States,,313328,Consumer Non-Durables,Apparel
+add,OXY,Occidental Petroleum Corporation Common Stock,$28.50,0.15,0.529%,26602432523.00,United States,,12207936,Energy,Oil & Gas Production
+add,PAC,Grupo Aeroportuario Del Pacifico S.A. B. de C.V. Grupo Aeroportuario Del Pacifico S.A. de C.V. (each representing 10 Series B shares),$114.26,3.10,2.789%,5979072692.00,Mexico,2006,108619,Transportation,Aerospace
+add,PACE,TPG Pace Tech Opportunities Corp. Class A Ordinary Shares,$10.17,0.16,1.598%,572062500.00,United States,2020,199141,Finance,Business Services
+add,PACK,Ranpak Holdings Corp Class A Common Stock,$20.68,-1.14,-5.225%,1568718128.00,,2018,197331,Basic Industries,Containers/Packaging
+add,PAG,Penske Automotive Group Inc. Common Stock,$79.28,0.26,0.329%,6407973994.00,United States,,253547,Consumer Services,Other Specialty Stores
+add,PAGS,PagSeguro Digital Ltd. Class A Common Shares,$52.23,0.76,1.477%,17184525110.00,Cayman Islands,2018,741483,Technology,EDP Services
+add,PAI,Western Asset Investment Grade Income Fund Inc.,$15.23,-0.02,-0.131%,144826563.00,United States,,26159,,
+add,PAM,Pampa Energia S.A. Pampa Energia S.A.,$17.39,-0.03,-0.172%,968348881.00,Argentina,,76740,Public Utilities,Electric Utilities: Central
+add,PANW,Palo Alto Networks Inc. Common Stock,$361.53,9.14,2.594%,35209724123.00,United States,2012,597631,Technology,EDP Services
+add,PAR,PAR Technology Corporation Common Stock,$63.93,-2.18,-3.298%,1660846292.00,United States,,178065,Technology,Computer Software: Prepackaged Software
+add,PARR,Par Pacific Holdings Inc.  Common Stock,$15.77,0.06,0.382%,949098337.00,United States,,170829,Energy,Integrated oil Companies
+add,PATH,UiPath Inc. Class A Common Stock,$73.37,4.66,6.782%,38090309243.00,,2021,11168563,Technology,Computer Software: Prepackaged Software
+add,PAY,Paymentus Holdings Inc. Class A Common Stock,$29.8992,1.6492,5.838%,3508975763.00,,2021,102247,Technology,Retail: Computer Software & Peripheral Equipment
+add,PAYC,Paycom Software Inc. Common Stock,$335.35,7.67,2.341%,20182460265.00,,2014,329138,Technology,Computer Software: Prepackaged Software
+add,PB,Prosperity Bancshares Inc. Common Stock,$75.07,-0.61,-0.806%,6976933658.00,United States,,218670,Finance,Major Banks
+add,PBA,Pembina Pipeline Corp. Ordinary Shares (Canada),$33.08,0.75,2.32%,18193305320.00,Canada,,871227,Energy,Oil & Gas Production
+add,PBC,Prospect Capital Corporation 6.875% Notes due 2029,$25.618,-0.0414,-0.161%,0.00,United States,2018,6313,Finance,Finance/Investors Services
+add,PBF,PBF Energy Inc. Class A Common Stock,$16.67,0.11,0.664%,2003417353.00,United States,2012,1840973,Energy,Integrated oil Companies
+add,PBFX,PBF Logistics LP Common Units representing limited partner interests,$15.72,0.13,0.834%,980387421.00,,2014,55379,,
+add,PBH,Prestige Consumer Healthcare Inc. Common Stock,$51.33,0.53,1.043%,2561926189.00,United States,2005,76327,Health Care,Major Pharmaceuticals
+add,PBI,Pitney Bowes Inc. Common Stock,$9.00,-0.15,-1.639%,1579437000.00,United States,,1343816,Miscellaneous,Office Equipment/Supplies/Services
+add,PBI^B,Pitney Bowes Inc 6.70% Notes Due 2043,$24.98,0.08,0.321%,,United States,,18082,,
+add,PBR,Petroleo Brasileiro S.A.- Petrobras Common Stock,$11.69,-0.02,-0.171%,76243356365.00,Brazil,,33060887,Energy,Oil & Gas Production
+add,PBT,Permian Basin Royalty Trust Common Stock,$4.55,0.04,0.887%,212070022.00,United States,,43138,Energy,Oil & Gas Production
+add,PBY,Prospect Capital Corporation 6.25% Notes due 2028,$25.051,-0.0265,-0.106%,1272273078.00,United States,2018,4074,Health Care,Major Pharmaceuticals
+add,PCF,High Income Securities Fund Common Stock,$9.795,-0.055,-0.558%,92933716.00,United States,,175634,,
+add,PCG,Pacific Gas & Electric Co. Common Stock,$10.48,0.20,1.946%,20803907767.00,United States,,7803143,Public Utilities,Power Generation
+add,PCGU,Pacific Gas & Electric Co. Equity Unit,$103.76,1.66,1.626%,0.00,United States,,5003,Public Utilities,Power Generation
+add,PCI,PIMCO Dynamic Credit and Mortgage Income Fund Common Shares of Beneficial Interest,$22.56,-0.06,-0.265%,3391160747.00,,2013,358985,,
+add,PCK,Pimco California Municipal Income Fund II Common Shares of Beneficial Interest,$9.37,-0.02,-0.213%,301217390.00,United States,2002,19822,,
+add,PCM,PCM Fund Inc. Common Stock,$11.8696,-0.0604,-0.506%,138283558.00,United States,1993,12221,,
+add,PCN,Pimco Corporate & Income Strategy Fund Common Stock,$18.7976,-0.0824,-0.436%,764633923.00,United States,2001,53040,,
+add,PCOR,Procore Technologies Inc. Common Stock,$86.31,-0.43,-0.496%,11059312344.00,,2021,317237,Technology,EDP Services
+add,PCPC,Periphas Capital Partnering Corporation Class A Common Stock,$24.66,0.05,0.203%,437803776.00,,2021,411,,
+add,PCQ,PIMCO California Municipal Income Fund Common Stock,$18.64,0.15,0.811%,351792720.00,United States,2001,14600,,
+add,PD,PagerDuty Inc. Common Stock,$39.82,0.88,2.26%,3330618706.00,,2019,987791,Technology,Retail: Computer Software & Peripheral Equipment
+add,PDAC,Peridot Acquisition Corp. Class A Ordinary Shares,$11.485,0.255,2.271%,430687500.00,United States,2020,294954,Finance,Business Services
+add,PDI,PIMCO Dynamic Income Fund Common Stock,$29.30,-0.18,-0.611%,2037832961.00,United States,2012,231598,,
+add,PDM,Piedmont Office Realty Trust Inc. Class A Common Stock,$20.21,0.14,0.698%,2506626110.00,United States,,302235,Consumer Services,Building operators
+add,PDO,PIMCO Dynamic Income Opportunities Fund Common Shares of Beneficial Interest,$21.74,-0.13,-0.594%,1512030327.00,,2021,406953,,
+add,PDOT,Peridot Acquisition Corp. II Class A Ordinary Shares,$9.78,0.01,0.102%,499335944.00,,2021,6890,,
+add,PDS,Precision Drilling Corporation Common Stock,$37.27,-0.02,-0.054%,495855920.00,Canada,,50602,Energy,Oil & Gas Production
+add,PDT,John Hancock Premium Dividend Fund,$17.11,-0.17,-0.984%,833085489.00,United States,,121514,,
+add,PEAK,Healthpeak Properties Inc. Common Stock,$34.88,0.27,0.78%,18798010212.00,United States,,1123322,Consumer Services,Real Estate Investment Trusts
+add,PEB,Pebblebrook Hotel Trust Common Shares of Beneficial Interest,$23.905,-0.185,-0.768%,3140764592.00,United States,2009,560385,Consumer Services,Real Estate Investment Trusts
+add,PEB^C,Pebblebrook Hotel Trust 6.50% Series C Cumulative Redeemable Preferred Shares of Beneficial Interest,$25.3375,0.0575,0.227%,,United States,,9331,,
+add,PEB^D,Pebblebrook Hotel Trust 6.375% Series D Cumulative Redeemable Preferred Shares of Beneficial Interest,$25.349,0.129,0.511%,,United States,,859,,
+add,PEB^E,Pebblebrook Hotel Trust 6.375% Series E Cumulative Redeemable Preferred Shares of Beneficial Interest,$25.4448,0.00,0.00%,,United States,,25,,
+add,PEB^F,Pebblebrook Hotel Trust 6.3% Series F Cumulative Redeemable Preferred Shares of Beneficial Interest,$25.30,-0.1205,-0.474%,,United States,,555,,
+add,PEB^G,Pebblebrook Hotel Trust 6.375% Series G Cumulative Redeemable Preferred Shares of Beneficial Interest,$25.87,0.07,0.271%,,United States,,29456,,
+add,PEG,Public Service Enterprise Group Incorporated Common Stock,$61.765,0.635,1.039%,31220954041.00,United States,,1065217,Public Utilities,Electric Utilities: Central
+add,PEI,Pennsylvania Real Estate Investment Trust Common Stock,$2.9699,-0.2001,-6.312%,235394013.00,United States,,2158956,Consumer Services,Real Estate Investment Trusts
+add,PEI^B,Pennsylvania Real Estate Investment Trust Cumulative Redeemable Perpetual Preferred Shares Series B,$12.91,-0.44,-3.296%,,United States,,19861,,
+add,PEI^C,Pennsylvania Real Estate Investment Trust 7.20% Series C Cumulative Redeemable Perpetual Preferred Shares,$13.10,-0.14,-1.057%,,United States,,8407,,
+add,PEI^D,Pennsylvania Real Estate Investment Trust 6.875% Series D Cumulative Redeemable Perpetual Preferred Shares,$12.84,-0.41,-3.094%,,United States,,5243,,
+add,PEN,Penumbra Inc. Common Stock,$285.58,1.80,0.634%,10418631512.00,,2015,87434,Health Care,Medical/Dental Instruments
+add,PEO,Adams Natural Resources Fund Inc. Common Stock,$16.67,0.12,0.725%,401387878.00,United States,,48265,,
+add,PFD,Flaherty & Crumrine Preferred and Income Fund Incorporated,$17.155,0.065,0.38%,194322062.00,United States,1991,39219,,
+add,PFE,Pfizer Inc. Common Stock,$40.605,0.795,1.997%,227294359470.00,United States,,28705331,Health Care,Major Pharmaceuticals
+add,PFGC,Performance Food Group Company Common Stock,$52.05,0.46,0.892%,6964594128.00,United States,2015,833508,Consumer Non-Durables,Food Distributors
+add,PFH,Prudential Financial Inc. 4.125% Junior Subordinated Notes due 2060,$25.79,-0.0611,-0.236%,0.00,United States,2020,46141,,
+add,PFL,PIMCO Income Strategy Fund Shares of Beneficial Interest,$12.8511,-0.0389,-0.302%,439526460.00,United States,2003,105751,,
+add,PFN,PIMCO Income Strategy Fund II,$10.9255,-0.0245,-0.224%,837173976.00,United States,2004,202450,,
+add,PFO,Flaherty & Crumrine Preferred and Income Opportunity Fund Incorporated,$13.4477,-0.0023,-0.017%,171427689.00,United States,1992,6830,,
+add,PFS,Provident Financial Services Inc Common Stock,$24.57,-0.29,-1.167%,1915644153.00,United States,2003,106485,Finance,Savings Institutions
+add,PFSI,PennyMac Financial Services Inc. Common Stock,$61.08,-0.47,-0.764%,4076124814.00,United States,2013,319104,Finance,Finance: Consumer Services
+add,PG,Procter & Gamble Company (The) Common Stock,$135.80,1.01,0.749%,332470012339.00,United States,,4837969,Consumer Non-Durables,Package Goods/Cosmetics
+add,PGP,Pimco Global Stocksplus & Income Fund Pimco Global StocksPlus & Income Fund Common Shares of Beneficial Interest,$11.04,-0.08,-0.719%,122258517.00,United States,2005,19466,,
+add,PGR,Progressive Corporation (The) Common Stock,$94.13,-0.69,-0.728%,55075463000.00,United States,,2662520,Finance,Property-Casualty Insurers
+add,PGRE,Paramount Group Inc. Common Stock,$11.53,0.00,0.00%,2524500372.00,United States,2014,931356,Consumer Services,Real Estate Investment Trusts
+add,PGTI,PGT Innovations Inc.,$22.74,-0.19,-0.829%,1354048911.00,United States,2006,249835,Capital Goods,Building Products
+add,PGZ,Principal Real Estate Income Fund Common Shares of Beneficial Interest,$16.04,0.01,0.062%,110135805.00,,2013,38493,Finance,Investment Managers
+add,PH,Parker-Hannifin Corporation Common Stock,$303.35,-2.05,-0.671%,39149120916.00,United States,,536990,Capital Goods,Office Equipment/Supplies/Services
+add,PHD,Pioneer Floating Rate Fund Inc.,$11.57,0.01,0.087%,286220673.00,United States,2004,38215,,
+add,PHG,Koninklijke Philips N.V. NY Registry Shares,$57.015,0.395,0.698%,51138061766.00,Netherlands,,411855,Health Care,Biotechnology: Electromedical & Electrotherapeutic Apparatus
+add,PHI,PLDT Inc. Sponsored ADR,$27.69,-0.09,-0.324%,5981040000.00,Philippines,,42256,Public Utilities,Telecommunications Equipment
+add,PHK,Pimco High Income Fund Pimco High Income Fund,$6.92,-0.05,-0.717%,924504644.00,United States,2003,259203,,
+add,PHM,PulteGroup Inc. Common Stock,$54.01,-1.83,-3.277%,14202800195.00,United States,,3543581,,
+add,PHR,Phreesia Inc. Common Stock,$57.32,0.02,0.035%,2895784733.00,United States,2019,373830,Health Care,Managed Health Care
+add,PHT,Pioneer High Income Fund Inc.,$9.88,-0.07,-0.704%,288809897.00,United States,,112396,,
+add,PHX,PHX Minerals Inc. Common Stock,$3.35,-0.04,-1.18%,101843913.00,United States,,187985,Energy,Oil & Gas Production
+add,PIAI,Prime Impact Acquisition I Class A Ordinary Shares,$9.77,0.00,0.00%,331259813.00,,2020,6994,Finance,Business Services
+add,PICC,Pivotal Investment Corporation III Class A Common Stock,$9.75,0.02,0.206%,336375000.00,,2021,2953,,
+add,PII,Polaris Inc. Common Stock,$127.31,3.51,2.835%,7796728696.00,United States,,1077802,Consumer Non-Durables,Recreational Products/Toys
+add,PIM,Putnam Master Intermediate Income Trust Common Stock,$4.29,0.03,0.704%,219535199.00,United States,1988,47208,,
+add,PINE,Alpine Income Property Trust Inc. Common Stock,$18.92,0.05,0.265%,205599970.00,United States,2019,137184,Consumer Services,Real Estate Investment Trusts
+add,PING,Ping Identity Holding Corp. Common Stock,$24.925,-0.215,-0.855%,2044647077.00,United States,2019,434454,Technology,EDP Services
+add,PINS,Pinterest Inc. Class A Common Stock,$67.87,1.75,2.647%,43223753762.00,,2019,6104389,,
+add,PIPP,Pine Island Acquisition Corp. Class A Common Stock,$9.86,0.02,0.203%,269163210.00,United States,2021,39709,,
+add,PIPR,Piper Sandler Companies Common Stock,$127.22,-0.19,-0.149%,1828711804.00,United States,,19638,Finance,Investment Bankers/Brokers/Service
+add,PJT,PJT Partners Inc. Class A Common Stock,$68.75,0.52,0.762%,2833901400.00,United States,2015,76227,Finance,Investment Managers
+add,PK,Park Hotels & Resorts Inc. Common Stock ,$21.2062,-0.1538,-0.72%,5015065096.00,United States,2016,1672864,Consumer Services,Real Estate Investment Trusts
+add,PKE,Park Aerospace Corp. Common Stock,$15.28,-0.14,-0.908%,311450345.00,United States,,21554,,
+add,PKG,Packaging Corporation of America Common Stock,$142.83,-0.16,-0.112%,13568002447.00,United States,2000,300665,Basic Industries,Paper
+add,PKI,PerkinElmer Inc. Common Stock,$146.00,4.60,3.253%,16365311550.00,United States,,395740,Health Care,Medical Specialities
+add,PKO,Pimco Income Opportunity Fund Common Shares of Beneficial Interest,$26.95,-0.23,-0.846%,559739750.00,United States,,73574,,
+add,PKX,POSCO Common Stock,$75.63,0.82,1.096%,22878248041.00,South Korea,1994,133587,Basic Industries,Steel/Iron Ore
+add,PLAN,Anaplan Inc. Common Stock,$51.00,1.50,3.03%,7381332459.00,United States,2018,1478758,Technology,Computer Software: Prepackaged Software
+add,PLD,Prologis Inc. Common Stock,$125.90,2.29,1.853%,93137420700.00,United States,,1440920,Consumer Services,Real Estate Investment Trusts
+add,PLNT,Planet Fitness Inc. Common Stock,$76.10,-0.10,-0.131%,6589156778.00,United States,2015,992304,Consumer Services,Other Consumer Services
+add,PLOW,Douglas Dynamics Inc. Common Stock,$43.29,-1.61,-3.586%,993742383.00,United States,2010,89610,Capital Goods,Construction/Ag Equipment/Trucks
+add,PLTR,Palantir Technologies Inc. Class A Common Stock,$24.21,0.04,0.165%,45436028044.00,,2020,30963592,Technology,Retail: Computer Software & Peripheral Equipment
+add,PLYM,Plymouth Industrial REIT Inc. Common Stock,$20.22,0.01,0.049%,594565440.00,United States,2017,172869,Consumer Services,Real Estate Investment Trusts
+add,PM,Philip Morris International Inc Common Stock,$97.465,0.715,0.739%,151902808413.00,United States,,1842502,Consumer Non-Durables,Farming/Seeds/Milling
+add,PMF,PIMCO Municipal Income Fund Common Stock,$14.86,-0.02,-0.134%,385483260.00,United States,2001,10278,,
+add,PML,Pimco Municipal Income Fund II Common Shares of Beneficial Interest,$14.77,0.00,0.00%,930199830.00,United States,2002,111316,,
+add,PMM,Putnam Managed Municipal Income Trust Common Stock,$8.46,0.01,0.118%,413524808.00,United States,1989,53530,,
+add,PMO,Putnam Municipal Opportunities Trust Common Stock,$13.99,-0.04,-0.285%,477194507.00,United States,1993,53130,,
+add,PMT,PennyMac Mortgage Investment Trust Common Shares of Beneficial Interest,$20.603,-0.137,-0.661%,2017823825.00,United States,2009,350106,Consumer Services,Real Estate Investment Trusts
+add,PMT^A,PennyMac Mortgage Investment Trust 8.125% Series A Fixed-to-Floating Rate Cumulative Redeemable Preferred Shares of Beneficial Interest,$25.90,-0.02,-0.077%,,United States,,4960,,
+add,PMT^B,PennyMac Mortgage Investment Trust 8.00% Series B Fixed-to-Floating Rate Cumulative Redeemable Preferred Shares of Beneficial Interest,$26.394,0.064,0.243%,,United States,,3512,,
+add,PMVC,PMV Consumer Acquisition Corp. Class A Common Stock,$9.7664,-0.0036,-0.037%,213640000.00,United States,2020,179884,,
+add,PMX,PIMCO Municipal Income Fund III Common Shares of Beneficial Interest,$12.615,0.065,0.518%,418250325.00,United States,2002,34271,,
+add,PNC,PNC Financial Services Group Inc. (The) Common Stock,$189.22,-1.57,-0.823%,80391696798.00,United States,,724798,Finance,Major Banks
+add,PNC^P,PNC Financial Services Group Inc. (The) Depositary Shares Representing 1/4000th Perpetual Preferred Series P,$26.2499,-0.0001,0.00%,,United States,,148282,,
+add,PNF,PIMCO New York Municipal Income Fund Common Stock,$12.96,-0.07,-0.537%,101463840.00,United States,2001,3036,,
+add,PNI,Pimco New York Municipal Income Fund II Common Shares of Beneficial Interest,$11.95,0.15,1.271%,133708550.00,United States,2002,12822,,
+add,PNM,PNM Resources Inc. (Holding Co.) Common Stock,$49.12,0.16,0.327%,4216209011.00,United States,,266078,Public Utilities,Electric Utilities: Central
+add,PNR,Pentair plc. Ordinary Share,$67.34,-1.86,-2.688%,11192021939.00,Switzerland,,1495339,Capital Goods,Fluid Controls
+add,PNTM,Pontem Corporation Class A Ordinary Shares,$9.73,-0.01,-0.103%,839212500.00,,2021,2434,Finance,Business Services
+add,PNW,Pinnacle West Capital Corporation Common Stock,$88.31,1.15,1.319%,9957037454.00,United States,,241661,Public Utilities,Electric Utilities: Central
+add,POLY,Plantronics Inc. Common Stock,$37.70,0.55,1.48%,1577325248.00,United States,,201443,Public Utilities,Telecommunications Equipment
+add,POR,Portland General Electric Co Common Stock,$49.945,0.335,0.675%,4475359583.00,United States,,311155,Public Utilities,Electric Utilities: Central
+add,POST,Post Holdings Inc. Common Stock,$114.23,0.52,0.457%,7268435138.00,United States,2012,123364,Consumer Non-Durables,Specialty Foods
+add,PPG,PPG Industries Inc. Common Stock,$177.42,0.31,0.175%,42064716978.00,United States,,546235,Basic Industries,Paints/Coatings
+add,PPL,PPL Corporation Common Stock,$29.185,0.195,0.673%,22455752649.00,United States,,4608792,Public Utilities,Electric Utilities: Central
+add,PPT,Putnam Premier Income Trust Common Stock,$4.75,0.05,1.064%,485507679.00,United States,1988,301785,,
+add,PPX,PPL Capital Funding Inc. 2013 Series B Junior Subordinated Notes due 2073,$26.08,-0.02,-0.077%,0.00,,,12322,Public Utilities,Electric Utilities: Central
+add,PQG,PQ Group Holdings Inc. Common Stock,$15.71,-0.21,-1.319%,2151083235.00,United States,2017,154233,Basic Industries,Major Chemicals
+add,PRA,ProAssurance Corporation Common Stock,$24.32,0.00,0.00%,1312146664.00,United States,,68637,Finance,Property-Casualty Insurers
+add,PRE^J,PartnerRe Ltd. 4.875% Fixed Rate Non-Cumulative Redeemable Preferred Shares Series J,$27.37,0.06,0.22%,,Bermuda,,21515,,
+add,PRG,PROG Holdings Inc. Common Stock,$54.8775,-1.0825,-1.934%,3716266325.00,United States,,225500,Technology,Diversified Commercial Services
+add,PRGO,Perrigo Company plc Ordinary Shares,$48.955,1.885,4.005%,6537894428.00,United States,,861856,Health Care,Major Pharmaceuticals
+add,PRI,Primerica Inc. Common Stock,$160.91,-2.14,-1.312%,6345962305.00,United States,2010,95367,Finance,Life Insurance
+add,PRIF^A,Priority Income Fund Inc. 6.375% Series A Term Preferred Stock due 2025,$25.30,0.00,0.00%,,,,91,,
+add,PRIF^C,Priority Income Fund Inc. 6.625% Series C Term Preferred Stock due 2024 par value $0.01 per share,$25.35,-0.01,-0.039%,,,,4073,,
+add,PRIF^D,Priority Income Fund Inc. 7.00% Series D Term Preferred Stock due 2029,$25.68,0.17,0.666%,,,,600,,
+add,PRIF^E,Priority Income Fund Inc. 6.375% Series E Preferred Stock Due 2024,$25.26,-0.09,-0.355%,,,,3625,,
+add,PRIF^F,Priority Income Fund Inc. 6.625% Series F Term Preferred Stock due 2027,$25.80,-0.2355,-0.905%,,,,7185,,
+add,PRIF^G,Priority Income Fund Inc. 6.25% Series G Preferred Stock Due 2026,$25.44,-0.3065,-1.19%,,,,260,,
+add,PRIF^H,Priority Income Fund Inc. 6.00% Series H Term Preferred Stock due 2026,$25.50,0.105,0.413%,,,,7590,,
+add,PRLB,Proto Labs Inc. Common stock,$86.62,0.26,0.301%,2398485799.00,United States,2012,242896,Capital Goods,Office Equipment/Supplies/Services
+add,PRMW,Primo Water Corporation Common Stock,$17.615,0.215,1.236%,2838342558.00,Canada,,808226,,
+add,PRO,PROS Holdings Inc. Common Stock,$47.68,0.01,0.021%,2109976174.00,United States,2007,83833,Technology,EDP Services
+add,PROS,ProSight Global Inc. Common Stock,$12.79,-0.01,-0.078%,559937452.00,United States,2019,71101,Finance,Property-Casualty Insurers
+add,PRPB,CC Neuberger Principal Holdings II Class A Ordinary Shares,$9.86,-0.01,-0.101%,1069810000.00,United States,2020,122944,Finance,Business Services
+add,PRPC,CC Neuberger Principal Holdings III Class A Ordinary Shares,$9.85,-0.01,-0.101%,544828125.00,,2021,135631,Finance,Business Services
+add,PRS,Prudential Financial Inc. 5.625% Junior Subordinated Notes due 2058,$27.84,0.01,0.036%,948274025.00,United States,2018,16340,Finance,Investment Bankers/Brokers/Service
+add,PRT,PermRock Royalty Trust Trust Units,$6.9305,0.0205,0.297%,84314606.00,United States,2018,22011,Energy,Oil & Gas Production
+add,PRTY,Party City Holdco Inc. Common Stock,$10.00,-0.76,-7.063%,1112966960.00,United States,2015,2354900,Miscellaneous,Diversified Commercial Services
+add,PRU,Prudential Financial Inc. Common Stock,$105.12,-0.97,-0.914%,41417280000.00,United States,2001,1091955,Finance,Life Insurance
+add,PSA,Public Storage Common Stock,$295.07,1.23,0.419%,51630799770.00,United States,,285208,Consumer Services,Real Estate Investment Trusts
+add,PSA^C,Public Storage Depositary Shares Each Representing 1/1000 of a 5.125% Cumulative Preferred Share of Beneficial Interest Series C,$25.32,-0.01,-0.039%,,United States,,5125,,
+add,PSA^D,Public Storage Depositary Shares Each Representing 1/1000 of a 4.95% Cumulative Preferred Share of Beneficial Interest Series D,$25.34,-0.01,-0.039%,,United States,,25420,,
+add,PSA^E,Public Storage Depositary Shares Each Representing 1/1000 of a 4.90% Cumulative Preferred Share of Beneficial Interest Series E,$25.81,0.02,0.078%,,United States,,7697,,
+add,PSA^F,Public Storage Depositary Shares Each Representing 1/1000 of a 5.15% Cumulative Preferred Share of Beneficial Interest Series F par value $0.01 per share,$26.94,-0.10,-0.37%,,United States,,10310,,
+add,PSA^G,Public Storage Depositary Shares Each Representing 1/1000 of a 5.05% Cumulative Preferred Share of Beneficial Interest Series G,$26.90,0.01,0.037%,,United States,,5013,,
+add,PSA^H,Public Storage Depositary Shares Each Representing 1/1000 of a  5.60% Cumulative Preferred  Share of Beneficial Interest Series H,$28.15,-0.01,-0.036%,,United States,,23863,,
+add,PSA^I,Public Storage Depositary Shares Each Representing 1/1000 of a 4.875% Cumulative Preferred Share of Beneficial Interest Series I par value $0.01 per share,$27.40,-0.13,-0.472%,,United States,,32443,,
+add,PSA^J,Public Storage Depositary Shares Each Representing 1/1000 of a 4.700% Cumulative Preferred Share of Beneficial Interest Series J par value $0.01 per share,$27.79,-0.03,-0.108%,,United States,,3215,,
+add,PSA^K,Public Storage Depositary Shares Each Representing 1/1000 of a 4.75% Cumulative Preferred Share of Beneficial Interest Series K,$27.8025,-0.0675,-0.242%,,United States,,7604,,
+add,PSA^L,Public Storage Depositary Shares Each Representing 1/1000 of a 4.625% Cumulative Preferred Share of Beneficial Interest Series L par value $0.01 per share,$27.35,-0.07,-0.255%,,United States,,31032,,
+add,PSA^M,Public Storage Depositary Shares Each Representing 1/1000 of a 4.125% Cumulative Preferred Share of Beneficial Interest Series M,$26.29,-0.03,-0.114%,,United States,,2300,,
+add,PSA^N,Public Storage Depositary Shares Each Representing 1/1000 of a 3.875% Cumulative Preferred Share of Beneficial Interest Series N,$25.75,0.04,0.156%,,United States,,12440,,
+add,PSA^O,Public Storage Depositary Shares Each Representing 1/1000 of a 3.900% Cumulative Preferred Share of Beneficial Interest Series O,$25.95,-0.0584,-0.225%,,United States,,17390,,
+add,PSB,PS Business Parks Inc. (MD) Common Stock,$160.90,1.03,0.644%,4429417226.00,United States,,38129,Consumer Services,Real Estate Investment Trusts
+add,PSB^W,PS Business Parks Inc. Depositary Shares Each Representing 1/1000 of a Share of 5.20% Cumulative Preferred Stock Series W,$25.828,0.068,0.264%,,United States,,4127,,
+add,PSB^X,PS Business Parks Inc. Depositary Shares Each Representing 1/1000 of a Share of 5.25% Cumulative Preferred Stock Series X,$26.69,-0.02,-0.075%,,United States,,7174,,
+add,PSB^Y,PS Business Parks Inc. 5.20% Cumulative Preferred Stock Series Y,$26.60,-0.07,-0.262%,,United States,,7938,,
+add,PSB^Z,PS Business Parks Inc. Depositary Shares Each Representing 1/1000 of a Share of 4.875% Cumulative Preferred Stock Series Z  par value $0.01 per share,$27.58,0.00,0.00%,,United States,,15528,,
+add,PSF,Cohen & Steers Select Preferred and Income Fund Inc. Common Stock,$29.79,0.03,0.101%,357974157.00,,2010,13882,,
+add,PSFE,Paysafe Limited Common Shares,$11.835,-0.195,-1.621%,8565136041.00,,2021,5751874,Miscellaneous,Business Services
+add,PSN,Parsons Corporation Common Stock,$39.75,0.44,1.119%,4070742168.00,,2019,176173,Capital Goods,Industrial Machinery/Components
+add,PSO,Pearson Plc Common Stock,$12.165,0.035,0.289%,9199596196.00,United Kingdom,,138359,Consumer Services,Books
+add,PSTG,Pure Storage Inc. Class A Common Stock,$19.15,0.22,1.162%,5425001911.00,,2015,1801401,Technology,Electronic Components
+add,PSTH,Pershing Square Tontine Holdings Ltd. Class A Common Stock,$23.1183,0.0383,0.166%,4623662312.00,,2020,3162196,,
+add,PSTL,Postal Realty Trust Inc. Class A Common Stock,$21.125,0.355,1.709%,282458615.00,,2019,121151,Consumer Services,Real Estate Investment Trusts
+add,PSX,Phillips 66 Common Stock,$92.015,-0.435,-0.471%,40290336974.00,United States,,1771336,Energy,Integrated oil Companies
+add,PSXP,Phillips 66 Partners LP Common Units representing limited partner interest in the Partnership,$41.08,0.28,0.686%,9380213198.00,United States,2013,251675,Energy,Oil & Gas Production
+add,PTA,Cohen & Steers Tax-Advantaged Preferred Securities and Income Fund Common Shares of Beneficial Interest,$25.26,0.02,0.079%,1396207524.00,,2020,50804,,
+add,PTR,PetroChina Company Limited Common Stock,$43.89,0.33,0.758%,80327907156.00,China,,139083,Energy,Oil & Gas Production
+add,PTY,Pimco Corporate & Income Opportunity Fund,$20.2784,-0.1616,-0.791%,2243129912.00,United States,2002,371167,,
+add,PUK,Prudential Public Limited Company Common Stock,$41.76,0.68,1.655%,54613956051.00,United Kingdom,,241326,Finance,Life Insurance
+add,PUK^,Prudential Public Limited Company 6.75% Perpetual Subordinated Captial Security,$28.45,0.01,0.035%,,United Kingdom,,5241,,
+add,PUK^A,Prudential Public Limited Company 6.50% Perpetual Subordinated Capital Securities Exchangeable at the Issuer's Option Into Non-Cumulative Dollar Denominated Preference Shares,$28.15,-0.09,-0.319%,,United Kingdom,,9129,,
+add,PUMP,ProPetro Holding Corp. Common Stock,$10.59,-0.18,-1.671%,1083148705.00,United States,2017,420507,Energy,Oilfield Services/Equipment
+add,PV,Primavera Capital Acquisition Corporation Class A Ordinary Shares,$9.71,-0.01,-0.103%,521912500.00,,2021,164502,Finance,Business Services
+add,PVG,Pretium Resources Inc. Ordinary Shares (Canada),$10.575,0.095,0.906%,1986334863.00,Canada,,1488447,,
+add,PVH,PVH Corp. Common Stock,$109.03,-1.82,-1.642%,7770127401.00,United States,,408209,,
+add,PVL,Permianville Royalty Trust Trust Units ,$1.795,0.005,0.279%,59235000.00,United States,2011,17597,Energy,Oil & Gas Production
+add,PWR,Quanta Services Inc. Common Stock,$91.805,-1.035,-1.115%,12792667976.00,United States,,1460486,Capital Goods,Engineering & Construction
+add,PXD,Pioneer Natural Resources Company Common Stock,$163.80,-3.95,-2.355%,39959403284.00,United States,,4334948,Energy,Oil & Gas Production
+add,PYN,PIMCO New York Municipal Income Fund III Common Shares of Beneficial Interest,$10.83,-0.14,-1.276%,62034240.00,United States,2002,7320,,
+add,PYS,Merrill Lynch Depositor Inc PPlus Tr Ser RRD-1 Tr Ctf Cl A,$21.75,0.13,0.601%,0.00,United States,,1374,Finance,Trusts Except Educational Religious and Charitable
+add,PYT,PPlus Tr GSC-2 Tr Ctf Fltg Rate,$24.04,-0.09,-0.373%,0.00,United States,,2000,,
+add,PZC,PIMCO California Municipal Income Fund III Common Shares of Beneficial Interest,$11.2304,0.0904,0.811%,251347582.00,United States,2002,6558,,
+add,PZN,Pzena Investment Management Inc Class A Common Stock,$11.45,-0.31,-2.636%,830898093.00,United States,2007,56280,Finance,Investment Managers
+add,QD,Qudian Inc. American Depositary Shares each representing one Class A Ordinary Share,$2.115,0.015,0.714%,535281539.00,China,2017,2666168,Technology,Computer Software: Prepackaged Software
+add,QFTA,Quantum FinTech Acquisition Corporation Common Stock,$9.745,-0.005,-0.051%,245147656.00,,2021,39969,,
+add,QGEN,Qiagen N.V. Common Shares ,$47.785,0.875,1.865%,10914428495.00,Netherlands,,282968,Health Care,Biotechnology: Biological Products (No Diagnostic Substances)
+add,QS,QuantumScape Corporation Class A Common Stock,$27.43,-3.61,-11.63%,11135865256.00,United States,2020,23059504,Capital Goods,Auto Parts:O.E.M.
+add,QSR,Restaurant Brands International Inc. Common Shares,$67.945,0.225,0.332%,20595030383.00,Canada,2014,2097687,,
+add,QTS,QTS Realty Trust Inc. Class A Common Stock,$78.17,-0.06,-0.077%,5349127527.00,United States,2013,2336536,Consumer Services,Real Estate Investment Trusts
+add,QTS^A,QTS Realty Trust Inc. 7.125% Series A Cumulative Redeemable Perpetual Preferred Stock,$26.33,0.08,0.305%,,United States,,3758,,
+add,QTS^B,QTS Realty Trust Inc. 6.50% Series B Cumulative Convertible Perpetual Preferred Stock,$172.975,-0.095,-0.055%,,United States,,1069,,
+add,QTWO,Q2 Holdings Inc. Common Stock,$97.40,2.45,2.58%,5484137194.00,,2014,367293,Technology,EDP Services
+add,QUAD,Quad Graphics Inc Class A Common Stock,$3.87,0.24,6.612%,211613171.00,United States,,772092,Consumer Services,Recreational Products/Toys
+add,QUOT,Quotient Technology Inc. Common Stock,$11.03,-0.03,-0.271%,1029787603.00,,2014,270315,Technology,Advertising
+add,QVCC,QVC Inc. 6.250% Senior Secured Notes due 2068,$25.95,0.05,0.193%,0.00,United States,2019,27321,,
+add,QVCD,QVC Inc. 6.375% Senior Secured Notes due 2067,$25.80,-0.07,-0.271%,0.00,United States,2018,13642,,
+add,R,Ryder System Inc. Common Stock,$78.19,-1.39,-1.747%,4212125560.00,United States,,375516,Miscellaneous,Rental/Leasing Companies
+add,RA,Brookfield Real Assets Income Fund Inc. Common Stock,$22.305,0.005,0.022%,979031201.00,,2016,251405,,
+add,RAAS,Cloopen Group Holding Limited American Depositary Shares each representing two Class A Ordinary Shares,$9.30,-0.41,-4.222%,1528642618.00,,2021,3231648,Technology,Computer Software: Prepackaged Software
+add,RACE,Ferrari N.V. Common Shares,$211.24,-0.94,-0.443%,52381890243.00,,2015,228312,Capital Goods,Auto Manufacturing
+add,RAD,Rite Aid Corporation Common Stock,$22.55,0.97,4.495%,1242589382.00,United States,,1709223,Health Care,Medical/Nursing Services
+add,RAMP,LiveRamp Holdings Inc. Common Stock,$48.40,0.17,0.352%,3311208608.00,United States,2018,306138,Technology,EDP Services
+add,RBA,Ritchie Bros. Auctioneers Incorporated Common Stock,$57.62,-0.04,-0.069%,6354368806.00,Canada,,368353,,
+add,RBAC,RedBall Acquisition Corp. Class A Ordinary Shares,$9.83,0.00,0.00%,706531250.00,United States,2020,61420,Finance,Business Services
+add,RBC,Regal Beloit Corporation Common Stock,$137.20,-1.03,-0.745%,5574424338.00,United States,,103024,Consumer Durables,Metal Fabrications
+add,RBLX,Roblox Corporation Class A Common Stock,$91.03,-0.01,-0.011%,51871758077.00,,2021,11834525,Technology,EDP Services
+add,RC,Ready Capital Corproation Common Stock,$15.60,-0.28,-1.763%,1111058504.00,United States,2013,350976,Consumer Services,Real Estate Investment Trusts
+add,RC^B,Ready Capital Corporation 8.625% Series B Cumulative Preferred Stock,$25.4604,-0.0332,-0.13%,,United States,,3478,,
+add,RC^C,Ready Capital Corporation 6.25% Series C Cumulative Convertible Preferred Stock,$25.34,-0.0102,-0.04%,,United States,,202,,
+add,RC^D,Ready Capital Corporation 7.625% Series D Cumulative Redeemable Preferred Stock,$25.39,0.00,0.00%,,United States,,2480,,
+add,RCA,Ready Capital Corporation 7.00% Convertible Senior Notes due 2023,$26.665,0.045,0.169%,0.00,United States,2017,2032,Consumer Services,Real Estate Investment Trusts
+add,RCB,Ready Capital Corporation 6.20% Senior Notes due 2026,$26.25,0.01,0.038%,0.00,United States,2019,154,,
+add,RCC,Ready Capital Corporation 5.75% Senior Notes due 2026,$25.95,0.17,0.659%,,United States,2021,1021,Finance,Finance Companies
+add,RCI,Rogers Communication Inc. Common Stock,$51.63,0.05,0.097%,26069294168.00,Canada,,132715,,
+add,RCL,D/B/A Royal Caribbean Cruises Ltd. Common Stock,$90.85,-1.94,-2.091%,23127744188.00,United States,1993,3692066,,
+add,RCS,PIMCO Strategic Income Fund Inc.,$7.9186,-0.0014,-0.018%,351038475.00,United States,1994,93580,,
+add,RCUS,Arcus Biosciences Inc. Common Stock,$24.87,0.45,1.843%,1765667038.00,,2018,296425,Health Care,Major Pharmaceuticals
+add,RDN,Radian Group Inc. Common Stock,$22.72,-0.36,-1.56%,4346712175.00,United States,,484138,Finance,Property-Casualty Insurers
+add,RDS/B,Royal Dutch Shell PLC,$37.915,0.445,1.188%,,Netherlands,,2431603,,
+add,RDY,Dr. Reddy's Laboratories Ltd Common Stock,$72.73,0.94,1.309%,12056402134.00,India,,51737,Health Care,Major Pharmaceuticals
+add,RE,Everest Re Group Ltd. Common Stock,$255.25,-2.40,-0.931%,10231319756.00,Bermuda,,177422,Finance,Property-Casualty Insurers
+add,RELX,RELX PLC PLC American Depositary Shares (Each representing One Ordinary Share),$26.79,0.11,0.412%,51793291074.00,United Kingdom,2015,258407,Consumer Services,Publishing
+add,RENN,Renren Inc. American Depositary Shares each representing fifteen Class A ordinary shares,$10.865,-0.555,-4.86%,260970303.00,China,2011,40362,Technology,EDP Services
+add,RES,RPC Inc. Common Stock,$5.68,-0.22,-3.729%,1225374936.00,United States,,706426,Energy,Oilfield Services/Equipment
+add,REV,Revlon Inc. New Common Stock,$15.98,-0.41,-2.502%,854712225.00,United States,1996,204838,Consumer Non-Durables,Package Goods/Cosmetics
+add,REVG,REV Group Inc. Common Stock,$16.3102,-3.0998,-15.97%,1055953272.00,United States,2017,1960935,Capital Goods,Auto Manufacturing
+add,REX,REX American Resources Corporation,$97.441,3.021,3.20%,583866472.00,United States,,18171,Basic Industries,Automotive Aftermarket
+add,REXR,Rexford Industrial Realty Inc. Common Stock,$59.02,0.63,1.079%,7912359838.00,United States,2013,429220,Consumer Services,Real Estate Investment Trusts
+add,REXR^A,Rexford Industrial Realty Inc. 5.875% Series A Cumulative Redeemable Preferred Stock,$25.49,0.0003,0.001%,,United States,,3028,,
+add,REXR^B,Rexford Industrial Realty Inc. 5.875% Series B Cumulative Redeemable Preferred Stock,$26.625,-0.245,-0.912%,,United States,,2591,,
+add,REXR^C,Rexford Industrial Realty Inc. 5.625% Series C Cumulative Redeemable Preferred Stock par value $0.01 per share,$27.90,0.21,0.758%,,United States,,7548,,
+add,REZI,Resideo Technologies Inc. Common Stock ,$30.90,-0.21,-0.675%,4444977144.00,,2018,316017,Miscellaneous,Diversified Manufacture
+add,RF,Regions Financial Corporation Common Stock,$21.345,-0.555,-2.534%,20518636778.00,United States,,5186138,Finance,Major Banks
+add,RF^A,Regions Financial Corporation Depositary Shares Representing 1/40th Perpetual Preferred Series A,$25.00,0.00,0.00%,,United States,,45355,,
+add,RF^B,Regions Financial Corporation Depositary Shares Representing 1/40th Perpetual Preferred Series B,$28.97,-0.15,-0.515%,,United States,,40423,,
+add,RF^C,Regions Financial Corporation Depositary Shares each Representing a 1/40th Interest in a  Share of 5.700% Fixed-to-Floating Rate Non-Cumulative  Perpetual Preferred Stock Series C,$29.00,-0.08,-0.275%,,United States,,21932,,
+add,RF^E,Regions Financial Corporation Depositary Shares Each Representing a 1/40th Interest in a Share of 4.45% Non-Cumulative Perpetual Preferred Stock Series E,$25.0499,0.0199,0.08%,,United States,,143377,,
+add,RFI,Cohen & Steers Total Return Realty Fund Inc. Common Stock,$16.75,0.25,1.515%,439697533.00,United States,1993,62514,,
+add,RFL,Rafael Holdings Inc. Class B Common Stock,$41.86,-2.05,-4.669%,741808009.00,United States,2018,56346,Health Care,Major Pharmaceuticals
+add,RFM,RiverNorth Flexible Municipal Income Fund Inc. Common Stock,$24.10,0.20,0.837%,147364246.00,,2020,16598,,
+add,RFMZ,RiverNorth Flexible Municipal Income Fund II Inc. Common Stock,$20.46,-0.07,-0.341%,0.00,,2021,25411,,
+add,RFP,Resolute Forest Products Inc. Common Stock,$12.9513,-0.3287,-2.475%,1024332784.00,Canada,,464839,Basic Industries,Paper
+add,RGA,Reinsurance Group of America Incorporated Common Stock,$123.43,-1.42,-1.137%,8391418543.00,United States,,109585,Finance,Life Insurance
+add,RGR,Sturm Ruger & Company Inc. Common Stock,$78.06,-1.05,-1.327%,1372575816.00,United States,,69336,,
+add,RGS,Regis Corporation Common Stock,$10.06,-0.63,-5.893%,360045589.00,United States,1991,161251,,
+add,RGT,Royce Global Value Trust Inc. Common Stock,$15.18,0.05,0.33%,85020007.00,,2013,8995,,
+add,RH,RH Common Stock,$710.35,99.02,16.197%,14938855136.00,United States,2012,3669024,Consumer Services,Other Specialty Stores
+add,RHI,Robert Half International Inc. Common Stock,$91.11,-0.20,-0.219%,10275439737.00,United States,,595852,Technology,Diversified Commercial Services
+add,RHP,Ryman Hospitality Properties Inc. (REIT),$78.39,-0.52,-0.659%,4316535081.00,United States,,314912,Consumer Services,Real Estate Investment Trusts
+add,RICE,Rice Acquisition Corp. Class A Common Stock,$16.4835,-0.4365,-2.58%,488881654.00,United States,2020,241835,,
+add,RIG,Transocean Ltd (Switzerland) Common Stock,$4.02,-0.14,-3.365%,2481541799.00,Switzerland,,18723205,Energy,Oil & Gas Production
+add,RIO,Rio Tinto Plc Common Stock,$86.91,0.04,0.046%,140704854260.00,Australia,2002,1876013,Basic Industries,Steel/Iron Ore
+add,RIV,RiverNorth Opportunities Fund Inc. Common Stock,$18.03,0.01,0.055%,183132513.00,,2015,74719,Finance,Finance Companies
+add,RJF,Raymond James Financial Inc. Common Stock,$129.31,0.09,0.07%,17769535287.00,United States,,331480,Finance,Investment Bankers/Brokers/Service
+add,RKT,Rocket Companies Inc. Class A Common Stock,$20.695,-1.035,-4.763%,2824328851.00,United States,2020,7710191,Finance,Finance: Consumer Services
+add,RKTA,Rocket Internet Growth Opportunities Corp. Class A Ordinary Shares,$9.95,0.07,0.709%,332081250.00,,2021,2362,,
+add,RL,Ralph Lauren Corporation Common Stock,$120.01,-1.43,-1.178%,8776488753.00,United States,1997,535927,Consumer Non-Durables,Apparel
+add,RLGY,Realogy Holdings Corp. Common Stock,$17.505,-0.645,-3.554%,2038007862.00,United States,2012,555933,Finance,Real Estate
+add,RLI,RLI Corp. Common Stock (DE),$103.18,0.26,0.253%,4664090733.00,United States,,109580,Finance,Property-Casualty Insurers
+add,RLJ,RLJ Lodging Trust Common Shares of Beneficial Interest $0.01 par value,$16.01,-0.22,-1.356%,2640333178.00,United States,2011,437566,Consumer Services,Real Estate Investment Trusts
+add,RLJ^A,RLJ Lodging Trust $1.95 Series A Cumulative Convertible  Preferred Shares,$29.04,0.15,0.519%,,United States,,13235,,
+add,RLX,RLX Technology Inc. American Depositary Shares each representing the right to receive one (1) Class A ordinary share,$9.165,-0.105,-1.133%,14396295574.00,,2021,5432410,Consumer Non-Durables,Farming/Seeds/Milling
+add,RM,Regional Management Corp. Common Stock,$49.25,-0.70,-1.401%,523374628.00,United States,2012,43635,Finance,Finance: Consumer Services
+add,RMAX,RE/MAX Holdings Inc. Class A Common Stock,$34.615,-0.025,-0.072%,1088648742.00,,2013,94673,Finance,Real Estate
+add,RMD,ResMed Inc. Common Stock,$219.61,7.65,3.609%,31957171086.00,United States,,427162,Health Care,Medical/Dental Instruments
+add,RMI,RiverNorth Opportunistic Municipal Income Fund Inc. Common Stock,$23.22,0.02,0.086%,147987283.00,,2018,14157,,
+add,RMM,RiverNorth Managed Duration Municipal Income Fund Inc. Common Stock,$20.40,0.11,0.542%,402686147.00,,2019,20644,,
+add,RMO,Romeo Power Inc. Class A Common Stock,$9.29,-0.59,-5.972%,1218823382.00,,2019,3806993,Capital Goods,Automotive Aftermarket
+add,RMPL^,RiverNorth Specialty Finance Corporation 5.875% ,$25.37,0.006,0.024%,,,,5842,,
+add,RMT,Royce Micro-Cap Trust Inc. Common Stock,$12.33,-0.21,-1.675%,539619836.00,United States,,96232,,
+add,RNG,RingCentral Inc. Class A Common Stock,$267.85,6.58,2.518%,24340335729.00,,2013,770841,Technology,EDP Services
+add,RNGR,Ranger Energy Services Inc. Class A Common Stock,$7.73,-0.10,-1.277%,131193344.00,United States,2017,2600,Energy,Oilfield Services/Equipment
+add,RNP,Cohen & Steers REIT and Preferred and Income Fund Inc. Common Shares,$26.95,0.17,0.635%,1282340101.00,United States,2003,70764,,
+add,RNR,RenaissanceRe Holdings Ltd. Common Stock,$149.64,-0.17,-0.113%,7427787822.00,Bermuda,,170718,Finance,Property-Casualty Insurers
+add,RNR^E,RenaissanceRe Holdings Ltd. 5.375% Series E Preference Shares,$25.37,0.01,0.039%,,Bermuda,,4060,,
+add,RNR^F,RenaissanceRe Holdings Ltd. Depositary Shares each Representing a 1/1000th Interest in a 5.750% Series F Preference Share,$26.81,0.01,0.037%,,Bermuda,,19619,,
+add,ROG,Rogers Corporation Common Stock,$189.02,-3.37,-1.752%,3536971349.00,United States,,23264,Capital Goods,Industrial Machinery/Components
+add,ROK,Rockwell Automation Inc. Common Stock,$281.19,2.04,0.731%,32639605867.00,United States,,530052,Capital Goods,Industrial Machinery/Components
+add,ROL,Rollins Inc. Common Stock,$33.13,0.08,0.242%,16304052085.00,United States,,656386,Technology,Industrial Specialties
+add,ROP,Roper Technologies Inc. Common Stock,$453.39,2.44,0.541%,47714322905.00,United States,1992,143143,Capital Goods,Office Equipment/Supplies/Services
+add,ROSS,Ross Acquisition Corp II Class A Ordinary Shares,$9.74,0.02,0.206%,420037500.00,,2021,3689,,
+add,ROT,Rotor Acquisition Corp. Class A Common Stock,$9.97,-0.01,-0.10%,343965000.00,,2021,65881,,
+add,RPAI,Retail Properties of America Inc. Class A Common Stock,$12.50,-0.20,-1.575%,2684156975.00,United States,2012,580442,Consumer Services,Real Estate Investment Trusts
+add,RPM,RPM International Inc. Common Stock,$91.32,-0.29,-0.317%,11826975021.00,United States,,216291,Basic Industries,Paints/Coatings
+add,RPT,RPT Realty Common Stock,$13.759,-0.171,-1.228%,1116749689.00,United States,,121023,Consumer Services,Real Estate Investment Trusts
+add,RPT^D,RPT Realty 7.25% ,$58.27,-0.03,-0.051%,,United States,,4334,,
+add,RQI,Cohen & Steers Quality Income Realty Fund Inc Common Shares,$16.23,0.14,0.87%,2178767607.00,United States,2002,380516,,
+add,RRC,Range Resources Corporation Common Stock,$15.455,0.195,1.278%,3857426293.00,United States,,3313139,Energy,Oil & Gas Production
+add,RRD,R.R. Donnelley & Sons Company Common Stock,$6.60,0.06,0.917%,476520000.00,United States,,685142,Consumer Services,Advertising
+add,RS,Reliance Steel & Aluminum Co. Common Stock (DE),$172.58,-0.68,-0.392%,10994699372.00,United States,1994,293300,Basic Industries,Steel/Iron Ore
+add,RSF,RiverNorth Specialty Finance Corporation,$19.165,-0.025,-0.13%,99037035.00,,2019,7901,,
+add,RSG,Republic Services Inc. Common Stock,$109.225,-0.005,-0.005%,34846424316.00,United States,1998,371132,Public Utilities,Environmental Services
+add,RSI,Rush Street Interactive Inc. Class A Common Stock,$13.80,-0.36,-2.542%,3024399223.00,,2020,590685,Consumer Services,Services-Misc. Amusement & Recreation
+add,RTP,Reinvent Technology Partners Class A Ordinary Shares,$10.0185,-0.0615,-0.61%,864095625.00,United States,2020,1236382,Finance,Business Services
+add,RTPZ,Reinvent Technology Partners Z Class A Ordinary Shares,$9.98,-0.0099,-0.099%,286925000.00,United States,2021,82079,Finance,Business Services
+add,RTX,Raytheon Technologies Corporation Common Stock,$88.265,-0.585,-0.658%,133729407376.00,United States,,3689742,Capital Goods,Military/Government/Technical
+add,RVI,Retail Value Inc. Common Stock ,$21.42,0.55,2.635%,451603258.00,United States,2018,123367,Consumer Services,Real Estate Investment Trusts
+add,RVLV,Revolve Group Inc. Class A Common Stock,$55.40,0.43,0.782%,4000234948.00,,2019,653088,Consumer Services,Catalog/Specialty Distribution
+add,RVT,Royce Value Trust Inc. Common Stock,$19.16,-0.23,-1.186%,1953796875.00,United States,1986,148005,,
+add,RWT,Redwood Trust Inc. Common Stock,$11.71,-0.27,-2.254%,1323352920.00,United States,1995,677041,Consumer Services,Real Estate Investment Trusts
+add,RXN,Rexnord Corporation Common Stock,$50.675,-0.515,-1.006%,6066864716.00,United States,2012,675652,Technology,Industrial Machinery/Components
+add,RY,Royal Bank Of Canada Common Stock,$103.19,0.07,0.068%,147055696794.00,Canada,,543875,,
+add,RY^T,Royal Bank Of Canada 6.750% Fixed Rate/Floating Rate Noncumulative First Preferred Shares Series C-2,$28.705,0.055,0.192%,,Canada,,214,,
+add,RYAM,Rayonier Advanced Materials Inc. Common Stock,$7.52,-0.38,-4.81%,478252095.00,United States,2014,338108,Basic Industries,Industrial Specialties
+add,RYB,RYB Education Inc. American depositary shares each representing one Class A ordinary share,$4.18,-0.15,-3.464%,115310926.00,,2017,32857,Miscellaneous,Other Consumer Services
+add,RYI,Ryerson Holding Corporation Common Stock,$15.81,-0.55,-3.362%,608283331.00,United States,2014,54142,Capital Goods,Office Equipment/Supplies/Services
+add,RYN,Rayonier Inc. REIT Common Stock,$36.23,-0.04,-0.11%,5037054762.00,United States,,376757,Consumer Services,Real Estate Investment Trusts
+add,RZA,Reinsurance Group of America Incorporated 6.20% Fixed-to-Floating Rate Subordinated Debentures due 2042,$26.33,0.08,0.305%,0.00,United States,,36206,Finance,Life Insurance
+add,RZB,Reinsurance Group of America Incorporated 5.75% Fixed-To-Floating Rate Subordinated Debentures due 2056,$28.28,0.10,0.355%,0.00,United States,2016,12593,Finance,Life Insurance
+add,SA,Seabridge Gold Inc. Ordinary Shares (Canada),$18.99,0.38,2.042%,1432591699.00,Canada,,184264,Basic Industries,Precious Metals
+add,SAF,Saratoga Investment Corp 6.25% Notes due 2023,$25.52,0.06,0.236%,0.00,United States,2018,4817,Finance,Finance Companies
+add,SAFE,Safehold Inc. Common Stock,$76.16,2.12,2.863%,4056496371.00,United States,2017,63113,Consumer Services,Real Estate Investment Trusts
+add,SAH,Sonic Automotive Inc. Common Stock,$46.43,-0.37,-0.791%,1931245543.00,United States,1997,123761,Consumer Services,Other Specialty Stores
+add,SAIC,SCIENCE APPLICATIONS INTERNATIONAL CORPORATION Common Stock,$93.64,1.47,1.595%,5427298364.00,,,210668,Technology,EDP Services
+add,SAIL,SailPoint Technologies Holdings Inc. Common Stock,$46.46,0.88,1.931%,4272494587.00,United States,2017,283336,Technology,Computer Software: Prepackaged Software
+add,SAK,Saratoga Investment Corp 7.25% Notes due 2025,$26.17,-0.03,-0.115%,0.00,United States,2020,5380,Finance,Finance Companies
+add,SAM,Boston Beer Company Inc. (The) Common Stock,$1032.75,-5.76,-0.555%,12689166881.00,United States,,86702,Consumer Non-Durables,Beverages (Production/Distribution)
+add,SAN,Banco Santander S.A. Sponsored ADR (Spain),$4.255,0.055,1.31%,73664801194.00,Spain,,20002528,Finance,Commercial Banks
+add,SAND          ,Sandstorm Gold Ltd. Ordinary Shares (Canada),$9.135,0.355,4.043%,1777396493.00,Canada,,1257246,Basic Industries,Precious Metals
+add,SAP,SAP  SE ADS,$141.765,1.795,1.282%,167223065135.00,Germany,,428158,Technology,EDP Services
+add,SAR,Saratoga Investment Corp New,$26.52,-0.11,-0.413%,295963067.00,United States,,28285,,
+add,SAVE,Spirit Airlines Inc. Common Stock,$34.135,-0.665,-1.911%,3700251170.00,United States,,2506387,Transportation,Air Freight/Delivery Services
+add,SB,Safe Bulkers Inc Common Stock ($0.001 par value),$4.17,0.21,5.303%,454006832.00,Monaco,2008,1949929,Transportation,Marine Transportation
+add,SB^C,Safe Bulkers Inc Cumulative Redeemable Perpetual Preferred Series C (Marshall Islands),$25.18,-0.073,-0.289%,,Monaco,,5925,,
+add,SB^D,Safe Bulkers Inc Perpetual Preferred Series D (Marshall Islands),$25.32,-0.04,-0.158%,,Monaco,,1830,,
+add,SBBA,Scorpio Tankers Inc. 7.00% Senior Notes due 2025,$25.29,-0.06,-0.237%,0.00,Monaco,2020,40614,Transportation,Marine Transportation
+add,SBG,Sandbridge Acquisition Corporation Class A Common Stock,$10.005,0.005,0.05%,287643750.00,,2020,264038,,
+add,SBH,Sally Beauty Holdings Inc. (Name to be changed from Sally Holdings Inc.) Common Stock,$20.165,-0.125,-0.616%,2277716785.00,United States,,517930,Miscellaneous,Diversified Commercial Services
+add,SBI,Western Asset Intermediate Muni Fund Inc Common Stock,$9.62,-0.05,-0.517%,135471870.00,United States,1992,213,,
+add,SBII,Sandbridge X2 Corp. Class A Common Stock,$9.72,-0.06,-0.613%,289385162.00,,2021,36645,,
+add,SBOW,SilverBow Resorces Inc. Common Stock,$21.07,1.16,5.826%,256980213.00,,,119840,Energy,Oil & Gas Production
+add,SBR,Sabine Royalty Trust Common Stock,$38.71,0.72,1.895%,564366445.00,United States,,33901,Energy,Oil & Gas Production
+add,SBS,Companhia de saneamento Basico Do Estado De Sao Paulo - Sabesp American Depositary Shares (Each repstg 250 Common Shares),$7.55,0.04,0.533%,5160499511.00,Brazil,2002,489348,,
+add,SBSW,D/B/A Sibanye-Stillwater Limited ADS,$18.955,0.055,0.291%,13991563211.00,,,2026718,Basic Industries,Precious Metals
+add,SC,Santander Consumer USA Holdings Inc. Common Stock,$38.08,-0.38,-0.988%,11653840789.00,,2014,334768,Finance,Finance Companies
+add,SCCO,Southern Copper Corporation Common Stock,$66.92,0.33,0.496%,51734063161.00,United States,,1150957,Basic Industries,Precious Metals
+add,SCD,LMP Capital and Income Fund Inc. Common Stock,$14.81,0.07,0.475%,266009859.00,United States,2004,27367,,
+add,SCE^G,SCE Trust II Trust Preferred Securities,$25.05,0.015,0.06%,,United States,,12941,,
+add,SCE^H,SCE Trust III Fixed/Floating Rate Trust Preference Securities,$25.31,0.01,0.04%,,United States,,44339,,
+add,SCE^J,Southern California Edison Company 5.375% Fixed-to-Floating Rate Trust Preference Securities,$24.96,-0.08,-0.319%,,United States,,46421,,
+add,SCE^K,Southern California Edison Company 5.45% Fixed-to-Floating Rate Trust Preference Securities,$25.40,-0.05,-0.196%,,United States,,28120,,
+add,SCE^L,SCE TRUST VI,$24.945,0.005,0.02%,,United States,,54885,,
+add,SCHW,Charles Schwab Corporation (The) Common Stock,$72.705,-0.145,-0.199%,137146810213.00,United States,,6778744,Finance,Investment Bankers/Brokers/Service
+add,SCHW^D,The Charles Schwab Corporation Depositary Shares each representing 1/40th interest in a share of 5.95% Non-Cumulative Perpetual Preferred Stock Series D,$25.3152,-0.0148,-0.058%,,United States,,231484,,
+add,SCHW^J,The Charles Schwab Corporation Depositary Shares Each Representing a 1/40th Interest in a Share of 4.450% Non-Cumulative Perpetual Preferred Stock Series J,$26.14,-0.11,-0.419%,,United States,,92738,,
+add,SCI,Service Corporation International Common Stock,$54.135,0.575,1.074%,9102333173.00,United States,,666393,Miscellaneous,Other Consumer Services
+add,SCL,Stepan Company Common Stock,$131.62,-0.09,-0.068%,2963678721.00,United States,,28010,Consumer Non-Durables,Package Goods/Cosmetics
+add,SCM,Stellus Capital Investment Corporation Common Stock,$13.1227,-0.1773,-1.333%,255708972.00,United States,2012,58627,Finance,Finance/Investors Services
+add,SCPE,SC Health Corporation Class A Ordinary Shares,$10.085,0.005,0.05%,230064063.00,,2019,62765,Finance,Business Services
+add,SCS,Steelcase Inc. Common Stock,$14.925,-0.025,-0.167%,1726291155.00,United States,1998,366195,Consumer Durables,Office Equipment/Supplies/Services
+add,SCU,Sculptor Capital Management Inc. Class A Common Stock,$24.79,-0.02,-0.081%,1431425915.00,United States,,67257,Finance,Investment Managers
+add,SCVX,SCVX Corp. Class A Ordinary Shares,$9.87,-0.06,-0.604%,283762500.00,,2020,48748,Finance,Business Services
+add,SCX,L.S. Starrett Company (The) Common Stock,$8.92,-0.36,-3.879%,63363702.00,United States,,11067,Consumer Durables,Home Furnishings
+add,SD,SandRidge Energy Inc. Common Stock,$6.32,0.12,1.935%,230723652.00,,2016,231284,Energy,Oil & Gas Production
+add,SDHY,PGIM Short Duration High Yield Opportunities Fund Common Shares,$18.54,-0.16,-0.856%,457438458.00,,2020,120026,,
+add,SE,Sea Limited American Depositary Shares each representing one Class A Ordinary Share,$271.61,8.53,3.242%,142441383478.00,United States,2017,3021872,Technology,Computer Software: Prepackaged Software
+add,SEAH,Sports Entertainment Acquisition Corp. Class A Common Stock,$10.185,0.065,0.642%,572906250.00,United States,2020,596641,,
+add,SEAS,SeaWorld Entertainment Inc. Common Stock,$55.1061,-0.8539,-1.526%,4356808508.00,United States,2013,339103,Consumer Services,Movies/Entertainment
+add,SEE,Sealed Air Corporation Common Stock,$58.085,0.205,0.354%,8828334097.00,United States,,621314,Basic Industries,Containers/Packaging
+add,SEM,Select Medical Holdings Corporation Common Stock,$41.085,0.675,1.67%,5539848236.00,United States,2009,550973,Health Care,Hospital/Nursing Management
+add,SEMR,SEMrush Holdings Inc. Class A Common Stock,$17.53,-1.42,-7.493%,2377510107.00,,2021,477233,Technology,EDP Services
+add,SF,Stifel Financial Corporation Common Stock,$63.985,-0.615,-0.952%,6724201118.00,United States,,444746,Finance,Investment Bankers/Brokers/Service
+add,SF^A,Stifel Financial Corporation Depositary Shares each representing a 1/1000th interest in a share of 6.25% Non-Cumulative Preferred Stock Series A,$25.19,0.0102,0.041%,,United States,,8261,,
+add,SF^B,Stifel Financial Corporation Depositary Shares Each Representing 1/1000th  Interest in a Share of 6.25% Non-Cumulative  Preferred Stock Series B,$27.14,0.00,0.00%,,United States,,5129,,
+add,SF^C,Stifel Financial Corporation Depositary Shares Each Representing 1/1000th Interest in a Share of 6.125% Non Cumulative Preferred Stock Series C,$27.19,0.07,0.258%,,United States,,17865,,
+add,SFB,Stifel Financial Corporation 5.20% Senior Notes due 2047,$26.47,0.09,0.341%,0.00,United States,2017,7468,Finance,Investment Bankers/Brokers/Service
+add,SFE,Safeguard Scientifics Inc. New Common Stock,$7.13,-0.20,-2.729%,149427488.00,United States,,50102,Finance,Finance/Investors Services
+add,SFL,SFL Corporation Ltd,$8.805,0.105,1.207%,1024543047.00,Bermuda,,1542709,Transportation,Marine Transportation
+add,SFTW,Osprey Technology Acquisition Corp. Class A Common Stock,$10.005,0.015,0.15%,395510156.00,,2019,378192,,
+add,SFUN,Fang Holdings Limited American Depositary Shares (Each representing Four Class A Ordinary Shares HK$1.00 par value),$11.6901,0.0001,0.001%,105271887.00,China,2010,2444,Technology,EDP Services
+add,SGFY,Signify Health Inc. Class A Common Stock,$29.11,0.71,2.50%,6567956471.00,,2021,194996,Technology,Retail: Computer Software & Peripheral Equipment
+add,SGU,Star Group L.P. Common Stock,$11.14,-0.07,-0.624%,447819444.00,United States,,81603,Public Utilities,Oil Refining/Marketing
+add,SHAK,Shake Shack Inc. Class A Common Stock,$97.75,-1.36,-1.372%,4107963496.00,United States,2015,480749,Consumer Services,Restaurants
+add,SHG,Shinhan Financial Group Co Ltd American Depositary Shares,$38.14,0.26,0.686%,19702864801.00,South Korea,,33769,Finance,Major Banks
+add,SHI,SINOPEC Shangai Petrochemical Company Ltd. Common Stock,$25.89,0.29,1.133%,2802285315.00,China,,22876,Basic Industries,Major Chemicals
+add,SHLX,Shell Midstream Partners L.P. Common Units representing Limited Partner Interests,$15.755,0.165,1.058%,6196276655.00,United States,2014,1036012,Energy,Oilfield Services/Equipment
+add,SHO,Sunstone Hotel Investors Inc. Sunstone Hotel Investors Inc. Common Shares,$13.17,-0.11,-0.828%,2847858780.00,United States,2004,1530218,Consumer Services,Hotels/Resorts
+add,SHO^E,Sunstone Hotel Investors Inc. 6.950% Series E Cumulative Redeemable Preferred Stock,$25.25,-0.02,-0.079%,,United States,,33160,,
+add,SHO^H,Sunstone Hotel Investors Inc. 6.125% Series H Cumulative Redeemable Preferred Stock,$26.77,0.32,1.21%,,United States,,1683,,
+add,SHOP,Shopify Inc. Class A Subordinate Voting Shares,$1234.80,19.24,1.583%,153588350664.00,Canada,2015,880857,,
+add,SHW,Sherwin-Williams Company (The) Common Stock,$277.88,0.92,0.332%,73902075126.00,United States,,950879,Basic Industries,Paints/Coatings
+add,SI,Silvergate Capital Corporation Class A Common Stock,$101.86,-4.35,-4.096%,2682072197.00,United States,2019,611778,,
+add,SID,Companhia Siderurgica Nacional S.A. Common Stock,$8.84,0.03,0.341%,12200212595.00,Brazil,,3397778,Basic Industries,Steel/Iron Ore
+add,SIG,Signet Jewelers Limited Common Shares,$70.09,9.05,14.826%,3670168509.00,Bermuda,,7215782,Consumer Services,Consumer Specialties
+add,SII,Sprott Inc. Common Shares,$43.93,0.07,0.16%,1095477446.00,,2020,28032,,
+add,SITC,SITE Centers Corp. Common Stock,$15.71,-0.05,-0.317%,3315299398.00,United States,,1312979,Consumer Services,Real Estate Investment Trusts
+add,SITC^A,SITE Centers Corp. 6.375% Class A Preferred Shares,$26.23,0.03,0.115%,,United States,,4963,,
+add,SITE,SiteOne Landscape Supply Inc. Common Stock,$161.12,-2.13,-1.305%,7158268200.00,United States,2016,203008,,
+add,SIX,Six Flags Entertainment Corporation New Common Stock,$43.11,-0.96,-2.178%,3681239075.00,United States,,1608259,Consumer Services,Movies/Entertainment
+add,SJI,South Jersey Industries Inc. Common Stock,$27.77,0.04,0.144%,3121942111.00,United States,,693269,Public Utilities,Oil/Gas Transmission
+add,SJIJ,South Jersey Industries Inc. 5.625% Junior Subordinated Notes due 2079,$26.33,-0.028,-0.106%,0.00,United States,2019,12113,Public Utilities,Oil/Gas Transmission
+add,SJIV,South Jersey Industries Inc. Corporate Units,$59.59,0.07,0.118%,0.00,United States,2021,45419,Public Utilities,Oil/Gas Transmission
+add,SJM,J.M. Smucker Company (The) New Common Stock,$135.62,-0.35,-0.257%,14689069196.00,United States,,356638,Consumer Non-Durables,Packaged Foods
+add,SJR,Shaw Communications Inc. Common Stock,$29.94,-0.03,-0.10%,14929800340.00,Canada,,119763,Consumer Services,Television Services
+add,SJT,San Juan Basin Royalty Trust Common Stock,$5.4521,0.0021,0.039%,254115817.00,United States,,65881,Energy,Oil & Gas Production
+add,SJW,SJW Group Common Stock (DE),$64.31,0.26,0.406%,1915787633.00,United States,,40636,Public Utilities,Water Supply
+add,SKLZ,Skillz Inc. Class A Common Stock,$21.15,-1.20,-5.369%,8385738712.00,,2020,11096481,Technology,EDP Services
+add,SKM,SK Telecom Co. Ltd. Common Stock,$33.025,0.275,0.84%,21171745236.00,South Korea,,287847,Public Utilities,Telecommunications Equipment
+add,SKT,Tanger Factory Outlet Centers Inc. Common Stock,$19.1199,-1.0801,-5.347%,1927363872.00,United States,1993,1117299,Consumer Services,Real Estate Investment Trusts
+add,SKX,Skechers U.S.A. Inc. Common Stock,$47.97,-0.18,-0.374%,7441185167.00,United States,1999,574652,Consumer Non-Durables,Shoe Manufacturing
+add,SKY,Skyline Champion Corporation Common Stock,$48.55,-1.93,-3.823%,2749853260.00,United States,,249254,Basic Industries,Homebuilding
+add,SLAC,Social Leverage Acquisition Corp I Class A Common Stock,$9.745,-0.005,-0.051%,420253125.00,,2021,19438,,
+add,SLB,Schlumberger N.V. Common Stock,$35.015,-0.745,-2.083%,48962611192.00,France,,10021237,Energy,Oilfield Services/Equipment
+add,SLCA,U.S. Silica Holdings Inc. Common Stock,$11.19,-0.19,-1.67%,831880456.00,United States,2012,392996,Energy,Metal Fabrications
+add,SLF,Sun Life Financial Inc. Common Stock,$52.98,-0.30,-0.563%,31019863059.00,Canada,,408637,Technology,Advertising
+add,SLG,SL Green Realty Corp Common Stock,$84.99,1.91,2.299%,5894393740.00,United States,1997,1484750,Consumer Services,Real Estate Investment Trusts
+add,SLG^I,SL Green Realty Corporation Preferred Series I,$26.30,-0.10,-0.379%,,United States,,3274,,
+add,SLQT,SelectQuote Inc. Common Stock,$20.495,-0.835,-3.915%,3348675037.00,,2020,1469479,Finance,Specialty Insurers
+add,SM,SM Energy Company Common Stock,$21.63,-1.05,-4.63%,2547965938.00,United States,,2865087,Energy,Oil & Gas Production
+add,SMAR,Smartsheet Inc. Class A Common Stock,$63.89,1.99,3.215%,7993403188.00,United States,2018,972084,Technology,EDP Services
+add,SMFG,Sumitomo Mitsui Financial Group Inc Unsponsored American Depositary Shares (Japan),$7.17,-0.04,-0.555%,49129835160.00,Japan,,518459,Finance,Commercial Banks
+add,SMG,Scotts Miracle-Gro Company (The) Common Stock,$193.78,-6.23,-3.115%,10794135479.00,United States,1992,391323,Basic Industries,Agricultural Chemicals
+add,SMHI,SEACOR Marine Holdings Inc. Common Stock ,$4.25,0.04,0.95%,102826128.00,,2017,24333,Transportation,Marine Transportation
+add,SMLP,Summit Midstream Partners LP Common Units Representing Limited Partner Interests,$29.00,0.221,0.768%,195597344.00,United States,2012,25142,Energy,Oilfield Services/Equipment
+add,SMM,Salient Midstream Common Shares of Beneficial Interest,$6.36,0.11,1.76%,112714769.00,United States,2012,63227,,
+add,SMP,Standard Motor Products Inc. Common Stock,$46.99,-0.77,-1.612%,1042552469.00,United States,,73656,Capital Goods,Auto Parts:O.E.M.
+add,SMWB,Similarweb Ltd. Ordinary Shares,$22.03,0.13,0.594%,1636568077.00,,2021,176763,,
+add,SNA,Snap-On Incorporated Common Stock,$240.8769,-3.5431,-1.45%,13026618898.00,United States,,380135,Capital Goods,Diversified Manufacture
+add,SNAP,Snap Inc. Class A Common Stock,$62.52,0.75,1.214%,97944811063.00,United States,2017,9590863,Technology,Computer Software: Prepackaged Software
+add,SNDR,Schneider National Inc. Common Stock,$22.71,-0.65,-2.783%,4032481688.00,United States,2017,403367,Transportation,Trucking Freight/Courier Services
+add,SNII,Supernova Partners Acquisition Company II Ltd. Class A Ordinary Shares,$9.81,0.01,0.102%,423056250.00,,2021,43062,,
+add,SNN,Smith & Nephew SNATS Inc. Common Stock,$43.885,1.385,3.259%,19289600887.00,United Kingdom,,886527,Health Care,Industrial Specialties
+add,SNOW,Snowflake Inc. Class A Common Stock,$249.25,2.24,0.907%,73802925000.00,United States,2020,2540608,Technology,Computer Software: Prepackaged Software
+add,SNP,China Petroleum & Chemical Corporation Common Stock,$53.29,0.14,0.263%,64518847596.00,China,,75946,Energy,Integrated oil Companies
+add,SNPR,Tortoise Acquisition Corp. II Class A Ordinary Shares,$10.15,-0.03,-0.295%,437718750.00,United States,2020,421202,Finance,Business Services
+add,SNR,New Senior Investment Group Inc. Common Stock,$7.225,-0.195,-2.628%,605598048.00,United States,2014,491714,Consumer Services,Real Estate Investment Trusts
+add,SNV,Synovus Financial Corp. Common Stock,$47.51,-1.12,-2.303%,7059981487.00,United States,,500786,Finance,Major Banks
+add,SNV^D,Synovus Financial Corp. Fixed-to-Floating Rate Non-Cumulative Perpetual Preferred Stock Series D Liquation Preference $25.00 per Share,$26.7599,-0.0101,-0.038%,,United States,,7601,,
+add,SNV^E,Synovus Financial Corp. 5.875% Fixed-Rate Reset Non-Cumulative Perpetual Preferred Stock Series E,$27.16,0.02,0.074%,,United States,,50828,,
+add,SNX,Synnex Corporation Common Stock,$126.90,0.44,0.348%,6580043292.00,United States,2003,105485,Technology,EDP Services
+add,SO,Southern Company (The) Common Stock,$63.91,0.28,0.44%,67657067905.00,United States,,2409523,Public Utilities,Electric Utilities: Central
+add,SOAC,Sustainable Opportunities Acquisition Corp. Class A Ordinary Shares,$9.9888,0.0088,0.088%,374580000.00,,2020,199449,Finance,Business Services
+add,SOGO,Sogou Inc. American Depositary Shares each representing one Class A Ordinary Share,$8.35,-0.04,-0.477%,3236384149.00,United States,2017,228976,Technology,EDP Services
+add,SOI,Solaris Oilfield Infrastructure Inc. Class A Common Stock,$10.43,-0.09,-0.856%,476491254.00,United States,2017,80113,Energy,Metal Fabrications
+add,SOJB,Southern Company (The) Series 2016A 5.25% Junior Subordinated Notes due October 1 2076,$25.68,-0.17,-0.658%,0.00,United States,2016,54567,Public Utilities,Power Generation
+add,SOJC,Southern Company (The) Series 2017B 5.25% Junior Subordinated Notes due December 1 2077,$26.47,0.08,0.303%,0.00,United States,2017,15988,Public Utilities,Power Generation
+add,SOJD,Southern Company (The) Series 2020A 4.95% Junior Subordinated Notes due January 30 2080,$26.93,-0.09,-0.333%,0.00,United States,2020,82002,Public Utilities,Electric Utilities: Central
+add,SOJE,Southern Company (The) Series 2020C 4.20% Junior Subordinated Notes due October 15 2060,$25.53,0.01,0.039%,0.00,United States,2020,79801,Public Utilities,Electric Utilities: Central
+add,SOL,Renesola Ltd. American Depsitary Shares (Each representing 10 shares),$9.24,0.20,2.212%,644475281.00,China,2008,5660550,Technology,Semiconductors
+add,SOLN,Southern Company (The) 2019 Series A Corporate Units,$52.14,0.05,0.096%,0.00,United States,2019,62689,Public Utilities,Power Generation
+add,SON,Sonoco Products Company Common Stock,$66.88,0.16,0.24%,6729036899.00,United States,,174375,Basic Industries,Containers/Packaging
+add,SONY,Sony Group Corporation American Depositary Shares ,$98.66,0.94,0.962%,122264661812.00,Japan,,479565,Consumer Non-Durables,Consumer Electronics/Appliances
+add,SOR,Source Capital Inc. Common Stock,$45.55,0.01,0.022%,382865196.00,United States,,2955,,
+add,SOS,SOS Limited American Depositary Shares,$3.82,-0.11,-2.799%,685718921.00,,2017,21284969,Finance,Finance: Consumer Services
+add,SPAQ,Spartan Acquisition Corp. III Class A Common Stock,$9.92,0.03,0.303%,684480000.00,,2021,70158,,
+add,SPB,Spectrum Brands Holdings Inc. Common Stock,$86.37,-0.22,-0.254%,3681846779.00,United States,,108535,,
+add,SPCE,Virgin Galactic Holdings Inc. Common Stock,$35.37,0.21,0.597%,8514002080.00,,2017,21849145,Consumer Services,Transportation Services
+add,SPE,Special Opportunities Fund Inc Common Stock,$15.50,0.06,0.389%,131765004.00,United States,,40236,,
+add,SPE^B,Special Opportunities Fund Inc. 3.50% Convertible Preferred Stock Series B,$29.96,-0.07,-0.233%,,United States,,22880,,
+add,SPFR,Jaws Spitfire Acquisition Corporation Class A Ordinary Shares,$10.04,0.03,0.30%,432975000.00,,2021,464602,Finance,Business Services
+add,SPG,Simon Property Group Inc. Common Stock,$134.63,-0.96,-0.708%,44231258345.00,United States,,1787912,Consumer Services,Real Estate Investment Trusts
+add,SPG^J,Simon Property Group Inc. Simon Property Group 8 3/8% Series J Cumulative Redeemable Preferred Stock,$70.98,-0.52,-0.727%,,United States,,662,,
+add,SPGI,S&P Global Inc. Common Stock,$386.41,1.80,0.468%,93086169000.00,United States,,681921,Technology,Advertising
+add,SPGS,Simon Property Group Acquisition Holdings Inc. Class A Common Stock,$9.785,0.025,0.256%,421978125.00,,2021,5738,,
+add,SPH,Suburban Propane Partners L.P. Common Stock,$15.21,-0.02,-0.131%,951069664.00,United States,1996,230110,Public Utilities,Other Specialty Stores
+add,SPLP,Steel Partners Holdings LP LTD PARTNERSHIP UNIT,$28.09,0.42,1.518%,624944269.00,United States,,35016,,
+add,SPLP^A,Steel Partners Holdings LP 6.0% Series A Preferred Units no par value,$22.90,-0.0707,-0.308%,,United States,,7037,,
+add,SPNT,SiriusPoint Ltd. Common Shares,$10.59,-0.03,-0.282%,1711238915.00,,2013,307940,Finance,Property-Casualty Insurers
+add,SPNV,Supernova Partners Acquisition Company Inc. Class A Common Stock,$9.94,0.00,0.00%,500106250.00,United States,2020,246607,Finance,Real Estate
+add,SPOT,Spotify Technology S.A. Ordinary Shares,$246.35,8.65,3.639%,47047539433.00,Luxembourg,2018,1243558,Consumer Services,Broadcasting
+add,SPR,Spirit Aerosystems Holdings Inc. Common Stock,$50.51,-0.81,-1.578%,5324744148.00,United States,2006,1898132,Capital Goods,Military/Government/Technical
+add,SPRQ,Spartan Acquisition Corp. II Class A Common Stock,$9.995,-0.005,-0.05%,431034375.00,United States,2021,263938,,
+add,SPXC,SPX Corporation Common Stock,$60.26,-1.48,-2.397%,2726973801.00,United States,,133495,Capital Goods,Industrial Machinery/Components
+add,SPXX,Nuveen S&P 500 Dynamic Overwrite Fund,$18.38,0.21,1.156%,315984512.00,United States,,36184,,
+add,SQ,Square Inc. Class A Common Stock,$216.59,6.38,3.035%,98628296120.00,United States,2015,6782644,Technology,Computer Software: Prepackaged Software
+add,SQM,Sociedad Quimica y Minera S.A. Common Stock,$47.38,-0.19,-0.399%,12472619407.00,Chile,1993,1343652,Basic Industries,Agricultural Chemicals
+add,SQNS,Sequans Communications S.A. American Depositary Shares,$6.1109,-0.1091,-1.754%,215655794.00,France,2011,116290,Technology,Semiconductors
+add,SQSP,Squarespace Inc. Class A Common Stock,$58.0058,0.9758,1.711%,7893272300.00,,2021,180880,Technology,EDP Services
+add,SQZ,SQZ Biotechnologies Company Common Stock,$13.53,0.09,0.67%,377239699.00,United States,2020,182372,Consumer Durables,Specialty Chemicals
+add,SR,Spire Inc. Common Stock,$74.60,0.69,0.934%,3855295251.00,United States,,241814,Public Utilities,Oil/Gas Transmission
+add,SR^A,Spire Inc. Depositary Shares each representing a 1/1000th interest in a share of 5.90% Series A Cumulative Redeemable Perpetual Preferred Stock,$27.99,-0.11,-0.391%,,United States,,13416,,
+add,SRC,Spirit Realty Capital Inc. Common Stock,$50.985,0.725,1.442%,5861323396.00,United States,2013,301188,Consumer Services,Real Estate Investment Trusts
+add,SRC^A,Spirit Realty Capital Inc. 6.000% Series A Cumulative Redeemable Preferred Stock,$26.59,-0.005,-0.019%,,United States,,51740,,
+add,SRE,Sempra Energy Common Stock,$139.92,0.48,0.344%,42362277844.00,United States,,939874,Public Utilities,Oil/Gas Transmission
+add,SRE^B,Sempra Energy 6.75% Mandatory Convertible Preferred Stock Series B,$105.00,0.1751,0.167%,,United States,,26297,,
+add,SREA,Sempra Energy 5.750% Junior Subordinated Notes due 2079,$27.91,0.16,0.577%,0.00,United States,2019,33467,Consumer Services,Professional Services
+add,SRG,Seritage Growth Properties Class A Common Stock,$18.86,-0.27,-1.411%,1064574691.00,United States,2015,223404,Consumer Services,Real Estate Investment Trusts
+add,SRG^A,Seritage Growth Properties 7.00% Series A Cumulative Redeemable Preferred Shares of Beneficial Interest,$24.65,0.01,0.041%,,United States,,184,,
+add,SRI,Stoneridge Inc. Common Stock,$32.66,-0.10,-0.305%,887156971.00,United States,1997,106271,Capital Goods,Auto Parts:O.E.M.
+add,SRL,Scully Royalty Ltd.,$12.995,0.185,1.444%,177835925.00,Canada,,14815,,
+add,SRLP,Sprague Resources LP Common Units representing Limited Partner Interests,$27.68,0.54,1.99%,725942738.00,,2013,21176,Energy,Oil Refining/Marketing
+add,SRT,StarTek Inc. Common Stock,$7.71,-0.11,-1.407%,314449829.00,United States,1997,14618,Miscellaneous,Business Services
+add,SRV,Cushing MLP & Infrastructure Total Return Fund,$31.3162,0.3462,1.118%,68375509.00,United States,,6009,,
+add,SSD,Simpson Manufacturing Company Inc. Common Stock,$108.88,-1.86,-1.68%,4728741802.00,United States,,68103,Capital Goods,Industrial Specialties
+add,SSL,Sasol Ltd. American Depositary Shares,$17.31,0.47,2.791%,10971593249.00,South Africa,,471005,Energy,Oil & Gas Production
+add,SSTK,Shutterstock Inc. Common Stock,$90.75,-0.37,-0.406%,3350909900.00,United States,2012,87013,,
+add,ST,Sensata Technologies Holding plc Ordinary Shares,$59.85,0.26,0.436%,9462874762.00,Netherlands,2010,356651,Capital Goods,Industrial Machinery/Components
+add,STAG,Stag Industrial Inc. Common Stock,$38.718,0.548,1.436%,6182807186.00,United States,2011,636606,Consumer Services,Real Estate Investment Trusts
+add,STAR          ,iStar Inc. Common Stock,$18.37,0.45,2.511%,1345341260.00,United States,,829389,Consumer Services,Real Estate Investment Trusts
+add,STAR^D,iStar Inc. Series D Cumulative Redeemable Preferred Stock,$25.7325,0.1225,0.478%,,United States,,3033,,
+add,STAR^G,iStar Inc. Series G Cumulative Redeemable Preferred Stock,$25.51,0.04,0.157%,,United States,,4529,,
+add,STAR^I,iStar Inc. Series I Cumulative Redeemable Preferred Stock,$25.80,0.05,0.194%,,United States,,10360,,
+add,STC,Stewart Information Services Corporation Common Stock,$59.50,-0.33,-0.552%,1595268899.00,United States,,83338,Finance,Specialty Insurers
+add,STE,STERIS plc (Ireland) Ordinary Shares,$197.65,2.11,1.079%,16874727089.00,United States,,675967,Health Care,Industrial Specialties
+add,STEM,Stem Inc. Class A Common Stock,$31.055,0.215,0.697%,3905306308.00,United States,2020,1891666,Technology,Computer Software: Prepackaged Software
+add,STG,Sunlands Technology Group American Depositary Shares representing Class A ordinary shares,$1.005,-0.025,-2.427%,169071075.00,,2018,319992,Consumer Services,Other Consumer Services
+add,STK,Columbia Seligman Premium Technology Growth Fund Inc,$35.22,0.12,0.342%,561249050.00,United States,2009,20150,,
+add,STL,Sterling Bancorp,$25.83,-0.32,-1.224%,4974839816.00,United States,,1073902,Finance,Major Banks
+add,STL^A,Sterling Bancorp Depositary Shares each representing ownership of a 1/40th interest in a share of 6.50% Non-Cumulative Perpetual Preferred Stock Series A,$26.8722,0.0972,0.363%,,United States,,9147,,
+add,STLA,Stellantis N.V. Common Shares,$20.53,-0.37,-1.77%,64285135698.00,United Kingdom,2014,3720288,,
+add,STM,STMicroelectronics N.V. Common Stock,$37.815,0.725,1.955%,34000227224.00,Switzerland,,1220093,Technology,Semiconductors
+add,STN,Stantec Inc Common Stock,$44.48,0.37,0.839%,4967785629.00,Canada,,29412,Transportation,Marine Transportation
+add,STNG,Scorpio Tankers Inc. Common Shares,$22.37,0.52,2.38%,1305726073.00,Monaco,2010,638850,Transportation,Marine Transportation
+add,STON,StoneMor Inc. Common Stock,$2.44,-0.15,-5.792%,287834334.00,United States,2004,241745,,
+add,STOR,STORE Capital Corporation Common Stock,$36.56,0.52,1.443%,9889245979.00,United States,2014,760436,Consumer Services,Real Estate Investment Trusts
+add,STPC,Star Peak Corp II Class A Common Stock,$9.99,0.01,0.10%,502621875.00,,2021,122935,,
+add,STRE,Supernova Partners Acquisition Company III Ltd. Class A Ordinary Shares,$9.75,0.00,0.00%,344086753.00,,2021,16,,
+add,STT,State Street Corporation Common Stock,$83.84,-0.73,-0.863%,29156891924.00,United States,,1116208,Finance,Investment Managers
+add,STT^D,State Street Corporation Depositary Shares representing 1/4000th Perpetual Preferred Series D,$28.54,-0.04,-0.14%,,United States,,58773,,
+add,STT^G,State Street Corporation Depositary shares each representing a 1/4000th ownership interest in a share of Fixed-to-Floating Rate Non-Cumulative,$29.57,0.00,0.00%,,United States,,33979,,
+add,STWD,STARWOOD PROPERTY TRUST INC. Starwood Property Trust Inc.,$26.655,0.085,0.32%,7649588160.00,United States,2009,1408401,Consumer Services,Real Estate Investment Trusts
+add,STZ,Constellation Brands Inc. Common Stock,$237.46,0.79,0.334%,45790407945.00,United States,,407079,Consumer Non-Durables,Beverages (Production/Distribution)
+add,STZ/B,Constellation Brands Inc,$238.083,0.00,0.00%,,United States,,13,,
+add,SU,Suncor Energy  Inc. Common Stock,$25.005,-0.025,-0.10%,37669637271.00,Canada,,5759988,Energy,Integrated oil Companies
+add,SUI,Sun Communities Inc. Common Stock,$177.59,2.28,1.301%,20134912322.00,United States,1993,206176,Consumer Services,Real Estate Investment Trusts
+add,SUM,Summit Materials Inc. Class A Common Stock,$34.72,-0.58,-1.643%,4074826347.00,United States,2015,455294,Capital Goods,Building Materials
+add,SUN,Sunoco LP Common Units representing limited partner interests,$37.895,0.615,1.65%,3780405693.00,United States,2012,301990,Energy,Oil Refining/Marketing
+add,SUP,Superior Industries International Inc. Common Stock (DE),$8.6039,-0.4961,-5.452%,223249368.00,United States,,230852,Capital Goods,Auto Parts:O.E.M.
+add,SUPV,Grupo Supervielle S.A. American Depositary Shares each Representing five Class B shares,$2.31,0.01,0.435%,211005712.00,,2016,538568,Finance,Commercial Banks
+add,SUZ,Suzano S.A. American Depositary Shares (each representing One Ordinary Share),$11.55,-0.24,-2.036%,15583509249.00,,2018,308716,Basic Industries,Paper
+add,SWBK,Switchback II Corporation Class A Ordinary Shares,$9.92,0.06,0.609%,392150000.00,,2021,237940,Finance,Business Services
+add,SWCH,Switch Inc. Class A Common Stock,$21.295,0.515,2.478%,5144138558.00,,2017,1636768,Technology,EDP Services
+add,SWI,SolarWinds Corporation Common Stock,$17.37,0.63,3.763%,5484252559.00,United States,2018,534613,Technology,Computer Software: Prepackaged Software
+add,SWK,Stanley Black & Decker Inc. Common Stock,$203.89,-2.68,-1.297%,32927168044.00,United States,,571856,Capital Goods,Diversified Manufacture
+add,SWM,Schweitzer-Mauduit International Inc. Common Stock,$40.72,-0.94,-2.256%,1278996021.00,United States,,57518,Basic Industries,Paper
+add,SWN,Southwestern Energy Company Common Stock,$5.58,0.05,0.904%,3777656981.00,United States,,8982471,Energy,Oil & Gas Production
+add,SWT,Stanley Black & Decker Inc. Corporate Unit,$120.75,-1.45,-1.187%,0.00,United States,2019,6414,Capital Goods,Diversified Manufacture
+add,SWX,Southwest Gas Holdings Inc. Common Stock (DE),$67.13,-0.08,-0.119%,3893633713.00,United States,,137884,Public Utilities,Oil & Gas Production
+add,SWZ,Swiss Helvetia Fund Inc. (The) Common Stock,$9.87,0.06,0.612%,130404947.00,United States,,41469,,
+add,SXC,SunCoke Energy Inc. Common Stock,$7.72,0.01,0.13%,640589195.00,United States,2011,956519,,
+add,SXI,Standex International Corporation Common Stock,$96.02,-2.49,-2.528%,1177310438.00,United States,,12878,Capital Goods,Industrial Machinery/Components
+add,SXT,Sensient Technologies Corporation Common Stock,$88.48,-0.09,-0.102%,3740916704.00,United States,,159887,Basic Industries,Major Chemicals
+add,SYF,Synchrony Financial Common Stock,$49.09,-0.98,-1.957%,28550687399.00,United States,2014,2905984,Finance,Diversified Financial Services
+add,SYF^A,Synchrony Financial Depositary Shares each Representing a 1/40th Interest in a Share of 5.625% Fixed Rate Non-Cumulative Perpetual Preferred Stock Series A,$26.72,-0.22,-0.817%,,United States,,88871,,
+add,SYK,Stryker Corporation Common Stock,$256.61,3.48,1.375%,96677269894.00,United States,,561289,Health Care,Medical/Dental Instruments
+add,SYX,Systemax Inc. Common Stock,$33.375,-1.025,-2.98%,1258874929.00,United States,,41501,Technology,Industrial Machinery/Components
+add,SYY,Sysco Corporation Common Stock,$78.9522,-0.5078,-0.639%,40390516406.00,United States,,1209778,Consumer Non-Durables,Food Distributors
+add,SZC,Cushing NextGen Infrastructure Income Fund Common Shares of Beneficial Interest,$49.97,0.34,0.685%,130007649.00,,2012,24965,,
+add,T,AT&T Inc.,$29.25,0.24,0.827%,208845000000.00,United States,,24598842,Consumer Services,Telecommunications Equipment
+add,T^A,AT&T Inc. Depositary Shares each representing a 1/1000th interest in a share of 5.000% Perpetual Preferred Stock Series A,$26.74,0.03,0.112%,,United States,,57921,,
+add,T^C,AT&T Inc. Depositary Shares each representing a 1/1000th interest in a share of 4.750% Perpetual Preferred Stock Series C,$26.09,-0.01,-0.038%,,United States,,104770,,
+add,TAC,TransAlta Corporation Ordinary Shares,$9.72,0.09,0.935%,2623263606.00,Canada,,105786,Public Utilities,Electric Utilities: Central
+add,TACA,Trepont Acquisition Corp I Class A Ordinary Shares,$9.89,0.01,0.101%,284337500.00,United States,2021,3705,Finance,Business Services
+add,TAK,Takeda Pharmaceutical Company Limited American Depositary Shares (each representing 1/2 of a share of Common Stock),$17.37,0.30,1.757%,54763715924.00,,2018,1319422,Health Care,Major Pharmaceuticals
+add,TAL,TAL Education Group American Depositary Shares,$31.175,2.325,8.059%,20104164115.00,China,,31600574,Miscellaneous,Other Consumer Services
+add,TALO,Talos Energy Inc. Common Stock,$16.42,-0.01,-0.061%,1341638693.00,,2018,437664,Energy,Oil & Gas Production
+add,TAP,Molson Coors Beverage Company Class B Common Stock,$60.805,0.065,0.107%,13189645846.00,Canada,,801339,Consumer Non-Durables,Beverages (Production/Distribution)
+add,TARO,Taro Pharmaceutical Industries Ltd. Ordinary Shares,$74.73,1.19,1.618%,2859026094.00,Israel,,51255,Health Care,Major Pharmaceuticals
+add,TBA,Thoma Bravo Advantage Class A Ordinary Shares,$10.275,0.085,0.834%,1309035000.00,,2021,1717954,Finance,Business Services
+add,TBB,AT&T Inc. 5.350% Global Notes due 2066,$26.70,0.06,0.225%,0.00,United States,2017,39253,Consumer Services,Telecommunications Equipment
+add,TBC,AT&T Inc. 5.625% Global Notes due 2067,$27.16,0.059,0.218%,0.00,United States,2018,36246,Public Utilities,Telecommunications Equipment
+add,TBI,TrueBlue Inc. Common Stock,$29.41,0.14,0.478%,1043212080.00,United States,,115114,Technology,Professional Services
+add,TCI,Transcontinental Realty Investors Inc. Common Stock,$30.805,0.295,0.967%,266134129.00,United States,,949,Finance,Real Estate
+add,TCS,Container Store (The) Common Stock,$13.675,-0.145,-1.049%,690471016.00,,2013,561786,Consumer Services,Catalog/Specialty Distribution
+add,TD,Toronto Dominion Bank (The) Common Stock,$72.10,0.00,0.00%,131128270000.00,Canada,,828413,Finance,Commercial Banks
+add,TDA,Telephone and Data Systems Inc. 5.875% Senior Notes due 2061,$25.60,0.13,0.51%,0.00,United States,,9840,Public Utilities,Telecommunications Equipment
+add,TDC,Teradata Corporation Common Stock,$47.78,0.03,0.063%,5236688000.00,United States,,345369,Technology,EDP Services
+add,TDF,Templeton Dragon Fund Inc. Common Stock,$23.60,0.12,0.511%,797777775.00,United States,,21513,,
+add,TDG,Transdigm Group Incorporated Transdigm Group Inc. Common Stock,$660.37,-3.63,-0.547%,36249123813.00,United States,2006,144522,Capital Goods,Military/Government/Technical
+add,TDI,Telephone and Data Systems Inc. Sr Nt,$26.8162,0.2055,0.772%,0.00,United States,,618,Public Utilities,Telecommunications Equipment
+add,TDOC,Teladoc Health Inc. Common Stock,$154.45,4.02,2.672%,23866506258.00,United States,2015,1984243,Health Care,Medical/Nursing Services
+add,TDS,Telephone and Data Systems Inc. Common Shares,$26.22,0.00,0.00%,2999200920.00,United States,,284488,Public Utilities,Telecommunications Equipment
+add,TDS^U,Telephone and Data Systems Inc. Depositary Shares Each Representing a 1/1000th Interest in a 6.625% Series UU Cumulative Redeemable Perpetual Preferred Stock,$28.20,-0.03,-0.106%,,United States,,56248,,
+add,TDW,Tidewater Inc. Common Stock,$14.21,-0.18,-1.251%,580495921.00,United States,2017,56188,Energy,Oilfield Services/Equipment
+add,TDY,Teledyne Technologies Incorporated Common Stock,$421.73,2.96,0.707%,19627468553.00,United States,,132948,Capital Goods,Industrial Machinery/Components
+add,TEAF,Tortoise Essential Assets Income Term Fund Common Shares of Beneficial Interest,$14.96,0.16,1.081%,201827260.00,,2019,21602,,
+add,TECK,Teck Resources Ltd Ordinary Shares,$23.425,0.065,0.278%,12455072500.00,Canada,,4683559,Basic Industries,Precious Metals
+add,TEF,Telefonica SA Common Stock,$5.055,0.155,3.163%,27517067383.00,Spain,1988,1628533,Public Utilities,Telecommunications Equipment
+add,TEI,Templeton Emerging Markets Income Fund Inc. Common Stock,$8.19,0.04,0.491%,393107043.00,United States,1993,349669,,
+add,TEL,TE Connectivity Ltd. New Switzerland Registered Shares,$136.99,1.30,0.958%,45237471516.00,Switzerland,,618226,Capital Goods,Industrial Machinery/Components
+add,TEN,Tenneco Inc. Class A Voting Common Stock,$20.40,0.38,1.898%,1672165886.00,United States,,2036717,Capital Goods,Auto Parts:O.E.M.
+add,TEO,Telecom Argentina SA,$6.47,-0.05,-0.767%,2786872285.00,Argentina,,296520,Public Utilities,Telecommunications Equipment
+add,TEVA,Teva Pharmaceutical Industries Limited American Depositary Shares,$11.485,0.755,7.036%,12596474381.00,Israel,,13327913,Health Care,Major Pharmaceuticals
+add,TEX,Terex Corporation Common Stock,$47.55,-1.90,-3.842%,3318990000.00,United States,,476394,Capital Goods,Construction/Ag Equipment/Trucks
+add,TFC,Truist Financial Corporation Common Stock,$57.915,-0.535,-0.915%,77886708252.00,United States,,5160961,Finance,Major Banks
+add,TFC^I,Truist Financial Corporation Depositary Shares,$26.15,-0.02,-0.076%,,United States,,4657,,
+add,TFC^O,Truist Financial Corporation Depositary Shares Each Representing a 1/1000th Interest in a Share of Series O Non-Cumulative Perpetual Preferred Stock,$27.93,0.03,0.108%,,United States,,24334,,
+add,TFC^R,Truist Financial Corporation Depositary Shares each representing 1/1000th interest in a share of Series R Non-Cumulative Perpetual Preferred Stock,$26.73,-0.01,-0.037%,,United States,,30235,,
+add,TFII,TFI International Inc. Common Shares,$92.82,0.38,0.411%,8654119110.00,,,116766,,
+add,TFSA,Terra Income Fund VI 7.00% Notes due 2026,$25.86,-0.14,-0.538%,0.00,,2021,9916,,
+add,TFX,Teleflex Incorporated Common Stock,$397.595,4.285,1.089%,18580677519.00,United States,,183082,Health Care,Medical/Dental Instruments
+add,TG,Tredegar Corporation Common Stock,$15.21,0.09,0.595%,512233756.00,United States,,101892,Basic Industries,Specialty Chemicals
+add,TGH,Textainer Group Holdings Limited Common Shares,$30.79,-1.49,-4.616%,1542360730.00,Bermuda,2007,563176,Technology,Diversified Commercial Services
+add,TGH^A,Textainer Group Holdings Limited Depositary Shares each representing a 1/1000th interest in a share of 7.000% Series A Cumulative Redeemable Perpetual Preference Shares,$26.25,-0.03,-0.114%,,Bermuda,,3175,,
+add,TGI,Triumph Group Inc. Common Stock,$21.275,0.075,0.354%,1366286074.00,United States,1996,505133,Capital Goods,Military/Government/Technical
+add,TGNA,TEGNA Inc,$19.02,-0.07,-0.367%,4199105313.00,United States,,610311,Consumer Services,Broadcasting
+add,TGP,Teekay LNG Partners L.P.,$15.94,0.04,0.252%,1386780000.00,Bermuda,2005,151951,Transportation,Marine Transportation
+add,TGP^A,Teekay LNG Partners L.P. 9.00% Series A Cumulative Redeemable Perpetual Preferred Units representing limited partner interests,$25.95,-0.09,-0.346%,,Bermuda,,8293,,
+add,TGP^B,Teekay LNG Partners L.P. 8.50% Series B Fixed-to-Floating Rate Cumulative Redeemable Perpetual Preferred Units representing limited partner interests,$27.45,0.00,0.00%,,Bermuda,,17357,,
+add,TGS,Transportadora de Gas del Sur SA TGS Common Stock,$5.60,-0.11,-1.926%,843092382.00,Argentina,,78681,Public Utilities,Natural Gas Distribution
+add,TGT,Target Corporation Common Stock,$232.22,0.28,0.121%,114884768731.00,United States,,1990807,Consumer Services,Department/Specialty Retail Stores
+add,THC,Tenet Healthcare Corporation Common Stock,$68.03,0.34,0.502%,7264947987.00,United States,,458887,Health Care,Hospital/Nursing Management
+add,THG,Hanover Insurance Group Inc,$138.68,-0.29,-0.209%,4978174881.00,United States,,86703,Finance,Property-Casualty Insurers
+add,THO,Thor Industries Inc. Common Stock,$115.775,-0.485,-0.417%,6410026552.00,United States,,1148414,Consumer Non-Durables,Homebuilding
+add,THQ,Tekla Healthcare Opportunies Fund Shares of Beneficial Interest,$23.70,0.01,0.042%,979768570.00,United States,2014,113145,,
+add,THR,Thermon Group Holdings Inc. Common Stock,$17.21,-0.19,-1.092%,572159340.00,United States,2011,71127,Consumer Durables,Electrical Products
+add,THS,Treehouse Foods Inc. Common Stock,$48.66,0.18,0.371%,2735699603.00,United States,,158101,Consumer Non-Durables,Packaged Foods
+add,THW,Tekla World Healthcare Fund Shares of Beneficial Interest,$16.4349,0.2149,1.325%,610990285.00,United States,2015,118874,,
+add,TIMB,TIM S.A. American Depositary Shares (Each representing 5 Common Shares) ,$12.91,0.32,2.542%,6250516948.00,,2020,321994,Public Utilities,Telecommunications Equipment
+add,TINV,Tiga Acquisition Corp. Class A Ordinary Shares,$10.10,-0.01,-0.099%,348450000.00,Singapore,2021,40236,Finance,Business Services
+add,TISI,Team Inc. Common Stock,$8.3899,-0.0801,-0.946%,259194005.00,United States,,62412,,
+add,TIXT,TELUS International (Cda) Inc. Subordinate Voting Shares,$30.805,-0.185,-0.597%,8179100764.00,,2021,30676,,
+add,TJX,TJX Companies Inc. (The) Common Stock,$64.85,-0.18,-0.277%,78240694012.00,United States,,5261313,Consumer Services,Clothing/Shoe/Accessory Stores
+add,TK,Teekay Corporation Common Stock,$3.99,0.04,1.013%,404103669.00,Bermuda,,449213,Transportation,Marine Transportation
+add,TKC,Turkcell Iletisim Hizmetleri AS Common Stock,$4.90,0.09,1.871%,4278888137.00,Turkey,,520948,Public Utilities,Telecommunications Equipment
+add,TKR,Timken Company (The) Common Stock,$85.21,-2.19,-2.506%,6474551734.00,United States,,361405,Capital Goods,Metal Fabrications
+add,TLGA,TLG Acquisition One Corp. Class A Common Stock,$9.71,0.00,0.00%,485500000.00,,2021,4486,,
+add,TLK,PT Telekomunikasi Indonesia Tbk,$25.55,0.47,1.874%,25310396341.00,Indonesia,,225896,Public Utilities,Telecommunications Equipment
+add,TLYS,Tilly's Inc. Common Stock,$16.255,0.245,1.53%,489972092.00,United States,2012,373575,,
+add,TM,Toyota Motor Corporation Common Stock,$180.32,-0.22,-0.122%,252082731186.00,Japan,,147831,Capital Goods,Auto Manufacturing
+add,TMAC,The Music Acquisition Corporation Class A Common Stock,$9.80,-0.02,-0.204%,281750000.00,,2021,278327,,
+add,TME,Tencent Music Entertainment Group American Depositary Shares each representing two Class A Ordinary Shares,$15.775,0.205,1.317%,26700321233.00,,2018,6985750,Consumer Services,Broadcasting
+add,TMHC,Taylor Morrison Home Corporation Common Stock,$27.56,-0.99,-3.468%,3554039982.00,United States,2013,955622,Capital Goods,Homebuilding
+add,TMO,Thermo Fisher Scientific Inc Common Stock,$464.57,16.36,3.65%,182588964999.00,United States,,2090309,Capital Goods,Biotechnology: Laboratory Analytical Instruments
+add,TMST,TimkenSteel Corporation Common Shares,$15.54,-0.15,-0.956%,710217316.00,United States,2014,741240,Basic Industries,Steel/Iron Ore
+add,TMX,Terminix Global Holdings Inc. Common Stock,$50.47,-0.11,-0.217%,6487858138.00,,2014,214197,Miscellaneous,Other Consumer Services
+add,TNC,Tennant Company Common Stock,$82.56,-0.41,-0.494%,1536501621.00,United States,,28369,Capital Goods,Industrial Machinery/Components
+add,TNET,TriNet Group Inc. Common Stock,$72.21,-0.48,-0.66%,4757313947.00,,2014,120661,Technology,Diversified Commercial Services
+add,TNK,Teekay Tankers Ltd.,$15.71,0.26,1.683%,530229498.00,Bermuda,2007,263555,Transportation,Marine Transportation
+add,TNL,Travel   Leisure Co. Common  Stock,$63.17,-0.16,-0.253%,5444180805.00,United States,,164625,Transportation,Other Consumer Services
+add,TNP,Tsakos Energy Navigation Ltd Common Shares,$9.00,0.07,0.784%,163762290.00,Greece,2002,139619,Transportation,Marine Transportation
+add,TNP^D,Tsakos Energy Navigation Ltd 8.75% Series D Cumulative Redeemable Perpetual Preferred Shares,$24.8102,0.0302,0.122%,,Greece,,5525,,
+add,TNP^E,Tsakos Energy Navigation Ltd Series E Fixed-to-Floating Rate Cumulative Redeemable Perpetual Preferred Shares par value $1.00,$24.93,0.005,0.02%,,Greece,,8649,,
+add,TNP^F,Tsakos Energy Navigation Ltd Series F Fixed-to-Floating Rate Cumulative Redeemable Perpetual Preferred Shares par value $1.00,$24.96,-0.02,-0.08%,,Greece,,6499,,
+add,TOL,Toll Brothers Inc. Common Stock,$58.97,-2.88,-4.656%,7275482720.00,United States,,2167453,Capital Goods,Homebuilding
+add,TOT,Total SE,$48.34,-0.25,-0.515%,127118015333.00,France,,3141559,Energy,Oil & Gas Production
+add,TPB,Turning Point Brands Inc. Common Stock,$45.065,0.195,0.435%,858914069.00,United States,2016,97966,Consumer Non-Durables,Tobacco
+add,TPC,Tutor Perini Corporation Common Stock,$15.002,-0.468,-3.025%,764165980.00,United States,,400294,Capital Goods,Engineering & Construction
+add,TPGS,TPG Pace Solutions Corp. Class A Ordinary Shares,$10.15,0.045,0.445%,385700000.00,,2021,109501,Finance,Business Services
+add,TPGY,TPG Pace Beneficial Finance Corp. Class A Ordinary Shares,$12.80,-0.46,-3.469%,576800000.00,United States,2020,452910,Finance,Business Services
+add,TPH,Tri Pointe Homes Inc. Common Stock,$21.715,-0.875,-3.873%,2571582415.00,United States,2013,765035,Capital Goods,Homebuilding
+add,TPL,Texas Pacific Land Corporation Common Stock,$1496.33,-25.67,-1.687%,11605768907.00,United States,,33395,Energy,Oil & Gas Production
+add,TPR,Tapestry Inc. Common Stock,$42.785,-0.635,-1.462%,11930953692.00,United States,,2206174,Consumer Non-Durables,Apparel
+add,TPVG,TriplePoint Venture Growth BDC Corp. Common Stock,$16.56,0.32,1.97%,511987391.00,,2014,181523,,
+add,TPX,Tempur Sealy International Inc. Common Stock,$38.48,-0.48,-1.232%,7578687602.00,United States,2003,1919671,Consumer Durables,Home Furnishings
+add,TPZ,Tortoise Power and Energy Infrastructure Fund Inc Common Stock,$13.90,0.09,0.652%,92235521.00,United States,2009,18986,,
+add,TR,Tootsie Roll Industries Inc. Common Stock,$34.28,-0.58,-1.664%,2321698666.00,United States,,241032,Consumer Non-Durables,Specialty Foods
+add,TRC,Tejon Ranch Co Common Stock,$15.27,0.12,0.792%,402270803.00,United States,,42988,Finance,Major Banks
+add,TRCA,Twin Ridge Capital Acquisition Corp. Class A Ordinary Shares,$9.75,-0.02,-0.205%,259701156.00,,2021,11532,,
+add,TREB,Trebia Acquisition Corp. Class A Ordinary Shares,$9.93,0.01,0.101%,642346875.00,United States,2020,16516,Finance,Business Services
+add,TREC,Trecora Resources Common Stock,$8.49,0.02,0.236%,211192418.00,United States,,45992,,
+add,TREX,Trex Company Inc. Common Stock,$98.68,0.86,0.879%,11383919200.00,United States,,771038,,
+add,TRGP,Targa Resources Inc. Common Stock,$46.65,1.44,3.185%,10666736624.00,United States,2010,2052143,Public Utilities,Natural Gas Distribution
+add,TRI,Thomson Reuters Corp Ordinary Shares,$97.955,0.625,0.642%,48551843796.00,United States,,221726,,
+add,TRN,Trinity Industries Inc. Common Stock,$29.555,-0.025,-0.085%,3231416495.00,United States,,698723,Capital Goods,Railroads
+add,TRNO,Terreno Realty Corporation Common Stock,$66.44,0.50,0.758%,4621746785.00,United States,2010,199530,Consumer Services,Real Estate Investment Trusts
+add,TROX,Tronox Holdings plc Ordinary Shares (UK),$22.94,-0.53,-2.258%,3515796558.00,United States,,540732,Basic Industries,Multi-Sector Companies
+add,TRP,TC Energy Corporation Common Stock,$53.09,-0.12,-0.226%,51975110000.00,Canada,,861642,,
+add,TRQ,Turquoise Hill Resources Ltd. Ordinary Shares,$17.05,0.35,2.096%,3430996154.00,Canada,,614139,,
+add,TRTN,Triton International Limited Common Shares,$50.41,-1.18,-2.287%,3396222923.00,,2016,468069,Technology,Diversified Commercial Services
+add,TRTN^A,Triton International Limited 8.50% Series A Cumulative Redeemable Perpetual  Preference Shares,$27.8044,-0.1056,-0.378%,,,,3040,,
+add,TRTN^B,Triton International Limited 8.00% Series B Cumulative Redeemable Perpetual Preference Shares,$27.9674,0.2474,0.892%,,,,4341,,
+add,TRTN^C,Triton International Limited 7.375% Series C Cumulative Redeemable Perpetual Preference Shares,$27.33,-0.065,-0.237%,,,,4150,,
+add,TRTN^D,Triton International Limited 6.875% Series D Cumulative Redeemable Perpetual Preference Shares,$26.505,0.025,0.094%,,,,5104,,
+add,TRTX,TPG RE Finance Trust Inc. Common Stock,$13.90,-0.28,-1.975%,1068869718.00,United States,2017,129811,Consumer Services,Real Estate Investment Trusts
+add,TRU,TransUnion Common Stock,$106.10,0.63,0.597%,20294025725.00,United States,2015,580631,Technology,Advertising
+add,TRV,The Travelers Companies Inc. Common Stock,$154.32,-0.42,-0.271%,38806120003.00,United States,,580378,Finance,Property-Casualty Insurers
+add,TS,Tenaris S.A. American Depositary Shares,$23.02,-0.04,-0.173%,13587978913.00,Luxembourg,,1056805,Basic Industries,Steel/Iron Ore
+add,TSE,Trinseo S.A. Ordinary Shares,$63.91,-0.96,-1.48%,2475812174.00,,2014,219740,Basic Industries,Major Chemicals
+add,TSI,TCW Strategic Income Fund Inc. Common Stock,$5.915,0.075,1.284%,282432017.00,United States,,66072,,
+add,TSLX,Sixth Street Specialty Lending Inc. Common Stock,$22.55,-0.12,-0.529%,1637553015.00,,2014,374818,Finance,Investment Managers
+add,TSM,Taiwan Semiconductor Manufacturing Company Ltd.,$118.0997,0.9697,0.828%,612474019777.00,Taiwan,1997,7547487,Technology,Semiconductors
+add,TSN,Tyson Foods Inc. Common Stock,$77.07,-0.33,-0.426%,28113843767.00,United States,,860218,Consumer Non-Durables,Meat/Poultry/Fish
+add,TSPQ,TCW Special Purpose Acquisition Corp. Class A Common Stock,$9.75,0.00,0.00%,565418334.00,,2021,13,,
+add,TSQ,Townsquare Media Inc. Class A Common Stock,$14.00,0.22,1.597%,228566646.00,United States,2014,55600,Technology,Advertising
+add,TT,Trane Technologies plc,$183.88,1.59,0.872%,43974443587.00,Ireland,,786328,Capital Goods,Auto Parts:O.E.M.
+add,TTC,Toro Company (The) Common Stock,$106.06,-0.14,-0.132%,11355146537.00,United States,,394354,Capital Goods,Tools/Hardware
+add,TTI,Tetra Technologies Inc. Common Stock,$3.76,-0.10,-2.591%,475968970.00,United States,,845162,Energy,Oil & Gas Production
+add,TTM,Tata Motors Ltd Tata Motors Limited,$23.485,0.065,0.278%,17983923670.00,India,,519317,Capital Goods,Auto Manufacturing
+add,TTP,Tortoise Pipeline & Energy Fund Inc. Common Stock,$25.13,0.46,1.865%,57282151.00,United States,2011,26024,,
+add,TU,Telus Corporation Ordinary Shares,$22.68,0.00,0.00%,30731400000.00,Canada,,835953,Public Utilities,Telecommunications Equipment
+add,TUFN,Tufin Software Technologies Ltd. Ordinary Shares,$9.69,0.18,1.893%,356308790.00,,2019,465589,Technology,EDP Services
+add,TUP,Tupperware Brands Corporation Common Stock,$24.02,-0.74,-2.989%,1192990819.00,United States,,450954,Consumer Non-Durables,Plastic Products
+add,TUYA,Tuya Inc. American Depositary Shares each representing one Class A Ordinary Share,$22.83,-1.60,-6.549%,12779322649.00,,2021,593758,Technology,Computer Software: Prepackaged Software
+add,TV,Grupo Televisa S.A. Common Stock,$14.46,-0.12,-0.823%,8046152347.00,Mexico,1993,2362735,Consumer Services,Broadcasting
+add,TVC,Tennessee Valley Authority Common Stock,$26.4063,-0.0302,-0.114%,0.00,United States,,6774,Public Utilities,Electric Utilities: Central
+add,TVE,Tennessee Valley Authority,$25.78,-0.20,-0.77%,0.00,United States,,8209,Public Utilities,Electric Utilities: Central
+add,TWI,Titan International Inc. (DE) Common Stock,$9.34,-0.33,-3.413%,575640498.00,United States,,286230,Capital Goods,Industrial Machinery/Components
+add,TWLO,Twilio Inc. Class A Common Stock,$324.465,9.855,3.132%,56033735284.00,United States,2016,1189569,Capital Goods,Industrial Machinery/Components
+add,TWN,Taiwan Fund Inc. (The) Common Stock,$32.65,0.36,1.115%,243858475.00,United States,1986,9788,,
+add,TWND,Tailwind Acquisition Corp. Class A Common Stock,$9.93,0.01,0.101%,414845233.00,,2020,50103,,
+add,TWNI,Tailwind International Acquisition Corp. Class A Ordinary Shares,$9.73,0.02,0.206%,419606250.00,,2021,3801,Finance,Business Services
+add,TWNT,Tailwind Two Acquisition Corp. Class A Ordinary Shares,$9.75,0.00,0.00%,0.00,,2021,605,,
+add,TWO,Two Harbors Investment Corp,$7.603,-0.077,-1.003%,2081122766.00,United States,,1708684,Consumer Services,Real Estate Investment Trusts
+add,TWO^A,Two Harbors Investments Corp 8.125% Series A Fixed-to-Floating Rate Cumulative Redeemable Preferred Stock ($25.00 liquidation preference per share),$26.35,-0.0599,-0.227%,,United States,,1342,,
+add,TWO^B,Two Harbors Investments Corp 7.625% Series B Fixed-to-Floating Rate Cumulative Redeemable Preferred Stock,$25.57,0.08,0.314%,,United States,,6756,,
+add,TWO^C,Two Harbors Investments Corp 7.25% Series C Fixed-to-Floating Rate Cumulative Redeemable Preferred Stock,$24.77,-0.01,-0.04%,,United States,,26518,,
+add,TWOA,two Class A Ordinary Shares,$9.97,-0.02,-0.20%,326891375.00,,2021,1995,Consumer Services,Real Estate Investment Trusts
+add,TWTR,Twitter Inc. Common Stock,$60.30,0.59,0.988%,48127035849.00,,2013,7260587,Technology,EDP Services
+add,TX,Ternium S.A. Ternium S.A. American Depositary Shares (each representing ten shares USD1.00 par value),$37.44,0.18,0.483%,7349759427.00,Luxembourg,,333955,Basic Industries,Steel/Iron Ore
+add,TXT,Textron Inc. Common Stock,$68.29,-0.77,-1.115%,15413659074.00,United States,,682890,Capital Goods,Aerospace
+add,TY,Tri Continental Corporation Common Stock,$34.85,0.09,0.259%,1816255007.00,United States,,19059,,
+add,TY^,Tri Continental Corporation Preferred Stock,$57.10,0.112,0.197%,,United States,,2799,,
+add,TYG,Tortoise Energy Infrastructure Corporation Common Stock,$30.49,0.71,2.384%,363681762.00,United States,2004,75551,,
+add,TYL,Tyler Technologies Inc. Common Stock,$424.50,8.19,1.967%,17293578999.00,United States,,130131,Technology,Computer Software: Prepackaged Software
+add,U,Unity Software Inc. Common Stock,$100.68,2.02,2.047%,28131737590.00,United States,2020,2307245,Technology,Retail: Computer Software & Peripheral Equipment
+add,UA,Under Armour Inc. Class C Common Stock,$18.295,-0.325,-1.745%,8360652449.00,United States,2016,4639101,Consumer Non-Durables,Apparel
+add,UAA,Under Armour Inc. Class A Common Stock,$21.135,-0.265,-1.238%,9658507216.00,United States,,3251535,Consumer Non-Durables,Apparel
+add,UAN,CVR Partners LP Common Units representing Limited Partner Interests,$66.63,-0.87,-1.289%,711697151.00,United States,2011,32067,Basic Industries,Agricultural Chemicals
+add,UBA,Urstadt Biddle Properties Inc. Common Stock,$19.63,-0.11,-0.557%,790731636.00,United States,,70840,Consumer Services,Real Estate Investment Trusts
+add,UBER,Uber Technologies Inc. Common Stock,$49.655,0.515,1.048%,92942246276.00,,2019,11435948,Technology,EDP Services
+add,UBP,Urstadt Biddle Properties Inc. Common Stock,$15.895,0.0516,0.326%,640279132.00,United States,,5593,Consumer Services,Real Estate Investment Trusts
+add,UBP^H,Urstadt Biddle Properties Inc. 6.250% Series H Cumulative Redeemable Preferred Stock,$26.32,-0.08,-0.303%,,United States,,1965,,
+add,UBP^K,Urstadt Biddle Properties Inc. 5.875% Series K Cumulative Redeemable Preferred Stock,$26.235,0.215,0.826%,,United States,,3500,,
+add,UBS,UBS Group AG Registered Ordinary Shares,$16.20,-0.07,-0.43%,57074992303.00,Switzerland,2014,1652160,Finance,Major Banks
+add,UDR,UDR Inc. Common Stock,$50.16,0.49,0.987%,14889223686.00,United States,,844927,Consumer Services,Real Estate Investment Trusts
+add,UE,Urban Edge Properties Common Shares of Beneficial Interest,$20.175,-0.025,-0.124%,2361005381.00,United States,2015,216807,Consumer Services,Real Estate Investment Trusts
+add,UFI,Unifi Inc. New Common Stock,$25.08,0.28,1.129%,463737677.00,United States,,60894,,
+add,UFS,Domtar Corporation (NEW) Common Stock,$54.60,0.11,0.202%,2746896461.00,Canada,,434389,Basic Industries,Paper
+add,UGI,UGI Corporation Common Stock,$47.60,-0.26,-0.543%,9937792959.00,United States,,402881,Public Utilities,Natural Gas Distribution
+add,UGIC,UGI Corporation Corporate Units,$107.50,-0.6101,-0.564%,0.00,United States,2021,660,Public Utilities,Natural Gas Distribution
+add,UGP,Ultrapar Participacoes S.A. (New) American Depositary Shares (Each representing one Common Share),$4.085,-0.025,-0.608%,4444937173.00,Brazil,,2143351,Energy,Oil Refining/Marketing
+add,UHS,Universal Health Services Inc. Common Stock,$159.88,0.41,0.257%,13626478870.00,United States,,420263,Health Care,Hospital/Nursing Management
+add,UHT,Universal Health Realty Income Trust Common Stock,$72.05,-1.10,-1.504%,992280670.00,United States,,23058,Consumer Services,Real Estate Investment Trusts
+add,UI,Ubiquiti Inc. Common Stock,$321.45,5.57,1.763%,20191600803.00,United States,,48831,Technology,Radio And Television Broadcasting And Communications Equipment
+add,UIS,Unisys Corporation New Common Stock,$26.79,-0.34,-1.253%,1795532775.00,United States,,222332,Technology,EDP Services
+add,UL,Unilever PLC Common Stock,$60.515,0.575,0.959%,158433635744.00,United Kingdom,,1391852,Consumer Non-Durables,Farming/Seeds/Milling
+add,UMC,United Microelectronics Corporation (NEW) Common Stock,$9.48,0.26,2.82%,23552114825.00,Taiwan,,5689276,Technology,Semiconductors
+add,UMH,UMH Properties Inc. Common Stock,$22.89,-0.07,-0.305%,1034110594.00,United States,,191117,Consumer Services,Real Estate Investment Trusts
+add,UMH^C,UMH Properties Inc. 6.75% Series C Cumulative Redeemable Preferred Stock  Liquidation Preference $25 per share,$26.10,-0.0188,-0.072%,,United States,,4951,,
+add,UMH^D,UMH Properties Inc. 6.375% Series D Cumulative Redeemable Preferred Stock Liquidation Preference $25 per share,$26.06,-0.04,-0.153%,,United States,,5235,,
+add,UNF,Unifirst Corporation Common Stock,$225.86,2.56,1.146%,4264195242.00,United States,,27339,Miscellaneous,Business Services
+add,UNFI,United Natural Foods Inc. Common Stock,$34.75,0.49,1.43%,1956287251.00,United States,2019,1769228,Consumer Non-Durables,Food Distributors
+add,UNH,UnitedHealth Group Incorporated Common Stock (DE),$401.48,0.38,0.095%,378877527138.00,United States,,2742930,Health Care,Medical Specialities
+add,UNM,Unum Group Common Stock,$30.47,-0.50,-1.614%,6223208401.00,United States,,999871,Finance,Accident &Health Insurance
+add,UNMA,Unum Group 6.250% Junior Subordinated Notes due 2058,$26.64,-0.12,-0.448%,0.00,United States,2018,28124,Finance,Accident &Health Insurance
+add,UNP,Union Pacific Corporation Common Stock,$219.9088,-1.5912,-0.718%,146085970230.00,United States,,2472458,Transportation,Railroads
+add,UNVR,Univar Solutions Inc. Common Stock,$27.22,-0.33,-1.198%,4616161080.00,United States,2015,550605,Basic Industries,Specialty Chemicals
+add,UPH,UpHealth Inc.,$10.01,0.63,6.716%,198321273.00,,2019,159973,,
+add,UPS,United Parcel Service Inc. Common Stock,$202.97,1.91,0.95%,176692003446.00,United States,1999,4093485,Transportation,Air Freight/Delivery Services
+add,URI,United Rentals Inc. Common Stock,$303.755,-10.955,-3.481%,21985222523.00,United States,1997,848076,Technology,Diversified Commercial Services
+add,USA,Liberty All-Star Equity Fund Common Stock,$8.785,-0.025,-0.284%,1907150444.00,United States,1986,681974,,
+add,USAC,USA Compression Partners LP Common Units Representing Limited Partner Interests,$15.8297,0.0497,0.315%,1535833744.00,United States,2013,129473,Energy,Oilfield Services/Equipment
+add,USB,U.S. Bancorp Common Stock,$58.74,-0.51,-0.861%,87503682313.00,United States,,3530199,Finance,Major Banks
+add,USB^A,U.S. Bancorp Depositary Shares Each representing a 1/100th interest in a share of Series A Non-CumulativePerpetual Pfd Stock,$955.00,8.94,0.945%,,United States,,611,,
+add,USB^H,U.S. Bancorp Depositary Shares repstg 1/1000th Pfd Ser B,$24.80,-0.06,-0.241%,,United States,,77803,,
+add,USB^M,U.S. Bancorp Depositary Shares Representing 1/1000th Interest in a Shares Series F,$26.17,-0.02,-0.076%,,United States,,51419,,
+add,USB^P,U.S. Bancorp Depositary Shares each representing a 1/1000th interest in a share of Series K Non-Cumulative Perpetual Preferred Stock,$28.45,-0.01,-0.035%,,United States,,35235,,
+add,USB^Q,U.S. Bancorp Depositary Shares Each Representing a 1/1000th Interest in a Share of Series L Non-Cumulative Perpetual Preferred Stock,$24.79,-0.01,-0.04%,,United States,,45888,,
+add,USB^R,U.S. Bancorp Depositary Shares Each Representing a 1/1000th Interest in a Share of Series M Non-Cumulative Perpetual Preferred Stock,$25.44,-0.03,-0.118%,,United States,,99768,,
+add,USDP,USD Partners LP Common Units representing limited partner interest,$6.69,0.15,2.294%,185216510.00,United States,2014,108233,Transportation,Railroads
+add,USFD,US Foods Holding Corp. Common Stock,$39.31,0.34,0.872%,8723344603.00,United States,2016,481134,Consumer Non-Durables,Food Distributors
+add,USM,United States Cellular Corporation Common Stock,$39.65,0.02,0.05%,3412183840.00,United States,1988,68309,Public Utilities,Telecommunications Equipment
+add,USNA,USANA Health Sciences Inc. Common Stock,$103.765,0.265,0.256%,2099860449.00,United States,,28655,Consumer Durables,Specialty Chemicals
+add,USPH,U.S. Physical Therapy Inc. Common Stock,$117.94,-1.81,-1.511%,1521021702.00,United States,1992,17919,Health Care,Medical Specialities
+add,USX,U.S. Xpress Enterprises Inc. Class A Common Stock,$10.38,-0.59,-5.378%,521498113.00,United States,2018,106024,Transportation,Trucking Freight/Courier Services
+add,UTF,Cohen & Steers Infrastructure Fund Inc Common Stock,$29.17,-0.05,-0.171%,2731408880.00,United States,2004,138563,,
+add,UTI,Universal Technical Institute Inc Common Stock,$5.76,-0.04,-0.69%,189007747.00,United States,2003,37781,,
+add,UTL,UNITIL Corporation Common Stock,$56.66,-0.50,-0.875%,852318135.00,United States,,71680,Public Utilities,Power Generation
+add,UTZ,Utz Brands Inc Class A Common Stock ,$23.66,-0.61,-2.513%,3238227107.00,United States,2018,300348,Consumer Non-Durables,Specialty Foods
+add,UVE,UNIVERSAL INSURANCE HOLDINGS INC Common Stock,$14.10,-0.01,-0.071%,440144627.00,United States,,82418,Finance,Property-Casualty Insurers
+add,UVV,Universal Corporation Common Stock,$57.00,-0.04,-0.07%,1397347419.00,United States,,44287,Consumer Non-Durables,Tobacco
+add,UWMC,UWM Holdings Corporation Class A Common Stock,$9.70,-0.26,-2.61%,1000149589.00,United States,,14615679,,
+add,UZA,United States Cellular Corporation 6.95% Senior Notes due 2060,$25.72,0.01,0.039%,0.00,United States,,22974,Public Utilities,Telecommunications Equipment
+add,UZC,United States Cellular Corporation 7.25% Senior Notes due 2064,$25.0699,0.0099,0.04%,0.00,United States,2015,7887,Public Utilities,Telecommunications Equipment
+add,UZD,United States Cellular Corporation 6.250% Senior Notes due 2069,$26.85,-0.08,-0.297%,0.00,United States,2020,36814,Public Utilities,Telecommunications Equipment
+add,UZE,United States Cellular Corporation 5.500% Senior Notes due 2070,$25.68,0.02,0.078%,0.00,United States,2020,59649,Public Utilities,Telecommunications Equipment
+add,UZF,United States Cellular Corporation 5.500% Senior Notes due 2070,$25.32,0.03,0.119%,0.00,United States,2021,227879,Public Utilities,Telecommunications Equipment
+add,V,Visa Inc.,$233.67,1.36,0.585%,498369823029.00,United States,,3206732,Miscellaneous,Business Services
+add,VAC,Marriott Vacations Worldwide Corporation Common Stock,$170.59,-1.05,-0.612%,7283367003.00,United States,,168590,Consumer Services,Hotels/Resorts
+add,VAL,Valaris Limited Common Shares,$28.04,-0.20,-0.708%,5593425285.00,,2021,266175,Energy,Oil & Gas Production
+add,VALE,VALE S.A.  American Depositary Shares Each Representing one common share,$22.28,0.13,0.587%,114072624337.00,Brazil,,33031344,Basic Industries,Steel/Iron Ore
+add,VAPO,Vapotherm Inc. Common Stock,$22.06,0.78,3.665%,571609786.00,United States,2018,144305,Health Care,Medical/Dental Instruments
+add,VBF,Invesco Bond Fund Common Stock,$20.25,0.24,1.199%,231164928.00,United States,,34523,,
+add,VCIF,Vertical Capital Income Fund Common Shares of Beneficial Interest,$10.67,0.02,0.188%,110754632.00,,2019,5756,,
+add,VCRA,Vocera Communications Inc. Common Stock,$36.77,0.83,2.309%,1263661721.00,United States,2012,234195,Capital Goods,Telecommunications Equipment
+add,VCV,Invesco California Value Municipal Income Trust Common Stock,$13.80,-0.02,-0.145%,660541609.00,United States,,55676,,
+add,VEC,Vectrus Inc. Common Stock,$49.63,1.30,2.69%,581713379.00,United States,2014,51201,,
+add,VEDL,Vedanta Limited  American Depositary Shares (Each representing four equity shares),$14.79,0.09,0.612%,13744334562.00,,2013,530178,Capital Goods,Metal Fabrications
+add,VEEV,Veeva Systems Inc. Class A Common Stock,$295.305,4.665,1.605%,45157824437.00,,2013,475342,Health Care,Managed Health Care
+add,VEI,Vine Energy Inc. Class A Common Stock,$15.27,0.17,1.126%,1149208839.00,,2021,240462,Energy,Oil & Gas Production
+add,VEL,Velocity Financial Inc. Common Stock,$13.315,0.065,0.491%,273856183.00,,2020,40565,Finance,Finance: Consumer Services
+add,VER,VEREIT Inc. Common Stock,$49.29,0.01,0.02%,11293815433.00,United States,,1155458,Consumer Services,Real Estate Investment Trusts
+add,VER^F,VEREIT Inc. 6.70% Series F Cumulative Redeemable Preferred Stock,$25.54,0.10,0.393%,,United States,,10846,,
+add,VET,Vermilion Energy Inc. Common (Canada),$8.6501,0.1101,1.289%,1378384785.00,Canada,,1255613,Energy,Oil & Gas Production
+add,VFC,V.F. Corporation Common Stock,$78.7699,0.3099,0.395%,30889766263.00,United States,,2651449,Consumer Non-Durables,Apparel
+add,VGAC,VG Acquisition Corp. Class A Ordinary Shares,$11.125,0.955,9.39%,707202344.00,,2020,5909918,Capital Goods,Industrial Machinery/Components
+add,VGI,Virtus Global Multi-Sector Income Fund Common Shares of Beneficial Interest,$11.9495,-0.1305,-1.08%,135119067.00,United States,2012,114711,,
+add,VGII,Virgin Group Acquisition Corp. II Class A Ordinary Shares,$9.90,0.11,1.124%,498093750.00,,2021,6664,,
+add,VGM,Invesco Trust for Investment Grade Municipals Common Stock (DE),$13.9499,0.0099,0.071%,756437457.00,United States,,48429,,
+add,VGR,Vector Group Ltd. Common Stock,$14.495,-0.165,-1.126%,2235051147.00,United States,,283583,Consumer Non-Durables,Farming/Seeds/Milling
+add,VHC,VirnetX Holding Corp Common Stock,$4.795,-0.215,-4.291%,340725843.00,United States,,350617,Miscellaneous,Multi-Sector Companies
+add,VHI,Valhi Inc. Common Stock,$27.65,-0.01,-0.036%,781751021.00,United States,,10359,Basic Industries,Multi-Sector Companies
+add,VIAO,VIA optronics AG American Depositary Shares each representing one-fifth of an Ordinary Share,$13.265,0.685,5.445%,300498744.00,,2020,6383,Technology,Semiconductors
+add,VICI,VICI Properties Inc. Common Stock,$32.815,0.165,0.505%,17622200024.00,,2018,1501807,Consumer Services,Real Estate Investment Trusts
+add,VIPS,Vipshop Holdings Limited American Depositary Shares each representing two ordinary shares,$22.225,-0.025,-0.112%,15282193147.00,China,2012,5472872,Consumer Services,Catalog/Specialty Distribution
+add,VIST,Vista Oil & Gas S.A.B. de C.V. American Depositary Shares each representing one series A share with no par value,$3.87,-0.08,-2.025%,340089621.00,,2019,352881,Energy,Oil & Gas Production
+add,VIV,Telefonica Brasil S.A. American Depositary Shares (Each representing One Common Share),$9.40,0.32,3.524%,15852752867.00,Brazil,2020,1059251,Public Utilities,Telecommunications Equipment
+add,VKQ,Invesco Municipal Trust Common Stock,$13.63,-0.02,-0.147%,754014694.00,United States,,48989,,
+add,VLO,Valero Energy Corporation Common Stock,$82.22,0.29,0.354%,33608260766.00,United States,,2177298,Energy,Integrated oil Companies
+add,VLRS,Controladora Vuela Compania de Aviacion S.A.B. de C.V. American Depositary Shares each representing ten (10) Ordinary Participation Certificates,$17.37,0.19,1.106%,1992263388.00,,2013,425228,Transportation,Air Freight/Delivery Services
+add,VLT,Invesco High Income Trust II,$14.61,-0.01,-0.068%,94888195.00,United States,1989,6991,,
+add,VMC,Vulcan Materials Company (Holding Company) Common Stock,$173.67,-4.95,-2.771%,23039973446.00,United States,,1041746,,
+add,VMI,Valmont Industries Inc. Common Stock,$234.26,-6.42,-2.667%,4977856099.00,United States,,102132,Capital Goods,Diversified Manufacture
+add,VMO,Invesco Municipal Opportunity Trust Common Stock,$13.66,-0.02,-0.146%,920882439.00,United States,,92570,,
+add,VMW,Vmware Inc. Common stock Class A,$163.43,1.43,0.883%,68465890552.00,United States,2007,892014,Technology,Computer Software: Prepackaged Software
+add,VNCE,Vince Holding Corp. Common Stock,$13.0924,0.0424,0.325%,154657903.00,,2013,43498,,
+add,VNE,Veoneer Inc. Common Stock ,$24.725,-0.285,-1.14%,2763961539.00,,2018,159192,,
+add,VNO,Vornado Realty Trust Common Stock,$50.26,0.05,0.10%,9623013711.00,United States,,724782,Consumer Services,Real Estate Investment Trusts
+add,VNO^K,Vornado Realty Trust Pfd S K,$26.081,-0.069,-0.264%,,United States,,12887,,
+add,VNO^L,Vornado Realty Trust Pfd Ser L %,$25.80,-0.17,-0.655%,,United States,,13754,,
+add,VNO^M,Vornado Realty Trust 5.25% Series M Cumulative Redeemable Preferred Shares of Beneficial Interest liquidation preference $25.00 per share no par value per share,$26.68,0.01,0.037%,,United States,,17429,,
+add,VNO^N,Vornado Realty Trust 5.25% Series N Cumulative Redeemable Preferred Shares of Beneficial Interest liquidation preference $25.00 per share,$26.82,0.09,0.337%,,United States,,4518,,
+add,VNT,Vontier Corporation Common Stock ,$35.02,0.54,1.566%,5911304454.00,,2020,769992,Capital Goods,Industrial Machinery/Components
+add,VNTR,Venator Materials PLC Ordinary Shares,$4.80,0.00,0.00%,514836509.00,,2017,488991,Basic Industries,Major Chemicals
+add,VOC,VOC Energy Trust Units of Beneficial Interest,$4.12,0.01,0.243%,70040000.00,United States,2011,24848,Energy,Oil & Gas Production
+add,VOYA,Voya Financial Inc. Common Stock,$64.08,-0.24,-0.373%,7768497923.00,United States,2013,542706,Finance,Investment Managers
+add,VOYA^B,Voya Financial Inc. Depositary Shares each representing a 1/40th interest in a share of 5.35% Fixed-Rate Reset Non-Cumulative Preferred Stock Series B,$28.10,-0.04,-0.142%,,United States,,43064,,
+add,VPCC,VPC Impact Acquisition Holdings III Inc. Class A Common Stock,$9.91,0.01,0.101%,314352613.00,,2021,179355,Finance,Business Services
+add,VPG,Vishay Precision Group Inc. Common Stock,$35.64,-0.26,-0.724%,485063180.00,United States,,29284,Capital Goods,Industrial Machinery/Components
+add,VPV,Invesco Pennsylvania Value Municipal Income Trust Common Stock (DE),$13.37,0.04,0.30%,318601003.00,United States,,23000,,
+add,VRS,Verso Corporation Common Stock,$16.99,-0.54,-3.08%,554729786.00,United States,2016,474786,Basic Industries,Paper
+add,VRT,Vertiv Holdings LLC Class A Common Stock,$26.005,-0.255,-0.971%,9159130683.00,United States,2018,1876999,Consumer Durables,Electrical Products
+add,VRTV,Veritiv Corporation Common Stock,$61.87,-2.31,-3.599%,954056931.00,,2014,126186,,
+add,VSH,Vishay Intertechnology Inc. Common Stock,$23.0925,-0.1975,-0.848%,3343975969.00,United States,,629376,Capital Goods,Industrial Machinery/Components
+add,VST,Vistra Corp. Common Stock,$18.195,-0.085,-0.465%,8770991053.00,,,2603616,Public Utilities,Power Generation
+add,VSTO,Vista Outdoor Inc. Common Stock,$42.07,-0.62,-1.452%,2429369466.00,United States,2015,474959,Consumer Non-Durables,Recreational Products/Toys
+add,VTA,Invesco Credit Opportunities Fund Common Shares of Beneficial Interest,$11.735,0.015,0.128%,739071955.00,,2007,139912,,
+add,VTN,Invesco Trust for Investment Grade New York Municipals Common Stock,$13.79,0.01,0.073%,268598214.00,United States,,36895,,
+add,VTOL,Bristow Group Inc. Common Stock,$25.53,-0.31,-1.20%,758054708.00,United States,,147010,Energy,Metal Fabrications
+add,VTR,Ventas Inc. Common Stock,$57.70,0.00,0.00%,21645614178.00,United States,,823795,Consumer Services,Real Estate Investment Trusts
+add,VVI,Viad Corp Common Stock,$48.31,-1.51,-3.031%,989577934.00,United States,,98297,Miscellaneous,Business Services
+add,VVNT,Vivint Smart Home Inc. ,$14.65,-0.14,-0.947%,3057028187.00,,2017,242862,Miscellaneous,Diversified Manufacture
+add,VVR,Invesco Senior Income Trust Common Stock (DE),$4.32,0.02,0.465%,661092780.00,United States,1998,394520,Finance,Trusts Except Educational Religious and Charitable
+add,VVV,Valvoline Inc. Common Stock,$34.00,-0.20,-0.585%,6156636428.00,United States,2016,390882,Basic Industries,Automotive Aftermarket
+add,VYGG,Vy Global Growth Class A Ordinary Shares,$9.98,-0.05,-0.499%,612558897.00,Cayman Islands,2020,116680,Finance,Business Services
+add,VZIO,VIZIO Holding Corp. Class A Common Stock,$21.90,-0.05,-0.228%,4028879797.00,,2021,126605,Consumer Non-Durables,Consumer Electronics/Appliances
+add,W,Wayfair Inc. Class A Common Stock,$328.03,4.53,1.40%,34180495395.00,United States,2014,584693,Consumer Services,Catalog/Specialty Distribution
+add,WAB,Westinghouse Air Brake Technologies Corporation Common Stock,$81.39,0.00,0.00%,15382521338.00,United States,,492938,Capital Goods,Railroads
+add,WAL,Western Alliance Bancorporation Common Stock (DE),$98.26,-3.46,-3.401%,10167433062.00,United States,2005,508095,Finance,Major Banks
+add,WALA,Western Alliance Bancorporation 6.25% Subordinated Debentures due 2056,$25.60,0.01,0.039%,0.00,United States,2016,521,Finance,Major Banks
+add,WARR,Warrior Technologies Acquisition Company Class A Common Stock,$9.71,0.01,0.103%,0.00,,2021,83547,,
+add,WAT,Waters Corporation Common Stock,$333.55,5.55,1.692%,20580201108.00,United States,1995,229129,Health Care,Medical Specialities
+add,WBK,Westpac Banking Corporation Common Stock,$20.73,0.15,0.729%,75983540173.00,Australia,,48700,Finance,Commercial Banks
+add,WBS,Webster Financial Corporation Common Stock,$56.85,-0.40,-0.699%,5140387631.00,United States,,989236,Finance,Major Banks
+add,WBS^F,Webster Financial Corporation Depositary Shares Each Representing 1/1000th Interest in a Share of 5.25% Series F Non-Cumulative Perpetual Preferred Stock,$25.863,0.023,0.089%,,United States,,3998,,
+add,WBT,Welbilt Inc. Common Stock,$24.185,-0.145,-0.596%,3432292441.00,,2016,1586927,Capital Goods,Diversified Manufacture
+add,WCC,WESCO International Inc. Common Stock,$110.01,0.36,0.328%,5520574625.00,United States,1999,334064,Consumer Non-Durables,Telecommunications Equipment
+add,WCC^A,WESCO International Inc. Depositary Shares each representing 1/1000th interest in a share of Series A Fixed-Rate Reset Cumulative Perpetual Preferred Stock,$31.56,0.02,0.063%,,United States,,16961,,
+add,WCN,Waste Connections Inc. Common Shares,$120.80,0.51,0.424%,31611508982.00,Canada,,508220,Public Utilities,Power Generation
+add,WD,Walker & Dunlop Inc Common Stock,$99.97,-2.22,-2.172%,3178528455.00,United States,2010,61533,Finance,Finance: Consumer Services
+add,WDH,Waterdrop Inc. American Depositary Shares (each representing the right to receive 10 Class A Ordinary Shares),$8.15,0.04,0.493%,3212131211.00,,2021,248508,,
+add,WEA,Western Asset Bond Fund Share of Beneficial Interest,$14.46,0.03,0.208%,171543853.00,United States,2002,25414,,
+add,WEC,WEC Energy Group Inc. Common Stock,$93.27,0.36,0.387%,29420578706.00,United States,,471790,Public Utilities,Power Generation
+add,WEI,Weidai Ltd. American depositary shares each  representing one (1) Class A ordinary share,$1.10,-0.02,-1.786%,77507601.00,Cayman Islands,2018,311541,Finance,Finance: Consumer Services
+add,WELL,Welltower Inc. Common Stock,$79.17,0.33,0.419%,33055097985.00,United States,,541931,Consumer Services,Real Estate Investment Trusts
+add,WES,Western Midstream Partners LP Common Units Representing Limited Partner Interests,$22.65,0.61,2.768%,9355892941.00,United States,2012,587817,Energy,Oilfield Services/Equipment
+add,WEX,WEX Inc. common stock,$201.39,-0.46,-0.228%,9010443963.00,United States,,176457,Technology,EDP Services
+add,WF,Woori Financial Group Inc. American Depositary Shares (each representing three (3) shares of Common Stock),$31.0074,-0.9926,-3.102%,7465214277.00,South Korea,,7740,Finance,Commercial Banks
+add,WFC,Wells Fargo & Company Common Stock,$45.195,-0.725,-1.579%,186816763988.00,United States,,16285214,Finance,Major Banks
+add,WFC^A,Wells Fargo & Company Depositary Shares each representing a 1/1000th interest in a share of Non-Cumulative Perpetual Class A Preferred Stock Series AA,$25.995,0.005,0.019%,,United States,,58582,,
+add,WFC^C,Wells Fargo & Company Depositary Shares each representing a 1/1000th interest in a share of Non-Cumulative Perpetual Class A Preferred Stock Series CC,$25.30,0.05,0.198%,,United States,,135549,,
+add,WFC^L,Wells Fargo & Company Wells Fargo & Company 7.50% Non-Cumulative Perpetual Convertible Class A Preferred Stock Series L,$1461.00,3.00,0.206%,,United States,,4134,,
+add,WFC^N,Wells Fargo & Company Dep Shs Repstg 1/1000th Perp Pfd Cl A Ser N,$25.00,0.00,0.00%,,United States,,12918,,
+add,WFC^O,Wells Fargo & Company Depositary Shares Representing 1/1000th Perpetual Preferred Class A Series O,$25.79,-0.04,-0.155%,,United States,,14682,,
+add,WFC^Q,Wells Fargo & Company Depositary Shares Representing 1/1000th Interest Perpetual Preferred Class A Series Q Fixed to Floating,$27.19,0.01,0.037%,,United States,,65589,,
+add,WFC^R,Wells Fargo & Company Dep Shs Repstg 1/1000th Int Perp Pfd Cl A (Ser R Fixed To Flltg),$28.70,-0.27,-0.932%,,United States,,101240,,
+add,WFC^X,Wells Fargo & Company Depositary Shares each representing a 1/1000th interest in a share of Non-Cumulative Perpetual Class A Preferred Stock Series X,$25.30,-0.01,-0.04%,,United States,,30608,,
+add,WFC^Y,Wells Fargo & Company Depositary Shares each representing a 1/1000th interest in a share of Non-Cumulative Perpetual Class A Preferred Stock Series Y,$26.13,0.01,0.038%,,United States,,52748,,
+add,WFC^Z,Wells Fargo & Company Depositary Shares each representing a 1/1000th interest in a share of Non-Cumulative Perpetual Class A Preferred Stock Series Z,$26.20,0.00,0.00%,,United States,,113462,,
+add,WFG,West Fraser Timber Co. Ltd Common stock,$71.94,-1.70,-2.309%,8746910005.00,,2021,278393,Basic Industries,Forest Products
+add,WGO,Winnebago Industries Inc. Common Stock,$67.44,-0.81,-1.187%,2265994723.00,United States,,462795,Consumer Non-Durables,Homebuilding
+add,WH,Wyndham Hotels & Resorts Inc. Common Stock ,$74.58,-0.97,-1.284%,6965682504.00,,2018,672611,Consumer Services,Hotels/Resorts
+add,WHD,Cactus Inc. Class A Common Stock,$41.10,0.65,1.607%,3111270000.00,,2018,166793,Energy,Metal Fabrications
+add,WHG,Westwood Holdings Group Inc Common Stock,$20.37,-0.17,-0.828%,169008994.00,United States,,11278,,
+add,WHR,Whirlpool Corporation Common Stock,$223.04,-6.86,-2.984%,13967824240.00,United States,,766030,Consumer Durables,Consumer Electronics/Appliances
+add,WIA,Western Asset Inflation-Linked Income Fund,$13.88,0.03,0.217%,323712913.00,United States,2003,25789,,
+add,WIT,Wipro Limited Common Stock,$8.25,0.09,1.103%,45043537061.00,India,,675668,Technology,EDP Services
+add,WIW,Western Asset Inflation-Linked Opportunities & Income Fund,$13.16,0.04,0.305%,805183203.00,United States,2004,73011,,
+add,WK,Workiva Inc. Class A Common Stock,$98.35,0.92,0.944%,4916900557.00,United States,2014,97505,Technology,Computer Software: Prepackaged Software
+add,WLK,Westlake Chemical Corporation Common Stock,$100.58,-2.10,-2.045%,12887578216.00,United States,2004,324904,Basic Industries,Major Chemicals
+add,WLKP,Westlake Chemical Partners LP Common Units representing limited partner interests,$26.89,-0.05,-0.186%,946498502.00,United States,2014,38421,Basic Industries,Major Chemicals
+add,WLL,Whiting Petroleum Corporation Common Stock (New),$49.93,0.01,0.02%,1949976006.00,United States,2020,333622,Energy,Oil & Gas Production
+add,WM,Waste Management Inc. Common Stock,$139.87,0.29,0.208%,59042939856.00,United States,,545120,Public Utilities,Environmental Services
+add,WMB,Williams Companies Inc. (The) Common Stock,$27.78,-0.35,-1.244%,33746098139.00,United States,,4907666,Public Utilities,Natural Gas Distribution
+add,WMC,Western Asset Mortgage Capital Corporation Common Stock,$4.14,0.16,4.02%,251764582.00,United States,2012,1440982,Consumer Services,Real Estate Investment Trusts
+add,WMK,Weis Markets Inc. Common Stock,$53.535,0.025,0.047%,1440008146.00,United States,,62703,Consumer Services,Food Chains
+add,WMS,Advanced Drainage Systems Inc. Common Stock,$103.70,-4.71,-4.345%,7424055142.00,United States,2014,458400,Capital Goods,Containers/Packaging
+add,WMT,Walmart Inc. Common Stock,$139.83,0.75,0.539%,391824064972.00,United States,,4184293,Consumer Services,Department/Specialty Retail Stores
+add,WNC,Wabash National Corporation Common Stock,$16.56,-0.41,-2.416%,853122679.00,United States,1991,189476,Capital Goods,Construction/Ag Equipment/Trucks
+add,WNS,WNS (Holdings) Limited Sponsored ADR (Jersey),$76.25,-0.34,-0.444%,3766917979.00,India,2006,165535,Miscellaneous,Business Services
+add,WOR,Worthington Industries Inc. Common Stock,$64.86,-1.39,-2.098%,3436991136.00,United States,,113434,Consumer Durables,Aerospace
+add,WORK,Slack Technologies Inc. Class A Common Stock,$44.45,0.43,0.977%,26079483084.00,,2019,1675845,Technology,EDP Services
+add,WOW,WideOpenWest Inc. Common Stock,$17.62,-0.23,-1.289%,1535114202.00,United States,2017,207696,Consumer Services,Television Services
+add,WPC,W. P. Carey Inc. REIT,$77.61,0.51,0.661%,13941611505.00,United States,,520444,Consumer Services,Real Estate Investment Trusts
+add,WPCA,Warburg Pincus Capital Corporation IA Class A Ordinary Shares,$9.92,-0.05,-0.502%,351443002.00,,2021,401241,,
+add,WPCB,Warburg Pincus Capital Corporation IB Class A Ordinary Shares,$9.83,-0.11,-1.107%,674276563.00,,2021,43548,,
+add,WPF,Foley Trasimene Acquisition Corp. Class A CommonStock,$10.605,-0.025,-0.235%,1372021875.00,United States,2020,631558,Finance,Business Services
+add,WPG,Washington Prime Group Inc. Common Stock,$5.04,-1.69,-25.111%,123276893.00,United States,2014,11579734,Consumer Services,Real Estate Investment Trusts
+add,WPG^H,Washington Prime Group Inc. 7.5% Series H Cumulative Redeemable Preferred SBI,$7.98,-0.07,-0.87%,,United States,,128170,,
+add,WPG^I,Washington Prime Group Inc. 6.875% Series I Cumulative Redeemable Preferred SBI,$7.85,-0.05,-0.633%,,United States,,121349,,
+add,WPM,Wheaton Precious Metals Corp Common Shares (Canada),$48.835,1.485,3.136%,21978146480.00,Canada,,1689429,Basic Industries,Precious Metals
+add,WPP,WPP plc American Depositary Shares,$69.61,-1.33,-1.875%,16740171292.00,Ireland,,38946,Technology,Advertising
+add,WRB,W.R. Berkley Corporation Common Stock,$75.48,0.03,0.04%,13388683763.00,United States,,284362,Finance,Property-Casualty Insurers
+add,WRB^E,W.R. Berkley Corporation 5.70% Subordinated Debentures due 2058,$27.32,-0.1137,-0.414%,,United States,,13883,,
+add,WRB^F,W.R. Berkley Corporation 5.10% Subordinated Debentures due 2059,$27.37,0.06,0.22%,,United States,,14283,,
+add,WRB^G,W.R. Berkley Corporation 4.25% Subordinated Debentures due 2060,$26.23,0.09,0.344%,,United States,,3799,,
+add,WRB^H,W.R. Berkley Corporation 4.125% Subordinated Debentures due 2061,$26.15,0.15,0.577%,,United States,,8241,,
+add,WRE,Washington Real Estate Investment Trust Common Stock,$26.395,-0.555,-2.059%,2232541468.00,United States,,689580,,
+add,WRI,Weingarten Realty Investors Common Stock,$33.71,-0.21,-0.619%,4302298450.00,United States,,424789,Consumer Services,Real Estate Investment Trusts
+add,WRK,Westrock Company Common Stock,$56.20,-0.72,-1.265%,14955738477.00,,2015,1543553,,
+add,WSM,Williams-Sonoma Inc. Common Stock (DE),$166.69,-0.63,-0.377%,12548807754.00,United States,,911398,Consumer Services,Other Specialty Stores
+add,WSO,Watsco Inc. Common Stock,$287.495,-1.345,-0.466%,11120621120.00,United States,,92414,Capital Goods,Wholesale Distributors
+add,WSO/B,Watsco Inc.,$292.01,0.00,0.00%,,United States,,83,,
+add,WSR,Whitestone REIT Common Shares,$8.56,-0.19,-2.171%,366177052.00,United States,2010,522725,Consumer Services,Real Estate Investment Trusts
+add,WST,West Pharmaceutical Services Inc. Common Stock,$342.95,7.02,2.09%,25317838258.00,United States,,236394,Health Care,Medical/Dental Instruments
+add,WTI,W&T Offshore Inc. Common Stock,$4.57,0.05,1.106%,650332799.00,United States,2005,1626640,Energy,Oil & Gas Production
+add,WTM,White Mountains Insurance Group Ltd. Common Stock,$1138.00,7.99,0.707%,3536069846.00,United States,,13755,Finance,Property-Casualty Insurers
+add,WTRG,Essential Utilities Inc. Common Stock,$48.00,0.49,1.031%,11790880464.00,United States,,232578,Public Utilities,Water Supply
+add,WTRU,Essential Utilities Inc. 6.00% TEU,$59.8801,0.2701,0.453%,0.00,United States,2019,1296,Public Utilities,Water Supply
+add,WTS,Watts Water Technologies Inc. Class A Common Stock,$142.06,0.23,0.162%,4783405111.00,United States,1986,59292,Capital Goods,Office Equipment/Supplies/Services
+add,WTTR,Select Energy Services Inc. Class A Common Stock,$6.675,-0.065,-0.964%,694719769.00,United States,2017,109289,Energy,Oil & Gas Production
+add,WU,Western Union Company (The) Common Stock,$24.735,-0.435,-1.728%,10122853587.00,United States,,2396450,Miscellaneous,Business Services
+add,WWE,World Wrestling Entertainment Inc. Class A Common Stock,$64.97,0.49,0.76%,4961144219.00,United States,,1043999,Consumer Services,Movies/Entertainment
+add,WWW,Wolverine World Wide Inc. Common Stock,$36.31,0.23,0.637%,3007460715.00,United States,,507319,Consumer Non-Durables,Shoe Manufacturing
+add,WY,Weyerhaeuser Company Common Stock,$35.095,-0.935,-2.595%,26293700425.00,United States,,4808695,Consumer Services,Real Estate Investment Trusts
+add,X,United States Steel Corporation Common Stock,$27.9002,0.5402,1.974%,7523605039.00,United States,,29228877,Basic Industries,Steel/Iron Ore
+add,XEC,Cimarex Energy Co Common Stock,$72.09,0.49,0.684%,7412675589.00,United States,,796875,Energy,Oil & Gas Production
+add,XFLT,XAI Octagon Floating Rate & Alternative Income Term Trust Common Shares of Beneficial Interest,$9.045,0.055,0.612%,165789758.00,United States,2017,120278,,
+add,XFLT^A,XAI Octagon Floating Rate & Alternative Income Term Trust 6.50% Series 2026 Term Preferred Shares (Liquidation Preference $25.00),$26.09,0.0932,0.359%,,United States,,340,,
+add,XHR,Xenia Hotels & Resorts Inc. Common Stock,$20.41,-0.02,-0.098%,2322741150.00,United States,2015,275867,Consumer Services,Real Estate Investment Trusts
+add,XIN,Xinyuan Real Estate Co Ltd American Depositary Shares,$2.85,0.28,10.895%,186967658.00,China,2007,11802485,Capital Goods,Homebuilding
+add,XL,XL Fleet Corp. Class A Common Stock,$8.72,-0.29,-3.219%,1213187431.00,,2019,5488269,Capital Goods,Automotive Aftermarket
+add,XOM,Exxon Mobil Corporation Common Stock,$62.95,0.30,0.479%,266501274825.00,United States,,21751321,Energy,Oil & Gas Production
+add,XPEV,XPeng Inc. American depositary shares each representing two Class A ordinary shares,$38.70,0.63,1.655%,30290599637.00,China,2020,9203863,Capital Goods,Auto Manufacturing
+add,XPO,XPO Logistics Inc.,$145.62,1.73,1.202%,16267291747.00,United States,,1130907,Transportation,Trucking Freight/Courier Services
+add,XPOA,DPCM Capital Inc. Class A Common Stock,$9.9001,-0.0299,-0.301%,335867258.00,United States,2020,61656,,
+add,XRX,Xerox Holdings Corporation Common Stock,$25.115,-0.045,-0.179%,4820757519.00,United States,,1591092,Technology,EDP Services
+add,XYF,X Financial American Depositary Shares each representing six Class A Ordinary Shares,$6.8271,0.2271,3.441%,367659748.00,,2018,34629,Finance,Finance: Consumer Services
+add,XYL,Xylem Inc. Common Stock New,$118.30,-0.15,-0.127%,21298920097.00,United States,2011,535601,Capital Goods,Fluid Controls
+add,Y,Alleghany Corporation Common Stock,$703.165,1.655,0.236%,9793163887.00,United States,,44716,Finance,Property-Casualty Insurers
+add,YAC,Yucaipa Acquisition Corporation Class A Ordinary Shares,$9.83,-0.01,-0.102%,423918750.00,United States,2020,10340,Finance,Business Services
+add,YALA,Yalla Group Limited American Depositary Shares each representing one Class A Ordinary Share,$18.77,-0.49,-2.544%,2701568540.00,United Arab Emirates,2020,882670,Technology,Computer Software: Programming Data Processing
+add,YELP,Yelp Inc. Common Stock,$39.47,-1.62,-3.943%,2940430889.00,United States,2012,517400,Technology,Internet and Information Services
+add,YETI,YETI Holdings Inc. Common Stock,$91.73,-3.03,-3.198%,8002586476.00,United States,2018,1137582,Consumer Services,Movies/Entertainment
+add,YEXT,Yext Inc. Common Stock,$14.47,-0.02,-0.138%,1826743662.00,United States,2017,935504,Technology,EDP Services
+add,YPF,YPF Sociedad Anonima Common Stock,$5.70,0.15,2.703%,2241882920.00,Argentina,1993,1462394,Energy,Integrated oil Companies
+add,YRD,Yiren Digital Ltd. American Depositary Shares each representing two ordinary shares,$5.00,0.89,21.655%,419920125.00,China,2015,8832949,Finance,Diversified Financial Services
+add,YSG,Yatsen Holding Limited American Depositary Shares each representing four Class A ordinary shares,$9.995,-0.405,-3.894%,6312976373.00,China,2020,2302581,Consumer Non-Durables,Package Goods/Cosmetics
+add,YTPG,TPG Pace Beneficial II Corp. Class A Ordinary Shares,$10.115,0.015,0.149%,539466663.00,,2021,106231,Finance,Business Services
+add,YUM,Yum! Brands Inc.,$118.56,1.03,0.876%,35319160700.00,United States,,950855,Consumer Services,Restaurants
+add,YUMC,Yum China Holdings Inc. Common Stock,$69.04,0.44,0.641%,29038133350.00,United States,2016,1198926,Consumer Services,Restaurants
+add,ZBH,Zimmer Biomet Holdings Inc. Common Stock,$159.175,0.955,0.604%,33185138427.00,United States,,653768,Health Care,Industrial Specialties
+add,ZEN,Zendesk Inc. Common Stock,$136.58,0.08,0.059%,16205182718.00,,2014,619755,Technology,EDP Services
+add,ZEPP,Zepp Health Corporation American Depositary Shares,$10.46,-0.09,-0.853%,658494426.00,China,2018,135383,Technology,Computer Manufacturing
+add,ZETA,Zeta Global Holdings Corp.,$8.62,8.62,,1651816499.00,,,8684019,,
+add,ZEV,Lightning eMotors Inc Common Stock,$8.38,-0.24,-2.784%,613664928.00,,2020,425968,Capital Goods,Industrial Machinery/Components
+add,ZH,Zhihu Inc. American Depositary Shares (every two of each representing one Class A ordinary share),$10.16,-0.41,-3.879%,5704894539.00,,2021,1804427,Miscellaneous,Business Services
+add,ZIM,ZIM Integrated Shipping Services Ltd. Ordinary Shares,$44.91,1.12,2.558%,5164650000.00,,2021,1111270,Transportation,Marine Transportation
+add,ZIP,ZipRecruiter Inc. Class A Common Stock,$22.465,-0.365,-1.599%,2349839000.00,,2021,732186,Technology,Computer Software: Programming Data Processing
+add,ZME,Zhangmen Education Inc. American Depositary Shares each representing nine (9) Class A ordinary shares,$13.51,-1.09,-7.466%,2130126739.00,,2021,332680,,
+add,ZNH,China Southern Airlines Company Limited Common Stock,$33.82,-0.24,-0.705%,10368776500.00,China,1997,6303,Transportation,Air Freight/Delivery Services
+add,ZTO,ZTO Express (Cayman) Inc. American Depositary Shares each representing one Class A ordinary share.,$31.59,0.03,0.095%,26128957978.00,China,2016,1335990,Transportation,Advertising
+add,ZTR,Virtus Total Return Fund Inc.,$10.14,-0.04,-0.393%,250078987.00,United States,1988,119906,,
+add,ZTS,Zoetis Inc. Class A Common Stock,$182.07,5.38,3.045%,86440773251.00,United States,2013,1483113,Health Care,Major Pharmaceuticals
+add,ZUO,Zuora Inc. Class A Common Stock,$15.09,0.14,0.936%,1845507000.00,,2018,594411,Technology,EDP Services
+add,ZYME,Zymeworks Inc. Common Shares,$37.33,0.19,0.512%,1723527369.00,Canada,2017,430508,,

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -475,7 +475,8 @@ impl Exchange {
                     self.fetch_account_pending_orders(&mut account);
                 }
 
-                if account.validate_order(&order) {
+                let (validated, _) = account.validate_order(&order);
+                if validated {
                     if let Err(e) = self.submit_order_to_market(users, buffers, order, username, true, conn) {
                         eprintln!("{}", e);
                     }

--- a/src/exchange/requests.rs
+++ b/src/exchange/requests.rs
@@ -45,7 +45,7 @@ impl Order {
         // Truncate price to 2 decimal places
         let price = f64::trunc(price  * 100.0) / 100.0;
 
-        // TODO: Need to include order status and time placed/updated.
+        // TODO: Do we need to include time placed/updated?
         Order {
             action: action.to_string().clone(),
             symbol: symbol.to_string().clone(),
@@ -114,7 +114,6 @@ impl PartialEq for Order {
 
 impl Eq for Order { }
 // Non-orders requests like price of a security,
-// TODO: number of buy or sell orders in a market, etc.
 pub struct InfoRequest {
     pub action: String,
     pub symbol: String

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -326,8 +326,11 @@ Please change the price of your order so that it cannot fill the following pendi
                 },
                 "show" => {
                     match users.authenticate(&account.username, &account.password, exchange, buffers, conn) {
-                        Ok(_) => {
-                            users.print_user(&account.username, true);
+                        Ok(acc) => {
+                            if !acc.pending_orders.is_complete {
+                                exchange.fetch_account_pending_orders(acc);
+                            }
+                            &acc.print_user(conn);
                         },
                         Err(e) => Users::print_auth_error(e)
                     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -92,12 +92,29 @@ pub fn tokenize_input(text: String) -> Result<Request, ()> {
         // Order
         "buy" | "sell" => {
             if let 6 = words.len() {
-                // Note that we do not provide an order ID (arg 4 is None).
+                let quantity = match words[2].to_string().trim().parse::<i32>() {
+                    Ok(quant) => quant,
+                    Err(e) => {
+                        eprintln!("{}", e);
+                        eprintln!("Please enter an integer number of shares!");
+                        return Err(());
+                    }
+                };
+
+                let price = match words[3].to_string().trim().parse::<f64>() {
+                    Ok(price) => price,
+                    Err(e) => {
+                        eprintln!("{}", e);
+                        eprintln!("Please enter a floating point price!");
+                        return Err(());
+                    }
+                };
+                // Note that we do not provide an order ID (arg is None).
                 // This value actually gets set later.
                 let order = Order::from( words[0].to_string().to_uppercase(),
                                          words[1].to_string().to_uppercase(),
-                                         words[2].to_string().trim().parse::<i32>().expect("Please enter an integer number of shares!"),// TODO we shouldn't panic here
-                                         words[3].to_string().trim().parse::<f64>().expect("Please enter a floating point price!"),     // TODO we shouldn't panic here
+                                         quantity,
+                                         price,
                                          OrderStatus::PENDING,
                                          None
                                        );
@@ -114,9 +131,17 @@ pub fn tokenize_input(text: String) -> Result<Request, ()> {
         },
         "cancel" => {
             if let 5 = words.len() {
+                let order_id = match words[2].to_string().trim().parse::<i32>() {
+                    Ok(id) => id,
+                    Err(e) => {
+                        eprintln!("{}", e);
+                        eprintln!("Please enter an integer order_id");
+                        return Err(());
+                    }
+                };
                 let req = CancelOrder {
                     symbol: words[1].to_string().to_uppercase(),
-                    order_id: words[2].to_string().trim().parse::<i32>().expect("Please enter an integer order id"), // TODO we shouldn't panic here.
+                    order_id: order_id,
                     username: words[3].to_string()
                 };
 
@@ -151,13 +176,36 @@ pub fn tokenize_input(text: String) -> Result<Request, ()> {
         // Simulate a market for n time steps
         "simulate" => {
             if let 4 = words.len() {
-                // TODO: We shouldn't panic here, just write to stderr...
-                let req: Simulation = Simulation::from( words[0].to_string(),
-                                                        words[1].to_string().trim().parse::<u32>().expect("Please enter an integer number of traders!"),
-                                                        words[2].to_string().trim().parse::<u32>().expect("Please enter an integer number of markets!"),
-                                                        words[3].to_string().trim().parse::<u32>().expect("Please enter an integer number of time steps!")
-                                                      );
+                let trader_count = match words[1].to_string().trim().parse::<u32>() {
+                    Ok(count) => count,
+                    Err(e) => {
+                        eprintln!("{}", e);
+                        eprintln!("Please enter an integer number of traders!");
+                        return Err(());
+                    }
+                };
+
+                let market_count = match words[2].to_string().trim().parse::<u32>() {
+                    Ok(count) => count,
+                    Err(e) => {
+                        eprintln!("{}", e);
+                        eprintln!("Please enter an integer number of markets!");
+                        return Err(());
+                    }
+                };
+
+                let time_step_count = match words[3].to_string().trim().parse::<u32>() {
+                    Ok(count) => count,
+                    Err(e) => {
+                        eprintln!("{}", e);
+                        eprintln!("Please enter an integer number of time steps!");
+                        return Err(());
+                    }
+                };
+
+                let req: Simulation = Simulation::from( words[0].to_string(), trader_count, market_count, time_step_count);
                 return Ok(Request::SimReq(req));
+
             } else {
                 malformed_req(&words[0], "sim");
                 return Err(());


### PR DESCRIPTION
There are a few bugs (unclear behaviour really) in the program. One of these is order validation, which I've decided to make a firm policy on:
- If a user places an order that theoretically could fill at least one of their pending orders, the order is invalid.
This doesn't take into account the possibility that the new order may be completed well before it reaches the obstructive pending order, ex:
- User placed buy at $10 for item `x`.
- User placed sell at $4 for item `x`.
- However, there is enough volume between the current market price and the $10 buy that the new sell would never reach the old buy.
I could have handled this situation, but it could always lead to the confusing end point of: *the new order will fill an old order that the same user placed*. Instead of dealing with this, I've just made it clear which order is at risk of being filled, and so if the user resubmits the new order at a price that won't fill the old one, it will absolutely be valid.

I also verified that this new method is not computationally expensive. I was able to cancel 1.8 million orders in under 2 seconds.