### PR TITLE
Switch to Utc everywhere

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -3,7 +3,7 @@ use std::collections::hash_map::Entry;
 use std::convert::TryInto;
 use std::sync::mpsc;
 
-use chrono::{Local, DateTime};
+use chrono::{DateTime, Utc};
 
 use postgres::Client;
 use crate::database;
@@ -45,8 +45,8 @@ pub struct DatabaseReadyOrder {
     pub order_id:     Option<i32>,
     pub status:       Option<OrderStatus>,
     pub user_id:      Option<i32>,
-    pub time_placed:  Option<DateTime<Local>>,
-    pub time_updated: Option<DateTime<Local>>,
+    pub time_placed:  Option<DateTime<Utc>>,
+    pub time_updated: Option<DateTime<Utc>>,
 }
 
 impl DatabaseReadyOrder {
@@ -79,7 +79,7 @@ impl DatabaseReadyOrder {
             order_id: Some(order.order_id),
             status: Some(order.status),
             user_id: order.user_id,
-            time_placed:  Some(Local::now()),
+            time_placed:  Some(Utc::now()),
             time_updated: None,
         }
     }
@@ -98,7 +98,7 @@ impl DatabaseReadyOrder {
             OrderStatus::COMPLETE | OrderStatus::CANCELLED => self.status = Some(order.status)
         }
 
-        self.time_updated = Some(Local::now());
+        self.time_updated = Some(Utc::now());
     }
 }
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,5 +1,5 @@
 use postgres::{Client, NoTls};
-use chrono::{Utc, DateTime, FixedOffset};
+use chrono::{DateTime, Utc};
 use std::time::Instant;
 
 use std::collections::BinaryHeap;
@@ -381,8 +381,7 @@ ORDER BY e.execution_time;";
         let filler_uid: i32  = row.get(6);
         let exchanged:  i32  = row.get(7);
         let execution_time:
-            DateTime<FixedOffset>
-                             = row.get(8);
+            DateTime<Utc>    = row.get(8);
 
         // Switch the action because we were the filler.
         if user.id.unwrap() == filler_uid {
@@ -425,8 +424,7 @@ pub fn read_trades(symbol: &String, conn: &mut Client) -> Option<Vec<Trade>> {
         let filler_uid: i32  = row.get(6);
         let exchanged:  i32  = row.get(7);
         let execution_time:
-            DateTime<FixedOffset>
-                             = row.get(8);
+            DateTime<Utc>    = row.get(8);
 
         trades.push(Trade::direct(symbol,
                                   action,
@@ -911,7 +909,7 @@ VALUES ");
                                                                                                trade.filler_oid,
                                                                                                trade.filler_uid,
                                                                                                trade.exchanged,
-                                                                                               trade.execution_time].as_str());
+                                                                                               trade.execution_time.to_rfc3339()].as_str());
         } else {
             // 1. Terminate the current query
             queries[index].pop();
@@ -930,7 +928,7 @@ VALUES ");
                                                                                                trade.filler_oid,
                                                                                                trade.filler_uid,
                                                                                                trade.exchanged,
-                                                                                               trade.execution_time].as_str());
+                                                                                               trade.execution_time.to_rfc3339()].as_str());
         }
         counter += 1;
     }

--- a/src/exchange/filled.rs
+++ b/src/exchange/filled.rs
@@ -1,5 +1,5 @@
 use crate::exchange::Order;
-use chrono::{DateTime, FixedOffset, Utc};
+use chrono::{DateTime, Utc};
 
 /* Note that a trade does not indicate a full order was processed!
  * It may have only filled part of an order.
@@ -38,7 +38,7 @@ impl Trade {
     }
 
     /* Used when reading data directly from the database. */
-    pub fn direct(symbol: &str, action: &str, price: f64, filled_oid: i32, filled_uid: i32, filler_oid: i32, filler_uid: i32, exchanged: i32, execution_time: DateTime<FixedOffset>) -> Self {
+    pub fn direct(symbol: &str, action: &str, price: f64, filled_oid: i32, filled_uid: i32, filler_oid: i32, filler_uid: i32, exchanged: i32, execution_time: DateTime<Utc>) -> Self {
         Trade {
             symbol: symbol.to_string().clone(),
             action: action.to_string().clone(),
@@ -48,7 +48,7 @@ impl Trade {
             filler_oid,
             filler_uid,
             exchanged,
-            execution_time: execution_time.with_timezone(&Utc)
+            execution_time
         }
     }
 }


### PR DESCRIPTION
Redis, Rust, and Postgres all display and store the times differently, and it's annoying.

I've decided the easiest way to deal with it is to store the time as Utc, then convert it to `rfc3339` when writing to redis or postgres, then converting from `rfc3339` when reading from them as well. Seems to work fine.