### PR TITLE
RED-2 Store executed trades in Redis to maintain consistency when users are evicted from cache.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d47c1b11006b87e492b53b313bb699ce60e16613c4dddaa91f8f7c220ab2fa"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,6 +160,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
 name = "exchange"
 version = "0.1.0"
 dependencies = [
@@ -158,6 +174,7 @@ dependencies = [
  "ctrlc",
  "postgres",
  "random-number",
+ "redis",
 ]
 
 [[package]]
@@ -165,6 +182,16 @@ name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures"
@@ -292,6 +319,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,6 +337,12 @@ checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "lazy_static"
@@ -625,6 +669,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "redis"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4f0ceb2ec0dd769483ecd283f6615aa83dcd0be556d5294c6e659caefe7cc54"
+dependencies = [
+ "async-trait",
+ "combine",
+ "dtoa",
+ "itoa",
+ "percent-encoding",
+ "sha1",
+ "url",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +697,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sha1"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "sha2"
@@ -832,6 +897,18 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ postgres = { version = "0.19.1", features = ["with-chrono-0_4"] }
 chrono = "0.4"
 ctrlc = { version = "3.1.9", features = ["termination"] }
 colour = "0.6.0"
+redis = "0.20.2"

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -473,7 +473,7 @@ impl BufferCollection {
         let tx = workers.senders.get(0).unwrap();
         let mut insert_container = UpdateCategories::new();
         insert_container.insert_orders = categories.insert_orders.clone();
-        tx.send((insert_container, Category::INSERT_NEW)).unwrap();
+        tx.send((insert_container, Category::InsertNew)).unwrap();
 
         // 2. Wait for response 'true' from insert thread
         if workers.receivers.get(0).unwrap().recv().unwrap() {
@@ -482,37 +482,37 @@ impl BufferCollection {
             let tx = workers.senders.get(1).unwrap();
             let mut update_order_container = UpdateCategories::new();
             update_order_container.update_orders = categories.update_orders.clone();
-            tx.send((update_order_container, Category::UPDATE_KNOWN)).unwrap();
+            tx.send((update_order_container, Category::UpdateKnown)).unwrap();
 
             // 3. insert pending
             let tx = workers.senders.get(2).unwrap();
             let mut insert_pending_container = UpdateCategories::new();
             insert_pending_container.insert_pending = categories.insert_pending.clone();
-            tx.send((insert_pending_container, Category::INSERT_PENDING)).unwrap();
+            tx.send((insert_pending_container, Category::InsertPending)).unwrap();
 
             // 4. delete pending
             let tx = workers.senders.get(3).unwrap();
             let mut delete_pending_container = UpdateCategories::new();
             delete_pending_container.delete_pending = categories.delete_pending.clone();
-            tx.send((delete_pending_container, Category::DELETE_PENDING)).unwrap();
+            tx.send((delete_pending_container, Category::DeletePending)).unwrap();
 
             // 5. update exchange stats
             let tx = workers.senders.get(4).unwrap();
             let mut update_total_container = UpdateCategories::new();
             update_total_container.total_orders = categories.total_orders.clone();
-            tx.send((update_total_container, Category::UPDATE_TOTAL)).unwrap();
+            tx.send((update_total_container, Category::UpdateTotal)).unwrap();
 
             // 6. update market stats
             let tx = workers.senders.get(5).unwrap();
             let mut update_market_container = UpdateCategories::new();
             update_market_container.update_markets = categories.update_markets.clone();
-            tx.send((update_market_container, Category::UPDATE_MARKET_STATS)).unwrap();
+            tx.send((update_market_container, Category::UpdateMarketStats)).unwrap();
 
             // 7. insert new trades
             let tx = workers.senders.get(6).unwrap();
             let mut insert_trades_container = UpdateCategories::new();
             insert_trades_container.insert_trades = categories.insert_trades.clone();
-            tx.send((insert_trades_container, Category::INSERT_NEW_TRADES)).unwrap();
+            tx.send((insert_trades_container, Category::InsertNewTrades)).unwrap();
 
             // Iterate over the received responses, this is like doing a thread join,
             // except with message passing. We're effectively waiting for all threads

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -475,8 +475,7 @@ impl Exchange {
                     self.fetch_account_pending_orders(&mut account);
                 }
 
-                let (validated, _) = account.validate_order(&order);
-                if validated {
+                if let None = account.validate_order(&order) {
                     if let Err(e) = self.submit_order_to_market(users, buffers, order, username, true, conn) {
                         eprintln!("{}", e);
                     }

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -21,6 +21,8 @@ pub use crate::buffer::BufferCollection;
 
 use postgres::Client;
 
+use std::time::Instant;
+
 // Error types for price information.
 pub enum PriceError {
     NoMarket,
@@ -91,7 +93,7 @@ impl Exchange {
              * in the mean time?)
              */
             // Updates database too.
-            users.update_account_orders(self, &mut modified_orders, &mut trades, buffers, conn);
+            users.update_account_orders(&mut modified_orders, &mut trades, buffers, conn);
             self.has_trades.insert(order.symbol.clone(), true);
         };
 
@@ -436,6 +438,8 @@ impl Exchange {
             users.new_account(UserAccount::from(name, &"password".to_string()), conn);
         }
 
+        let start = Instant::now();
+        println!("Starting sim timer!");
         // Simulation loop
         for _time_step in 0..sim.duration {
             // We want to randomly decide to buy or sell,
@@ -466,7 +470,7 @@ impl Exchange {
             // Choose the number of shares
             let shares:i32 = random!(2..=13); // TODO: get random number of shares
 
-            if let Ok(mut account) =  users.authenticate(username, &"password".to_string(), self, buffers, conn) {
+            if let Ok(mut account) =  users.authenticate(username, &"password".to_string(), conn) {
                 // Create the order and send it to the market
                 let order = Order::from(action.to_string(), symbol.to_string().clone(), shares, new_price, OrderStatus::PENDING, account.id);
 
@@ -492,5 +496,6 @@ impl Exchange {
                 }
             }
         }
+        println!("SIMULATION TOOK: {} seconds!", start.elapsed().as_secs());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,13 +28,13 @@ use std::time::Instant;
 
 // Helps us determine what each thread will work on.
 pub enum Category {
-    INSERT_NEW,
-    UPDATE_KNOWN,
-    INSERT_PENDING,
-    DELETE_PENDING,
-    UPDATE_TOTAL,
-    UPDATE_MARKET_STATS,
-    INSERT_NEW_TRADES
+    InsertNew,
+    UpdateKnown,
+    InsertPending,
+    DeletePending,
+    UpdateTotal,
+    UpdateMarketStats,
+    InsertNewTrades
 }
 
 // Helps manage the workload.
@@ -161,13 +161,13 @@ fn main() {
 
                     // Perform the database write here depending on the type of category.
                     match category_type {
-                        Category::INSERT_NEW            => BufferCollection::launch_insert_orders(&data.insert_orders, &mut conn),
-                        Category::UPDATE_KNOWN          => BufferCollection::launch_update_orders(&data.update_orders, &mut conn),
-                        Category::INSERT_PENDING        => BufferCollection::launch_insert_pending_orders(&data.insert_pending, &mut conn),
-                        Category::DELETE_PENDING        => BufferCollection::launch_delete_pending_orders(&data.delete_pending, &mut conn),
-                        Category::UPDATE_TOTAL          => BufferCollection::launch_exchange_stats_update(data.total_orders, &mut conn),
-                        Category::UPDATE_MARKET_STATS   => BufferCollection::launch_update_market(&data.update_markets, &mut conn),
-                        Category::INSERT_NEW_TRADES     => BufferCollection::launch_insert_trades(&data.insert_trades, &mut conn)
+                        Category::InsertNew            => BufferCollection::launch_insert_orders(&data.insert_orders, &mut conn),
+                        Category::UpdateKnown          => BufferCollection::launch_update_orders(&data.update_orders, &mut conn),
+                        Category::InsertPending        => BufferCollection::launch_insert_pending_orders(&data.insert_pending, &mut conn),
+                        Category::DeletePending        => BufferCollection::launch_delete_pending_orders(&data.delete_pending, &mut conn),
+                        Category::UpdateTotal          => BufferCollection::launch_exchange_stats_update(data.total_orders, &mut conn),
+                        Category::UpdateMarketStats    => BufferCollection::launch_update_market(&data.update_markets, &mut conn),
+                        Category::InsertNewTrades      => BufferCollection::launch_insert_trades(&data.insert_trades, &mut conn)
                     }
                     // Return the successful response message
                     response_tx.send(true).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #[macro_use] extern crate random_number;
 extern crate chrono;
 extern crate ctrlc;
+extern crate redis;
 #[macro_use] extern crate colour;
 
 pub mod exchange;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -239,7 +239,7 @@ pub fn service_request(request: Request, exchange: &mut Exchange, users: &mut Us
             match &order.action[..] {
                 "BUY" | "SELL" => {
                     // Try to get the account
-                    match users.authenticate(&username, &password, exchange, buffers, conn) {
+                    match users.authenticate(&username, &password, conn) {
                         Ok(mut account) => {
                             // Set the order's user id now that we have an account
                             order.user_id = account.id;
@@ -271,7 +271,7 @@ Please change the price of your order so that it cannot fill the following pendi
             }
         },
         Request::CancelReq(order_to_cancel, password) => {
-            match users.authenticate(&(order_to_cancel.username), &password, exchange, buffers, conn) {
+            match users.authenticate(&(order_to_cancel.username), &password, conn) {
                 Ok(_) => {
                     match exchange.cancel_order(&order_to_cancel, users, buffers, conn) {
                         Ok(_) => println!("Order successfully cancelled."),
@@ -330,7 +330,7 @@ Please change the price of your order so that it cannot fill the following pendi
         Request::UpgradeDbReq(db_name, username, password) => {
             // First, lets authenticate to make sure we're the admin.
             if username.as_str() == "admin" {
-                match users.authenticate(&username, &password, exchange, buffers, conn) {
+                match users.authenticate(&username, &password, conn) {
                     Ok(_) => {
                         println!("Please enter the file path to the configuration:");
                         let mut file_path = String::new();
@@ -373,7 +373,7 @@ Please change the price of your order so that it cannot fill the following pendi
                    }
                 },
                 "show" => {
-                    match users.authenticate(&account.username, &account.password, exchange, buffers, conn) {
+                    match users.authenticate(&account.username, &account.password, conn) {
                         Ok(acc) => {
                             if !acc.pending_orders.is_complete {
                                 exchange.fetch_account_pending_orders(acc);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -251,18 +251,16 @@ pub fn service_request(request: Request, exchange: &mut Exchange, users: &mut Us
                                 exchange.fetch_account_pending_orders(&mut account);
                             }
 
-                            let (validated, obstruction) = account.validate_order(&order);
-                            if validated {
+                            if let Some(obstruction) = account.validate_order(&order) {
+                                eprintln!("\
+The order could not be placed. You have a pending order in ${} that could potentially be filled by the order you just requested.
+Please change the price of your order so that it cannot fill the following pending order:\n\t{:?}", obstruction.symbol, obstruction);
+                            } else {
                                 if let Err(e) =  &exchange.submit_order_to_market(users, buffers, order.clone(), &username, true, conn) {
                                     eprintln!("{}", e);
                                 } else {
                                     &exchange.show_market(&order.symbol);
                                 }
-                            } else {
-                                let obstruction = obstruction.unwrap();
-                                eprintln!("\
-The order could not be placed. You have a pending order in ${} that could potentially be filled by the order you just requested.
-Please change the price of your order so that it cannot fill the following pending order:\n\t{:?}", obstruction.symbol, obstruction);
                             }
                         },
                         Err(e) => Users::print_auth_error(e)
@@ -380,7 +378,7 @@ Please change the price of your order so that it cannot fill the following pendi
                             if !acc.pending_orders.is_complete {
                                 exchange.fetch_account_pending_orders(acc);
                             }
-                            &acc.print_user(conn);
+                            &acc.print_user();
                         },
                         Err(e) => Users::print_auth_error(e)
                     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -391,6 +391,7 @@ Please change the price of your order so that it cannot fill the following pendi
         Request::ExitReq => {
             println!("Initiating graceful shutdown...");
             buffers.flush_on_shutdown(exchange);
+            users.flush_user_cache(); // Send all cached users recent trades to redis.
             buffers.tx.as_ref().unwrap().send(None).unwrap();
         }
     }


### PR DESCRIPTION
When a user is evicted from our in-program cache, it's likely that the database hasn't reached a level of consistency where we can say that all the users recent trades will be there. To get around this issue, we can just store trades in Redis to access them while the exchange is still running, in-case the user is re-inserted into the cache before the database is fully consistent.

I want to make sure that we write these updates in bulk, so when we write to redis, we will make sure all `recent_trades` are sent in a single `LPUSH`.

This PR solves issue #18.